### PR TITLE
Updating README.md to replace build.yml to ci.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PASS - Personal Access System for Services
 
-[![Build status](https://github.com/codeforpdx/pass/actions/workflows/build.yml/badge.svg)](https://github.com/codeforpdx/pass/actions?query=workflow%3ABuild)
+[![Build status](https://github.com/codeforpdx/pass/actions/workflows/ci.yml/badge.svg)](https://github.com/codeforpdx/pass/actions?query=workflow%3ABuild)
 
 ## Description
 


### PR DESCRIPTION
Noticed the badge broke on Master, so I've checked the README.md and updated it