### PR TITLE
Merging issue-55/general-code-review to Development; Includes guard rails for setDocAclPermission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,27 @@
-Changelog
+# Changelog
 
-v0.0.1
+## v0.0.1 (March 14, 2023)
 
-## Features / Frontend Changes
+## Features
 
-- Included README and CONTRIBUTING for PASS project to root directory (#18)
 - Migrated PASS from vanilla JS to React.js (#19)
-- Included PASS' React Documentation to /docs (#24, #32, #33, #45)
 - Added login/logout features to PASS (#6, #19)
 - Added upload/search/delete features to Solid Pod using Inrupt's JS/React libraries (#6, #19)
 - Added cross-pod searching from one user to another (#38)
 - Added permission setting via Access Control List (or ACL) file by users (#38)
 - Added linting and formatting through ESLint and Prettier (#48)
 - Automated GitHub build process using GitHub Actions (#31, #41)
+- Added button disabling when processing upload/search/delete features to Solid Pod (#54)
+- Added guard rails that prevent users from removing access to their own containers on Solid (#56)
 
 ## Fixes
 
 - Corrected typo for GitHub Actions configuration file (#42)
-- Reorganized project file structure with README, CONTRIBUTING, and /docs/README (#26)
 - Corrected HTML id property in JSX for Logout.jsx (#52)
+
+## Others
+
+- Reorganized project file structure with README, CONTRIBUTING, and /docs/README (#26)
+- Included README and CONTRIBUTING for PASS project to root directory (#18)
+- Included PASS' React Documentation to /docs (#24, #32, #33, #45)
+- Included CHANGELOG for PASS project to root directory (#56)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,32 @@
 # Changelog
 
-## v0.0.1 (March 14, 2023)
+## v0.0.1 (March 18, 2023)
 
 ## Features
 
-- Migrated PASS from vanilla JS to React.js (#19)
-- Added login/logout features to PASS (#6, #19)
-- Added upload/search/delete features to Solid Pod using Inrupt's JS/React libraries (#6, #19)
-- Added cross-pod searching from one user to another (#38)
-- Added permission setting via Access Control List (or ACL) file by users (#38)
-- Added linting and formatting through ESLint and Prettier (#48)
-- Added button disabling when processing upload/search/delete features to Solid Pod (#54)
 - Added guard rails that prevent users from removing access to their own containers on Solid (#56)
+- Added button disabling when processing upload/search/delete features to Solid Pod (#54)
+- Added linting and formatting through ESLint and Prettier (#48)
+- Added permission setting via Access Control List (or ACL) file by users (#38)
+- Added cross-pod searching from one user to another (#38)
+- Migrated PASS from vanilla JS to React.js (#19)
+- Added upload/search/delete features to Solid Pod using Inrupt's JS/React libraries (#6, #19)
+- Added login/logout features to PASS (#6, #19)
 
 ## Fixes
 
-- Corrected typo for GitHub Actions configuration file (#42)
 - Corrected HTML id property in JSX for Logout.jsx (#52)
+- Corrected typo for GitHub Actions configuration file (#42)
+
+## Dev Changes
+
+- Refactored Form components with new FormSection component (#56)
+- Included CHANGELOG for PASS project to root directory (#56)
+- Refactored SessionProvider to index.jsx instead of App.jsx (#40)
 
 ## Others
 
 - Automated GitHub build process using GitHub Actions (#31, #41)
 - Reorganized project file structure with README, CONTRIBUTING, and /docs/README (#26)
-- Included README and CONTRIBUTING for PASS project to root directory (#18)
 - Included PASS' React Documentation to /docs (#24, #32, #33, #45)
-- Included CHANGELOG for PASS project to root directory (#56)
+- Included README and CONTRIBUTING for PASS project to root directory (#18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 - Added cross-pod searching from one user to another (#38)
 - Added permission setting via Access Control List (or ACL) file by users (#38)
 - Added linting and formatting through ESLint and Prettier (#48)
-- Automated GitHub build process using GitHub Actions (#31, #41)
 - Added button disabling when processing upload/search/delete features to Solid Pod (#54)
 - Added guard rails that prevent users from removing access to their own containers on Solid (#56)
 
@@ -21,6 +20,7 @@
 
 ## Others
 
+- Automated GitHub build process using GitHub Actions (#31, #41)
 - Reorganized project file structure with README, CONTRIBUTING, and /docs/README (#26)
 - Included README and CONTRIBUTING for PASS project to root directory (#18)
 - Included PASS' React Documentation to /docs (#24, #32, #33, #45)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+Changelog
+
+v0.0.1
+
+## Features / Frontend Changes
+
+- Included README and CONTRIBUTING for PASS project to root directory (#18)
+- Migrated PASS from vanilla JS to React.js (#19)
+- Included PASS' React Documentation to /docs (#24, #32, #33, #45)
+- Added login/logout features to PASS (#6, #19)
+- Added upload/search/delete features to Solid Pod using Inrupt's JS/React libraries (#6, #19)
+- Added cross-pod searching from one user to another (#38)
+- Added permission setting via Access Control List (or ACL) file by users (#38)
+- Added linting and formatting through ESLint and Prettier (#48)
+- Automated GitHub build process using GitHub Actions (#31, #41)
+
+## Fixes
+
+- Corrected typo for GitHub Actions configuration file (#42)
+- Reorganized project file structure with README, CONTRIBUTING, and /docs/README (#26)
+- Corrected HTML id property in JSX for Logout.jsx (#52)

--- a/src/components/Form/CrossPodQueryForm.jsx
+++ b/src/components/Form/CrossPodQueryForm.jsx
@@ -20,19 +20,16 @@ const CrossPodQueryForm = () => {
   const handleCrossPodQuery = async (event) => {
     event.preventDefault();
     dispatch({ type: 'SET_PROCESSING' });
+    const docType = event.target.document.value;
+    const podUrl = event.target.crossPodQuery.value;
 
-    if (!event.target.crossPodQuery.value) {
+    if (!podUrl) {
       runNotification('Search failed. Reason: Pod URL not provided', 3, state, dispatch);
       return;
     }
 
     try {
-      const documentUrl = await fetchDocuments(
-        session,
-        event.target.document.value,
-        'cross-fetch',
-        event.target.crossPodQuery.value
-      );
+      const documentUrl = await fetchDocuments(session, docType, 'cross-fetch', podUrl);
 
       if (state.documentUrl) {
         dispatch({ type: 'CLEAR_DOCUMENT_LOCATION' });

--- a/src/components/Form/CrossPodQueryForm.jsx
+++ b/src/components/Form/CrossPodQueryForm.jsx
@@ -6,7 +6,7 @@ import { StatusNotification } from '../Notification';
 import DocumentSelection from './DocumentSelection';
 
 /**
- * CrossPodQueryForm Component - Component that generates the form for cross pod search for a specific document to another user's Solid Pod via Solid Session
+ * CrossPodQueryForm Component - Component that generates the form for cross pod search for a specific document from another user's Solid Pod via Solid Session
  * @memberof Forms
  * @component
  * @name CrossPodQueryForm
@@ -16,13 +16,13 @@ const CrossPodQueryForm = () => {
   const { session } = useSession();
   const { state, dispatch } = useStatusNotification();
 
+  // Event handler for Cross Pod Querying/Searching
   const handleCrossPodQuery = async (event) => {
     event.preventDefault();
     dispatch({ type: 'SET_PROCESSING' });
 
     if (!event.target.crossPodQuery.value) {
-      runNotification(`Search failed. Reason: Pod URL not provided`, 3, state, dispatch);
-      console.log('Search failed. Reason: Pod URL not provided');
+      runNotification('Search failed. Reason: Pod URL not provided', 3, state, dispatch);
       return;
     }
 
@@ -38,23 +38,16 @@ const CrossPodQueryForm = () => {
         dispatch({ type: 'CLEAR_DOCUMENT_LOCATION' });
       }
 
-      runNotification(`Locating document...`, 3, state, dispatch);
+      runNotification('Locating document...', 3, state, dispatch);
 
       // setTimeout is used to let fetchDocuments complete its fetch
       setTimeout(() => {
         dispatch({ type: 'SET_DOCUMENT_LOCATION', payload: documentUrl });
-        runNotification(`Document found! Document located at: `, 7, state, dispatch);
+        runNotification('Document found! Document located at: ', 7, state, dispatch);
       }, 3000);
     } catch (_error) {
       dispatch({ type: 'CLEAR_DOCUMENT_LOCATION' });
-      runNotification(
-        `Search failed. Reason: Document not found or unauthorized`,
-        3,
-        state,
-        dispatch
-      );
-
-      console.log('Search failed. Reason: Document not found or unauthorized');
+      runNotification('Search failed. Reason: Document not found', 3, state, dispatch);
     }
   };
 

--- a/src/components/Form/CrossPodQueryForm.jsx
+++ b/src/components/Form/CrossPodQueryForm.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { useSession } from '@inrupt/solid-ui-react';
 import { fetchDocuments, runNotification } from '../../utils';
 import { useStatusNotification } from '../../hooks';
-import { StatusNotification } from '../Notification';
 import DocumentSelection from './DocumentSelection';
+import FormSection from './FormSection';
 
 /**
  * CrossPodQueryForm Component - Component that generates the form for cross pod search
@@ -25,7 +25,7 @@ const CrossPodQueryForm = () => {
     const podUrl = event.target.crossPodQuery.value;
 
     if (!podUrl) {
-      runNotification('Search failed. Reason: Pod URL not provided', 3, state, dispatch);
+      runNotification('Search failed. Reason: Pod URL not provided.', 3, state, dispatch);
       return;
     }
 
@@ -54,7 +54,7 @@ const CrossPodQueryForm = () => {
   };
 
   return (
-    <section className="panel">
+    <FormSection state={state} statusType="Search status" defaultMessage="To be searched...">
       <strong>Cross Pod Search</strong>
       <form onSubmit={handleCrossPodQuery} autoComplete="off">
         <div style={formRowStyle}>
@@ -73,13 +73,7 @@ const CrossPodQueryForm = () => {
           </button>
         </div>
       </form>
-      <StatusNotification
-        notification={state.message}
-        statusType="Search status"
-        defaultMessage="To be searched..."
-        locationUrl={state.documentUrl}
-      />
-    </section>
+    </FormSection>
   );
 };
 

--- a/src/components/Form/CrossPodQueryForm.jsx
+++ b/src/components/Form/CrossPodQueryForm.jsx
@@ -6,7 +6,8 @@ import { StatusNotification } from '../Notification';
 import DocumentSelection from './DocumentSelection';
 
 /**
- * CrossPodQueryForm Component - Component that generates the form for cross pod search for a specific document from another user's Solid Pod via Solid Session
+ * CrossPodQueryForm Component - Component that generates the form for cross pod search
+ * for a specific document from another user's Solid Pod via Solid Session
  * @memberof Forms
  * @component
  * @name CrossPodQueryForm

--- a/src/components/Form/CrossPodWriteForm.jsx
+++ b/src/components/Form/CrossPodWriteForm.jsx
@@ -4,7 +4,8 @@ import { StatusNotification } from '../Notification';
 import DocumentSelection from './DocumentSelection';
 
 /**
- * CrossPodWriteForm Component - Component that generates the form for cross pod uploading for a specific document to another user's Solid Pod via Solid Session
+ * CrossPodWriteForm Component - Component that generates the form for cross pod uploading
+ * for a specific document to another user's Solid Pod via Solid Session
  * @memberof Forms
  * @component
  * @name CrossPodWriteForm

--- a/src/components/Form/DeleteDocumentForm.jsx
+++ b/src/components/Form/DeleteDocumentForm.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { useSession } from '@inrupt/solid-ui-react';
 import { deleteDocumentFile, deleteDocumentContainer, runNotification } from '../../utils';
 import { useStatusNotification } from '../../hooks';
-import { StatusNotification } from '../Notification';
 import DocumentSelection from './DocumentSelection';
+import FormSection from './FormSection';
 
 /**
  * DeleteDocumentForm Component - Component that generates the form for
@@ -44,7 +44,7 @@ const DeleteDocumentForm = () => {
   };
 
   return (
-    <section className="panel">
+    <FormSection state={state} statusType="Deletion status" defaultMessage="To be deleted...">
       <strong>Delete Document</strong>
       <form onSubmit={handleDeleteDocument} autoComplete="off">
         <div style={formRowStyle}>
@@ -55,12 +55,7 @@ const DeleteDocumentForm = () => {
           </button>
         </div>
       </form>
-      <StatusNotification
-        notification={state.message}
-        statusType="Deletion status"
-        defaultMessage="To be searched..."
-      />
-    </section>
+    </FormSection>
   );
 };
 

--- a/src/components/Form/DeleteDocumentForm.jsx
+++ b/src/components/Form/DeleteDocumentForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSession } from '@inrupt/solid-ui-react';
-import { useStatusNotification } from '../../hooks';
 import { deleteDocumentFile, deleteDocumentContainer, runNotification } from '../../utils';
+import { useStatusNotification } from '../../hooks';
 import { StatusNotification } from '../Notification';
 import DocumentSelection from './DocumentSelection';
 
@@ -14,7 +14,6 @@ import DocumentSelection from './DocumentSelection';
 
 const DeleteDocumentForm = () => {
   const { session } = useSession();
-  // Combined state for file upload with useReducer
   const { state, dispatch } = useStatusNotification();
 
   // Event handler for deleting document
@@ -35,8 +34,6 @@ const DeleteDocumentForm = () => {
       }, 3000);
     } catch (_error) {
       runNotification('Deletion failed. Reason: Data not found', 3, state, dispatch);
-
-      console.log('Deletion failed. Reason: Data not found');
     }
   };
 

--- a/src/components/Form/DeleteDocumentForm.jsx
+++ b/src/components/Form/DeleteDocumentForm.jsx
@@ -6,7 +6,8 @@ import { StatusNotification } from '../Notification';
 import DocumentSelection from './DocumentSelection';
 
 /**
- * DeleteDocumentForm Component - Component that generates the form for deleting a specific document type from a user's Solid Pod via Solid Session
+ * DeleteDocumentForm Component - Component that generates the form for
+ * deleting a specific document type from a user's Solid Pod via Solid Session
  * @memberof Forms
  * @component
  * @name DeleteDocumentForm

--- a/src/components/Form/DeleteDocumentForm.jsx
+++ b/src/components/Form/DeleteDocumentForm.jsx
@@ -20,9 +20,10 @@ const DeleteDocumentForm = () => {
   const handleDeleteDocument = async (event) => {
     event.preventDefault();
     dispatch({ type: 'SET_PROCESSING' });
+    const docType = event.target.document.value;
 
     try {
-      const documentUrl = await deleteDocumentFile(session, event.target.document.value);
+      const documentUrl = await deleteDocumentFile(session, docType);
 
       runNotification('File being deleted from Pod...', 3, state, dispatch);
 

--- a/src/components/Form/DocumentSelection.jsx
+++ b/src/components/Form/DocumentSelection.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import docTypes from '../../utils/form-helper';
 
 /**
- * DocumentSelection Component - Sub-component that generates the drop down box/menu for selecting document type to a user's Solid Pod via Solid Session
+ * DocumentSelection Component - Sub-component that generates the dropdown
+ * box/menu for selecting document type to a user's Solid Pod via Solid Session
  * @memberof Forms
  * @component
  * @name DocumentSelection

--- a/src/components/Form/DocumentSelection.jsx
+++ b/src/components/Form/DocumentSelection.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import docTypes from '../../utils/form-helper';
 
 /**
- * DocumentSelection Component - Sub-component that generates the drop down box for selecting document type to a user's Solid Pod via Solid Session
+ * DocumentSelection Component - Sub-component that generates the drop down box/menu for selecting document type to a user's Solid Pod via Solid Session
  * @memberof Forms
  * @component
  * @name DocumentSelection

--- a/src/components/Form/FetchDocumentForm.jsx
+++ b/src/components/Form/FetchDocumentForm.jsx
@@ -20,9 +20,10 @@ const FetchDocumentForm = () => {
   const handleGetDocumentSubmission = async (event) => {
     event.preventDefault();
     dispatch({ type: 'SET_PROCESSING' });
+    const docType = event.target.document.value;
 
     try {
-      const documentUrl = await fetchDocuments(session, event.target.document.value, 'self-fetch');
+      const documentUrl = await fetchDocuments(session, docType, 'self-fetch');
 
       if (state.documentUrl) {
         dispatch({ type: 'CLEAR_DOCUMENT_LOCATION' });

--- a/src/components/Form/FetchDocumentForm.jsx
+++ b/src/components/Form/FetchDocumentForm.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { useSession } from '@inrupt/solid-ui-react';
 import { fetchDocuments, runNotification } from '../../utils';
 import { useStatusNotification } from '../../hooks';
-import { StatusNotification } from '../Notification';
 import DocumentSelection from './DocumentSelection';
+import FormSection from './FormSection';
 
 /**
  * FetchDocumentForm Component - Component that generates the form for searching
@@ -48,7 +48,7 @@ const FetchDocumentForm = () => {
   };
 
   return (
-    <section className="panel">
+    <FormSection state={state} statusType="Search status" defaultMessage="To be searched...">
       <strong>Search Document</strong>
       <form onSubmit={handleGetDocumentSubmission} autoComplete="off">
         <div style={formRowStyle}>
@@ -59,13 +59,7 @@ const FetchDocumentForm = () => {
           </button>
         </div>
       </form>
-      <StatusNotification
-        notification={state.message}
-        statusType="Search status"
-        defaultMessage="To be searched..."
-        locationUrl={state.documentUrl}
-      />
-    </section>
+    </FormSection>
   );
 };
 

--- a/src/components/Form/FetchDocumentForm.jsx
+++ b/src/components/Form/FetchDocumentForm.jsx
@@ -6,7 +6,8 @@ import { StatusNotification } from '../Notification';
 import DocumentSelection from './DocumentSelection';
 
 /**
- * FetchDocumentForm Component - Component that generates the form for searching a specific document type from a user's Solid Pod via Solid Session
+ * FetchDocumentForm Component - Component that generates the form for searching
+ * a specific document type from a user's Solid Pod via Solid Session
  * @memberof Forms
  * @component
  * @name FetchDocumentForm

--- a/src/components/Form/FetchDocumentForm.jsx
+++ b/src/components/Form/FetchDocumentForm.jsx
@@ -14,10 +14,9 @@ import DocumentSelection from './DocumentSelection';
 
 const FetchDocumentForm = () => {
   const { session } = useSession();
-  // Combined state for file upload with useReducer
   const { state, dispatch } = useStatusNotification();
 
-  // Event handler for fetching document
+  // Event handler for searching/fetching document
   const handleGetDocumentSubmission = async (event) => {
     event.preventDefault();
     dispatch({ type: 'SET_PROCESSING' });
@@ -29,18 +28,16 @@ const FetchDocumentForm = () => {
         dispatch({ type: 'CLEAR_DOCUMENT_LOCATION' });
       }
 
-      runNotification(`Locating document...`, 3, state, dispatch);
+      runNotification('Locating document...', 3, state, dispatch);
 
       // setTimeout is used to let fetchDocuments complete its fetch
       setTimeout(() => {
         dispatch({ type: 'SET_DOCUMENT_LOCATION', payload: documentUrl });
-        runNotification(`Document found! Document located at: `, 7, state, dispatch);
+        runNotification('Document found! Document located at: ', 7, state, dispatch);
       }, 3000);
     } catch (_error) {
       dispatch({ type: 'CLEAR_DOCUMENT_LOCATION' });
-      runNotification(`Search failed. Reason: Document not found`, 3, state, dispatch);
-
-      console.log('Search failed. Reason: Document not found');
+      runNotification('Search failed. Reason: Document not found', 3, state, dispatch);
     }
   };
 

--- a/src/components/Form/FormSection.jsx
+++ b/src/components/Form/FormSection.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StatusNotification } from '../Notification';
 
 /**
- *  @typedef {import('../../hooks').statusNotificationObject} statusNotificationObject
+ * @typedef {import('../../hooks').statusNotificationObject} statusNotificationObject
  */
 
 /**

--- a/src/components/Form/FormSection.jsx
+++ b/src/components/Form/FormSection.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { StatusNotification } from '../Notification';
+
+/**
+ *  @typedef {import('../../hooks').statusNotificationObject} statusNotificationObject
+ */
+
+/**
+ * @typedef {Object} formSectionProps
+ * @property {statusNotificationObject} state - The state for status notification
+ * @property {String} statusType - Type of action for PASS
+ * @property {String} defaultMessage - Default notification message when inactive
+ * @property {JSX.Element} children - JSX Element of the wrapped form
+ */
+
+/**
+ * FormSection Component - Component that wraps Form with StatusNotification
+ * @memberof Forms
+ * @component
+ * @name FormSection
+ * @param {formSectionProps} formSectionProps - A react prop that consists of that
+ * consist of state, statusType, defaultMessage, and children
+ */
+
+const FormSection = ({ state, statusType, defaultMessage, children }) => (
+  <section className="panel">
+    {children}
+    <StatusNotification
+      notification={state.message}
+      statusType={statusType}
+      defaultMessage={defaultMessage}
+      locationUrl={state.documentUrl}
+    />
+  </section>
+);
+
+export default FormSection;

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -6,7 +6,8 @@ import { StatusNotification } from '../Notification';
 import DocumentSelection from './DocumentSelection';
 
 /**
- * SetAclPermissionForm Component - Component that generates the form for setting document ACL permissions to another user's Solid Pod via Solid Session
+ * SetAclPermissionForm Component - Component that generates the form for setting
+ * document ACL permissions to another user's Solid Pod via Solid Session
  * @memberof Forms
  * @component
  * @name SetAclPermissionForm

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { useSession } from '@inrupt/solid-ui-react';
 import { runNotification, setDocAclPermission } from '../../utils';
 import { useStatusNotification } from '../../hooks';
-import { StatusNotification } from '../Notification';
 import DocumentSelection from './DocumentSelection';
+import FormSection from './FormSection';
 
 /**
  * SetAclPermissionForm Component - Component that generates the form for setting
@@ -26,13 +26,13 @@ const SetAclPermissionForm = () => {
     const permissionType = event.target.setAclPerms.value;
 
     if (!podUrl) {
-      runNotification('Set permissions failed. Reason: Pod URL not provided', 3, state, dispatch);
+      runNotification('Set permissions failed. Reason: Pod URL not provided.', 3, state, dispatch);
       return;
     }
 
     if (`https://${podUrl}/` === String(session.info.webId.split('profile')[0])) {
       runNotification(
-        'Set permissions failed. Reason: Current user Pod cannot change container permissions to itself',
+        'Set permissions failed. Reason: Current user Pod cannot change container permissions to itself.',
         3,
         state,
         dispatch
@@ -41,7 +41,7 @@ const SetAclPermissionForm = () => {
     }
 
     if (!permissionType) {
-      runNotification('Set permissions failed. Reason: Permissions not set', 3, state, dispatch);
+      runNotification('Set permissions failed. Reason: Permissions not set.', 3, state, dispatch);
       return;
     }
 
@@ -49,13 +49,13 @@ const SetAclPermissionForm = () => {
       await setDocAclPermission(session, docType, permissionType, podUrl);
 
       runNotification(
-        `${permissionType} permission to ${podUrl} for ${docType}`,
+        `${permissionType} permission to ${podUrl} for ${docType}.`,
         7,
         state,
         dispatch
       );
     } catch (error) {
-      runNotification('Set permissions failed. Reason: File not found', 3, state, dispatch);
+      runNotification('Set permissions failed. Reason: File not found.', 3, state, dispatch);
     }
   };
 
@@ -64,7 +64,7 @@ const SetAclPermissionForm = () => {
   };
 
   return (
-    <section className="panel">
+    <FormSection state={state} statusType="Permission status" defaultMessage="To be set...">
       <strong>Permission to Files</strong>
       <form onSubmit={handleAclPermission} autoComplete="off">
         <div style={formRowStyle}>
@@ -90,13 +90,7 @@ const SetAclPermissionForm = () => {
           Set Permission
         </button>
       </form>
-      <StatusNotification
-        notification={state.message}
-        statusType="Permission status"
-        defaultMessage="Permission to be set..."
-        locationUrl={state.documentUrl}
-      />
-    </section>
+    </FormSection>
   );
 };
 

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -16,48 +16,44 @@ const SetAclPermissionForm = () => {
   const { session } = useSession();
   const { state, dispatch } = useStatusNotification();
 
+  // Event handler for setting ACL permissions to file container on Solid
   const handleAclPermission = async (event) => {
     event.preventDefault();
     dispatch({ type: 'SET_PROCESSING' });
+    const podUrl = event.target.setAclTo.value;
+    const permissionType = event.target.setAclPerms.value;
 
-    if (!event.target.setAclTo.value) {
-      runNotification(
-        `Permission assignment failed. Reason: Pod URL not provided`,
-        3,
-        state,
-        dispatch
-      );
-      console.log('Permission assignment failed. Reason: Pod URL not provided');
+    if (!podUrl) {
+      runNotification('Set permissions failed. Reason: Pod URL not provided', 3, state, dispatch);
       return;
     }
 
-    if (!event.target.setAclPerms.value) {
+    if (`https://${podUrl}/` === String(session.info.webId.split('profile')[0])) {
       runNotification(
-        `Permission assignment failed. Reason: Permissions not set`,
+        'Set permissions failed. Reason: Current user Pod cannot change container permissions to itself',
         3,
         state,
         dispatch
       );
-      console.log('Permission assignment failed. Reason: Permissions not set');
+      return;
+    }
+
+    if (!permissionType) {
+      runNotification('Set permissions failed. Reason: Permissions not set', 3, state, dispatch);
       return;
     }
 
     try {
-      await setDocAclPermission(
-        session,
-        event.target.document.value,
-        event.target.setAclPerms.value,
-        event.target.setAclTo.value
-      );
+      await setDocAclPermission(session, event.target.document.value, permissionType, podUrl);
 
       runNotification(
-        `${event.target.setAclPerms.value} permission to ${event.target.setAclTo.value} for ${event.target.document.value}`,
+        `${permissionType} permission to ${podUrl} for ${event.target.document.value}`,
         7,
         state,
         dispatch
       );
     } catch (error) {
-      runNotification('Set permission failed. Reason: File not found', 3, state, dispatch);
+      runNotification('Set permissions failed. Reason: File not found', 3, state, dispatch);
     }
   };
 

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -20,6 +20,7 @@ const SetAclPermissionForm = () => {
   const handleAclPermission = async (event) => {
     event.preventDefault();
     dispatch({ type: 'SET_PROCESSING' });
+    const docType = event.target.document.value;
     const podUrl = event.target.setAclTo.value;
     const permissionType = event.target.setAclPerms.value;
 
@@ -44,10 +45,10 @@ const SetAclPermissionForm = () => {
     }
 
     try {
-      await setDocAclPermission(session, event.target.document.value, permissionType, podUrl);
+      await setDocAclPermission(session, docType, permissionType, podUrl);
 
       runNotification(
-        `${permissionType} permission to ${podUrl} for ${event.target.document.value}`,
+        `${permissionType} permission to ${podUrl} for ${docType}`,
         7,
         state,
         dispatch

--- a/src/components/Form/UploadDocumentForm.jsx
+++ b/src/components/Form/UploadDocumentForm.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { useSession } from '@inrupt/solid-ui-react';
 import { useField, useStatusNotification } from '../../hooks';
 import { uploadDocument, runNotification } from '../../utils';
-import { StatusNotification } from '../Notification';
 import DocumentSelection from './DocumentSelection';
+import FormSection from './FormSection';
 
 /**
  * UploadDocumentForm Component - Component that generates the form for uploading
@@ -54,11 +54,11 @@ const UploadDocumentForm = () => {
     try {
       await uploadDocument(session, fileObject);
 
-      runNotification(`Uploading "${fileObject.file.name}" to Solid`, 3, state, dispatch);
+      runNotification(`Uploading "${fileObject.file.name}" to Solid...`, 3, state, dispatch);
 
       // setTimeout is used to let uploadDocument finish its upload to user's Pod
       setTimeout(() => {
-        runNotification(`File "${fileObject.file.name}" uploaded to Solid`, 7, state, dispatch);
+        runNotification(`File "${fileObject.file.name}" uploaded to Solid.`, 7, state, dispatch);
       }, 3000);
     } catch (_error) {
       runNotification(
@@ -81,7 +81,7 @@ const UploadDocumentForm = () => {
   };
 
   return (
-    <section className="panel">
+    <FormSection state={state} statusType="Writing status" defaultMessage="To be uploaded...">
       <strong>Upload Document</strong>
       <form onSubmit={handleFormSubmission} autoComplete="off">
         <div style={formRowStyle}>
@@ -112,12 +112,7 @@ const UploadDocumentForm = () => {
           </button>
         </div>
       </form>
-      <StatusNotification
-        notification={state.message}
-        statusType="Writing status"
-        defaultMessage="To be uploaded..."
-      />
-    </section>
+    </FormSection>
   );
 };
 

--- a/src/components/Form/UploadDocumentForm.jsx
+++ b/src/components/Form/UploadDocumentForm.jsx
@@ -6,7 +6,8 @@ import { StatusNotification } from '../Notification';
 import DocumentSelection from './DocumentSelection';
 
 /**
- * UploadDocumentForm Component - Component that generates the form for uploading a specific document type to a user's Solid Pod via Solid Session
+ * UploadDocumentForm Component - Component that generates the form for uploading
+ * a specific document type to a user's Solid Pod via Solid Session
  * @memberof Forms
  * @component
  * @name UploadDocumentForm

--- a/src/components/Form/UploadDocumentForm.jsx
+++ b/src/components/Form/UploadDocumentForm.jsx
@@ -34,6 +34,9 @@ const UploadDocumentForm = () => {
   const handleFormSubmission = async (event) => {
     event.preventDefault();
     dispatch({ type: 'SET_PROCESSING' });
+    const docType = event.target.document.value;
+    const expirationDate = event.target.date.value;
+    const docDescription = event.target.description.value;
 
     if (!state.file) {
       runNotification('Submission failed. Reason: missing file', 2, state, dispatch);
@@ -41,9 +44,9 @@ const UploadDocumentForm = () => {
     }
 
     const fileObject = {
-      type: event.target.document.value,
-      date: event.target.date.value || '01/01/1800',
-      description: event.target.description.value || 'No Description provided',
+      type: docType,
+      date: expirationDate || '01/01/1800',
+      description: docDescription || 'No Description provided',
       file: state.file
     };
 

--- a/src/components/Form/UploadDocumentForm.jsx
+++ b/src/components/Form/UploadDocumentForm.jsx
@@ -20,18 +20,10 @@ const UploadDocumentForm = () => {
   // Initalized state for file upload
   const handleFileChange = (event) => {
     if (event.target.files) {
-      dispatch({
-        type: 'SET_FILE',
-        payload: event.target.files[0]
-      });
+      dispatch({ type: 'SET_FILE', payload: event.target.files[0] });
     } else {
-      dispatch({
-        type: 'CLEAR_FILE'
-      });
-      dispatch({
-        type: 'SET_FILE',
-        payload: event.target.files[0]
-      });
+      dispatch({ type: 'CLEAR_FILE' });
+      dispatch({ type: 'SET_FILE', payload: event.target.files[0] });
     }
   };
 
@@ -44,8 +36,7 @@ const UploadDocumentForm = () => {
     dispatch({ type: 'SET_PROCESSING' });
 
     if (!state.file) {
-      runNotification(`Submission failed. Reason: missing file`, 2, state, dispatch);
-      console.log('Submission failed. Reason: missing file');
+      runNotification('Submission failed. Reason: missing file', 2, state, dispatch);
       return;
     }
 
@@ -67,13 +58,11 @@ const UploadDocumentForm = () => {
       }, 3000);
     } catch (_error) {
       runNotification(
-        `Submission failed. Reason: Previous file has already been saved to this type`,
-        3,
+        'Submission failed. Reason: A previous file has already been saved to this type. Please delete the previous file if you wish to reupload.',
+        7,
         state,
         dispatch
       );
-
-      console.log('Submission failed. Reason: Previous file has already been saved to this type');
     }
 
     setTimeout(() => {

--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -3,7 +3,8 @@ import { LoginButton } from '@inrupt/solid-ui-react';
 import { SOLID_IDENTITY_PROVIDER } from '../../utils';
 
 /**
- * Login Component - Component that generates Login section for users to a Solid Pod via Solid Session
+ * Login Component - Component that generates Login section for users to a
+ * Solid Pod via Solid Session
  * @memberof Login
  * @component
  * @name Login

--- a/src/components/Login/Logout.jsx
+++ b/src/components/Login/Logout.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { useSession, LogoutButton } from '@inrupt/solid-ui-react';
 
 /**
- * Logout Component - Component that generates Logout section for users to a Solid Pod via Solid Session
+ * Logout Component - Component that generates Logout section for users to a
+ * Solid Pod via Solid Session
  * @memberof Login
  * @component
  * @name Logout

--- a/src/components/Notification/StatusMessage.jsx
+++ b/src/components/Notification/StatusMessage.jsx
@@ -1,13 +1,18 @@
 import React from 'react';
 
 /**
+ * @typedef {Object} statusMessageProps
+ * @property {String} notification - File status message
+ * @property {String} [locationUrl] - URL location of file, if exist
+ */
+
+/**
  * StatusMessage Component - Sub-component that shows status message for StatusNotification
  * @memberof Notifications
  * @component
  * @name StatusMessage
- * @param {object}
- * @property {string} notification - File status message
- * @property {string} [locationUrl] - URL location of file, if exist
+ * @param {statusMessageProps} statusMessageProps - A react prop that consist of notification,
+ * and locationUrl, which is optional
  */
 
 const StatusMessage = ({ notification, locationUrl }) => {

--- a/src/components/Notification/StatusMessage.jsx
+++ b/src/components/Notification/StatusMessage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 /**
- * StatusMessage Component - Sub-component that shows Status message for StatusNotification
+ * StatusMessage Component - Sub-component that shows status message for StatusNotification
  * @memberof Notifications
  * @component
  * @name StatusMessage

--- a/src/components/Notification/StatusNotification.jsx
+++ b/src/components/Notification/StatusNotification.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import StatusMessage from './StatusMessage';
 
 /**
- * StatusNotification Component - Component that renders status notification and message for file upload, search, delete, etc.
+ * StatusNotification Component - Component that renders status notification and message
+ * for file upload, search, delete, etc.
  * @memberof Notifications
  * @component
  * @name StatusNotification

--- a/src/components/Notification/StatusNotification.jsx
+++ b/src/components/Notification/StatusNotification.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import StatusMessage from './StatusMessage';
 
 /**
- * StatusNotification Component - Component that renders Status notification and message for file upload, search, delete, etc.
+ * StatusNotification Component - Component that renders status notification and message for file upload, search, delete, etc.
  * @memberof Notifications
  * @component
  * @name StatusNotification

--- a/src/components/Notification/StatusNotification.jsx
+++ b/src/components/Notification/StatusNotification.jsx
@@ -2,16 +2,21 @@ import React from 'react';
 import StatusMessage from './StatusMessage';
 
 /**
+ * @typedef {Object} statusNotificationProps
+ * @property {String} notification - File status message
+ * @property {String} statusType - Type of file status (i.e. file upload, file fetch, file delete)
+ * @property {String} defaultMessage - Default message when status is not triggered
+ * @property {String} [locationUrl] - URL location of file, if exist
+ */
+
+/**
  * StatusNotification Component - Component that renders status notification and message
  * for file upload, search, delete, etc.
  * @memberof Notifications
  * @component
  * @name StatusNotification
- * @param {object}
- * @property {string} notification - File status message
- * @property {string} statusType - Type of file status (i.e. file upload, file fetch, file delete)
- * @property {string} defaultMessage - Default message when status is not triggered
- * @property {string} [locationUrl] - URL location of file, if exist
+ * @param {statusNotificationProps} statusNotificationProps - A react prop that consist of notification,
+ * statusType, defaultMessage, and locationUrl, which is optional
  */
 
 const StatusNotification = ({ notification, statusType, defaultMessage, locationUrl = '' }) => (

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -15,7 +15,8 @@ import statusReducer, { initialStatusState } from '../reducers/statusReducer';
  */
 
 /**
- * Custom hook that provide the value of input element, type attribute of HTML input element, set value of input element onChange, and a clear value function
+ * Custom hook that provide the value of input element, type attribute of HTML input element,
+ * set value of input element onChange, and a clear value function
  * @memberof hooks
  * @function useField
  * @param {string} type - Type attribute of HTML input element
@@ -47,14 +48,17 @@ export const useField = (type) => {
  * @property {string} message - Status message for file upload, query, or deletion
  * @property {string|null} timeoutID - Timeout ID for status message
  * @property {object|null} file - Object that includes file in question
- * @property {boolean} processing - Boolean on whether application is uploading/fetching/querying data from Solid
+ * @property {boolean} processing - Boolean on whether application is uploading,
+ * fetching, querying data from Solid
  */
 
 /**
- * Custom hook that provide the useStatusNotificationObject as the state and a useReducer dispatch function to alter the state
+ * Custom hook that provide the useStatusNotificationObject as the state and a
+ * useReducer dispatch function to alter the state
  * @memberof hooks
  * @function useStatusNotification
- * @return {useStatusNotificationObject} useStatusNotificationObject - An object that contains { documentUrl, message, timeoutID, and file }
+ * @return {useStatusNotificationObject} useStatusNotificationObject - An object that
+ * contains { documentUrl, message, timeoutID, and file }
  */
 
 export const useStatusNotification = () => {

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -8,10 +8,10 @@ import statusReducer, { initialStatusState } from '../reducers/statusReducer';
 
 /**
  * @typedef {Object} useFieldObject
- * @property {string} type - Type attribute of HTML input element
- * @property {string} value - The value of input element
- * @property {function} onChange - Event handler for changes in input element
- * @property {function} clearValue - Event handler that clears value set for input element
+ * @property {String} type - Type attribute of HTML input element
+ * @property {String} value - The value of input element
+ * @property {Function} onChange - Event handler for changes in input element
+ * @property {Function} clearValue - Event handler that clears value set for input element
  */
 
 /**
@@ -19,7 +19,7 @@ import statusReducer, { initialStatusState } from '../reducers/statusReducer';
  * set value of input element onChange, and a clear value function
  * @memberof hooks
  * @function useField
- * @param {string} type - Type attribute of HTML input element
+ * @param {String} type - Type attribute of HTML input element
  * @return {useFieldObject} useFieldObject - An object that contains { type, value, onChange, clearValue }
  */
 
@@ -43,13 +43,14 @@ export const useField = (type) => {
 };
 
 /**
+ * @typedef {import("../reducers/statusReducer").statusNotificationObject} statusNotificationObject
+ */
+
+/**
  * @typedef {Object} useStatusNotificationObject
- * @property {string|null} documentUrl - Url link to document container
- * @property {string} message - Status message for file upload, query, or deletion
- * @property {string|null} timeoutID - Timeout ID for status message
- * @property {object|null} file - Object that includes file in question
- * @property {boolean} processing - Boolean on whether application is uploading,
- * fetching, querying data from Solid
+ * @property {statusNotificationObject} statusNotificationObject - An object consisting of the
+ * state for status notifications
+ * @property {React.DispatchWithoutAction} dispatch - React's useReducer dispatch function
  */
 
 /**
@@ -58,7 +59,7 @@ export const useField = (type) => {
  * @memberof hooks
  * @function useStatusNotification
  * @return {useStatusNotificationObject} useStatusNotificationObject - An object that
- * contains { documentUrl, message, timeoutID, and file }
+ * contains the StatusNotification state and React's useReducer dispatch function
  */
 
 export const useStatusNotification = () => {

--- a/src/reducers/statusReducer.js
+++ b/src/reducers/statusReducer.js
@@ -12,7 +12,8 @@
  * @property {string} message - Status message for file upload, query, or deletion
  * @property {string|null} timeoutID - Timeout ID for status message
  * @property {object|null} file - Object that includes file in question
- * @property {boolean} processing - Boolean on whether application is uploading/fetching/querying data from Solid
+ * @property {boolean} processing - Boolean on whether application is uploading,
+ * fetching, querying data from Solid
  */
 
 export const initialStatusState = {
@@ -27,7 +28,8 @@ export const initialStatusState = {
  * @memberof reducers
  * @function statusReducer
  * @param {useStatusNotificationObject} state - the state for status notification
- * @param {Object} action - useReducer Object for useReducer hook containing action.payload for useStatusNotification hook
+ * @param {Object} action - useReducer Object for useReducer hook containing
+ * action.payload for useStatusNotification hook
  * @return {useStatusNotificationObject} state - The updated state based on useReducer action
  */
 

--- a/src/reducers/statusReducer.js
+++ b/src/reducers/statusReducer.js
@@ -7,12 +7,12 @@
  * Initial state for useStatusNotification hook
  * @memberof reducers
  * @name initialStatusState
- * @typedef {Object} useStatusNotificationObject
- * @property {string|null} documentUrl - Url link to document container
- * @property {string} message - Status message for file upload, query, or deletion
- * @property {string|null} timeoutID - Timeout ID for status message
- * @property {object|null} file - Object that includes file in question
- * @property {boolean} processing - Boolean on whether application is uploading,
+ * @typedef {Object} statusNotificationObject
+ * @property {String|null} documentUrl - Url link to document container
+ * @property {String} message - Status message for file upload, query, or deletion
+ * @property {String|null} timeoutID - Timeout ID for status message
+ * @property {Object|null} file - Object that includes file in question
+ * @property {Boolean} processing - Boolean on whether application is uploading,
  * fetching, querying data from Solid
  */
 
@@ -27,10 +27,10 @@ export const initialStatusState = {
 /**
  * @memberof reducers
  * @function statusReducer
- * @param {useStatusNotificationObject} state - the state for status notification
+ * @param {statusNotificationObject} state - The state for status notification
  * @param {Object} action - useReducer Object for useReducer hook containing
  * action.payload for useStatusNotification hook
- * @return {useStatusNotificationObject} state - The updated state based on useReducer action
+ * @return {statusNotificationObject} state - The updated state based on useReducer action
  */
 
 const statusReducer = (state, action) => {

--- a/src/utils/form-helper.js
+++ b/src/utils/form-helper.js
@@ -2,10 +2,10 @@
  * Document Types is an array of strings that represent the different document types for upload, fetch, or delete
  * @memberof utils
  * @name docTypes
- * @type {Array<string>}
- * @property {string} Bank_Document - Bank Document
- * @property {string} Passport - Passport
- * @property {string} Drivers_License - Drivers License
+ * @type {Array<String>}
+ * @property {String} Bank_Document - Bank Document
+ * @property {String} Passport - Passport
+ * @property {String} Drivers_License - Drivers License
  */
 
 const docTypes = ['Bank Statement', 'Passport', 'Drivers License'];

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,7 @@
 /**
- * The utils module to help run functions for PASS forms, notifications, and Solid Session
+ * The utils module to help run functions for PASS forms, notifications, and Solid Session.
+ * The file session-core contains functions that is exported to PASS, while session-helper
+ * contains functions that is only exported to session-core
  * @module utils
  * @namespace utils
  */

--- a/src/utils/notification-helper.js
+++ b/src/utils/notification-helper.js
@@ -1,13 +1,17 @@
 /**
+ * @typedef {import("../reducers/statusReducer").statusNotificationObject} statusNotificationObject
+ */
+
+/**
  * Function that runs status messages provided a message, the duration (time in seconds),
  * the timeoutID of previous message (if exist), and the useReducer dispatch function
  * @memberof utils
  * @function runNotification
- * @param {string} message - File status message for upload, fetch, or delete file
- * @param {number} time - Duration of message in seconds
- * @param {useStatusNotificationObject} state - useStatusNotificationObject
+ * @param {String} message - File status message for upload, fetch, or delete file
+ * @param {Number} time - Duration of message in seconds
+ * @param {statusNotificationObject} state - useStatusNotificationObject
  * @param {React.DispatchWithoutAction} dispatch - useStatusNotification dispatch function
- * @returns {void} Void - Status message is displayed via dispatch call
+ * @returns {Void} Void - Status message is displayed via dispatch call
  */
 
 const runNotification = (

--- a/src/utils/notification-helper.js
+++ b/src/utils/notification-helper.js
@@ -1,5 +1,6 @@
 /**
- * Function that runs status messages provided a message, the duration (time in seconds), the timeoutID of previous message (if exist), and the useReducer dispatch function
+ * Function that runs status messages provided a message, the duration (time in seconds),
+ * the timeoutID of previous message (if exist), and the useReducer dispatch function
  * @memberof utils
  * @function runNotification
  * @param {string} message - File status message for upload, fetch, or delete file

--- a/src/utils/session-core.js
+++ b/src/utils/session-core.js
@@ -61,7 +61,8 @@ export const setDocAclPermission = async (session, fileType, accessType, otherPo
  * @property {string} type - Type of document
  * @property {string} date - Date of upload
  * @property {string} description - Description of document
- * @property {Object} file - An object which contain infomation about the file being uploaded as well the document itself
+ * @property {Object} file - An object which contain infomation about the file being uploaded
+ * as well the document itself
  */
 
 /**
@@ -110,14 +111,17 @@ export const uploadDocument = async (session, fileObject) => {
 };
 
 /**
- * Function that fetch the URL of the container containing a specific file uploaded to a user's Pod on Solid, if exist
+ * Function that fetch the URL of the container containing a specific file uploaded to
+ * a user's Pod on Solid, if exist
  * @memberof utils
  * @function fetchDocuments
  * @param {Session} session - Solid Session
  * @param {string} fileType - Type of document
- * @param {string} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods, or "cross-fetch")
+ * @param {string} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods,
+ * or "cross-fetch")
  * @param {string} [otherPodUrl] - Url to other user's Pod (set to empty string by default)
- * @returns {Promise} Promise - Either a string containing the url location of the document, if exist, or throws an Error
+ * @returns {Promise} Promise - Either a string containing the url location of the document,
+ * if exist, or throws an Error
  */
 
 export const fetchDocuments = async (session, fileType, fetchType, otherPodUrl = '') => {
@@ -132,12 +136,14 @@ export const fetchDocuments = async (session, fileType, fetchType, otherPodUrl =
 };
 
 /**
- * Function that deletes all files from a Solid container associated to a file type, if exist, and returns the container's URL
+ * Function that deletes all files from a Solid container associated to a file type,
+ * if exist, and returns the container's URL
  * @memberof utils
  * @function deleteDocuments
  * @param {Session} session - Solid Session
  * @param {string} fileType - Type of document
- * @returns {Promise} container.url - The URL of document container and the response on whether document file is deleted, if exist, and delete all existing files within it
+ * @returns {Promise} container.url - The URL of document container and the response on
+ * whether document file is deleted, if exist, and delete all existing files within it
  */
 
 export const deleteDocumentFile = async (session, fileType) => {

--- a/src/utils/session-core.js
+++ b/src/utils/session-core.js
@@ -46,9 +46,6 @@ export const setDocAclPermission = async (session, fileType, accessType, otherPo
     case 'Give':
       accessObject = { read: true };
       break;
-    case 'Revoke':
-      accessObject = { read: false };
-      break;
     default:
       accessObject = { read: false };
       break;
@@ -56,8 +53,6 @@ export const setDocAclPermission = async (session, fileType, accessType, otherPo
 
   const updatedAcl = setupAcl(resourceAcl, webId, accessObject);
   await saveAclFor(podResouceWithAcl, updatedAcl, { fetch: session.fetch });
-
-  console.log(`Permissions for ${fileType} has been set to: "${accessType}"`);
 };
 
 /**
@@ -97,31 +92,21 @@ export const uploadDocument = async (session, fileObject) => {
   let myDataset;
   if (ttlFile !== null) {
     myDataset = await getSolidDataset(ttlFile, { fetch: session.fetch });
-
-    console.log('Call original dataset: ', myDataset);
-
     myDataset = setThing(myDataset, toBeUpdated);
-    const result = await saveSolidDatasetAt(ttlFile, documentUrl, myDataset, {
+
+    await saveSolidDatasetAt(ttlFile, documentUrl, myDataset, {
       fetch: session.fetch
     });
-
-    console.log('New dataset: ', result);
   } else {
     let courseSolidDataset = createSolidDataset();
     courseSolidDataset = setThing(courseSolidDataset, toBeUpdated);
-    const result = await saveSolidDatasetInContainer(documentUrl, courseSolidDataset, {
+
+    await saveSolidDatasetInContainer(documentUrl, courseSolidDataset, {
       fetch: session.fetch
     });
 
-    console.log('Newly generated and uploaded dataset: ', result);
-
     await createDocAclForUser(session, documentUrl);
   }
-
-  console.log(
-    `Uploaded ${fileObject.file.name} to pod successfully and set identifier to ${fileObject.type},
-    end date to ${fileObject.date}, and description to ${fileObject.description}`
-  );
 };
 
 /**
@@ -142,7 +127,6 @@ export const fetchDocuments = async (session, fileType, fetchType, otherPodUrl =
     await getSolidDataset(documentUrl, { fetch: session.fetch });
     return documentUrl;
   } catch (error) {
-    console.log('No data found or unauthorized');
     throw new Error('No data found or unauthorized');
   }
 };
@@ -160,8 +144,8 @@ export const deleteDocumentFile = async (session, fileType) => {
   const documentUrl = fetchUrl(session, fileType, 'self-fetch');
   const fetched = await getSolidDataset(documentUrl, { fetch: session.fetch });
 
-  // Solid requires all files within Pod Container must be deleted before
-  // the container itself can be delete itself
+  // Solid requires all files within Pod container must be deleted before
+  // the container itself can be deleted from Pod
   const [container, files] = hasFiles(fetched);
   files.filter(async (file) => {
     if (!file.url.slice(-3).includes('/')) {

--- a/src/utils/session-core.js
+++ b/src/utils/session-core.js
@@ -127,7 +127,7 @@ export const fetchDocuments = async (session, fileType, fetchType, otherPodUrl =
     await getSolidDataset(documentUrl, { fetch: session.fetch });
     return documentUrl;
   } catch (error) {
-    throw new Error('No data found or unauthorized');
+    throw new Error('No data found');
   }
 };
 

--- a/src/utils/session-core.js
+++ b/src/utils/session-core.js
@@ -28,9 +28,9 @@ import {
  * @memberof utils
  * @function setDocAclPermission
  * @param {Session} session - Solid Session
- * @param {string} fileType - Type of document
- * @param {string} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods, or "cross-fetch")
- * @param {string} otherPodUrl - Url to other user's Pod or empty string
+ * @param {String} fileType - Type of document
+ * @param {String} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods, or "cross-fetch")
+ * @param {String} otherPodUrl - Url to other user's Pod or empty string
  * @returns {Promise} Promise - Sets permission for otherPodUrl for given document type, if exists, or null
  */
 
@@ -58,9 +58,9 @@ export const setDocAclPermission = async (session, fileType, accessType, otherPo
 /**
  * An input object for functions related to file uploads to Solid's Pod
  * @typedef fileObject
- * @property {string} type - Type of document
- * @property {string} date - Date of upload
- * @property {string} description - Description of document
+ * @property {String} type - Type of document
+ * @property {String} date - Date of upload
+ * @property {String} description - Description of document
  * @property {Object} file - An object which contain infomation about the file being uploaded
  * as well the document itself
  */
@@ -116,10 +116,10 @@ export const uploadDocument = async (session, fileObject) => {
  * @memberof utils
  * @function fetchDocuments
  * @param {Session} session - Solid Session
- * @param {string} fileType - Type of document
- * @param {string} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods,
+ * @param {String} fileType - Type of document
+ * @param {String} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods,
  * or "cross-fetch")
- * @param {string} [otherPodUrl] - Url to other user's Pod (set to empty string by default)
+ * @param {String} [otherPodUrl] - Url to other user's Pod (set to empty string by default)
  * @returns {Promise} Promise - Either a string containing the url location of the document,
  * if exist, or throws an Error
  */
@@ -141,7 +141,7 @@ export const fetchDocuments = async (session, fileType, fetchType, otherPodUrl =
  * @memberof utils
  * @function deleteDocuments
  * @param {Session} session - Solid Session
- * @param {string} fileType - Type of document
+ * @param {String} fileType - Type of document
  * @returns {Promise} container.url - The URL of document container and the response on
  * whether document file is deleted, if exist, and delete all existing files within it
  */
@@ -167,7 +167,7 @@ export const deleteDocumentFile = async (session, fileType) => {
  * @memberof utils
  * @function deleteDocumentContainer
  * @param {Session} session - Solid Session
- * @param {string} documentUrl - Url of document container
+ * @param {String} documentUrl - Url of document container
  * @returns {Promise} Promise - Perform action that deletes container completely from Pod
  */
 

--- a/src/utils/session-helper.js
+++ b/src/utils/session-helper.js
@@ -159,6 +159,4 @@ export const createDocAclForUser = async (session, documentUrl) => {
 
   const newAcl = setupAcl(resourceAcl, session.info.webId, accessObject);
   await saveAclFor(podResourceWithoutAcl, newAcl, { fetch: session.fetch });
-
-  console.log(`ACL generated for ${documentUrl}`);
 };

--- a/src/utils/session-helper.js
+++ b/src/utils/session-helper.js
@@ -11,7 +11,7 @@ import {
 /**
  * The URL to a specific Solid Provider
  * @name SOLID_IDENTITY_PROVIDER
- * @type {string}
+ * @type {String}
  */
 
 export const SOLID_IDENTITY_PROVIDER = 'https://opencommons.net';
@@ -22,7 +22,7 @@ export const SOLID_IDENTITY_PROVIDER = 'https://opencommons.net';
  * @function placeFileInContainer
  * @param {Session} session - Solid Session
  * @param {Object} fileObject - Object of file being uploaded to Solid
- * @param {string} containerUrl - URL location of Pod container
+ * @param {String} containerUrl - URL location of Pod container
  * @returns {Promise} Promise - Places and saves uploaded file onto Solid Pod via a container
  */
 
@@ -38,7 +38,7 @@ export const placeFileInContainer = async (session, fileObject, containerUrl) =>
  * Function that checks if container URL contains TTL files
  * @memberof utils
  * @function hasTTLFiles
- * @param {string} containerUrl - URL of a Solid container
+ * @param {String} containerUrl - URL of a Solid container
  * @returns {Object|null} ttlFiles or null - An object of the first ttl file in location or null,
  * if the ttl file does not exist
  */
@@ -61,7 +61,7 @@ export const hasTTLFiles = (containerUrl) => {
  * Function checks if container URL contains any files
  * @memberof utils
  * @function hasFiles
- * @param {string} containerUrl - URL of location in question
+ * @param {String} containerUrl - URL of location in question
  * @returns {Array|null} [directory, files] or null - an Array of Objects consisting of the
  * directory container and the rest of the files or null
  */
@@ -92,11 +92,11 @@ export const hasFiles = (containerUrl) => {
  * @memberof utils
  * @function fetchUrl
  * @param {Session} session - Solid Session
- * @param {string} fileType - Type of document
- * @param {string} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods,
+ * @param {String} fileType - Type of document
+ * @param {String} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods,
  * or "cross-fetch")
- * @param {string} otherPodUrl - Url to other user's Pod or empty string
- * @returns {string|null} url or null - A url of where the container that stores the file
+ * @param {String} otherPodUrl - Url to other user's Pod or empty string
+ * @returns {String|null} url or null - A url of where the container that stores the file
  * is located in or null, if container doesn't exist
  */
 
@@ -125,7 +125,7 @@ export const fetchUrl = (session, fileType, fetchType, otherPodUrl) => {
  * @memberof utils
  * @function setupAcl
  * @param {AclDataset} resourceWithAcl - A Solid Session Dataset with ACL file
- * @param {string} webId - Solid webId
+ * @param {String} webId - Solid webId
  * @param {Access} accessObject - Solid Access Object which sets ACL permission for
  * read, append, write, and control
  * @returns {AclDataset} - Solid Session Dataset with updated ACL file
@@ -145,7 +145,7 @@ export const setupAcl = (resourceWithAcl, webId, accessObject) => {
  * @memberof utils
  * @function createDocAclForUser
  * @param {Session} session - Solid Session
- * @param {string} documentUrl - Url link to document container
+ * @param {String} documentUrl - Url link to document container
  * @returns {Promise} Promise - Generates ACL file for container and give user access
  * and control to it and its contents
  */

--- a/src/utils/session-helper.js
+++ b/src/utils/session-helper.js
@@ -23,19 +23,15 @@ export const SOLID_IDENTITY_PROVIDER = 'https://opencommons.net';
  * @param {Session} session - Solid Session
  * @param {Object} fileObject - Object of file being uploaded to Solid
  * @param {string} containerUrl - URL location of Pod container
- * @returns {Promise} Promise - A message regarding the status of upload to user's Pod
+ * @returns {Promise} Promise - Places and saves uploaded file onto Solid Pod via a container
  */
 
 export const placeFileInContainer = async (session, fileObject, containerUrl) => {
-  try {
-    await saveFileInContainer(containerUrl, fileObject.file, {
-      slug: fileObject.file.name,
-      contentType: fileObject.type,
-      fetch: session.fetch
-    });
-  } catch (error) {
-    console.log(error);
-  }
+  await saveFileInContainer(containerUrl, fileObject.file, {
+    slug: fileObject.file.name,
+    contentType: fileObject.type,
+    fetch: session.fetch
+  });
 };
 
 /**

--- a/src/utils/session-helper.js
+++ b/src/utils/session-helper.js
@@ -39,7 +39,8 @@ export const placeFileInContainer = async (session, fileObject, containerUrl) =>
  * @memberof utils
  * @function hasTTLFiles
  * @param {string} containerUrl - URL of a Solid container
- * @returns {Object|null} ttlFiles or null - An object of the first ttl file in location or null, if the ttl file does not exist
+ * @returns {Object|null} ttlFiles or null - An object of the first ttl file in location or null,
+ * if the ttl file does not exist
  */
 
 export const hasTTLFiles = (containerUrl) => {
@@ -61,7 +62,8 @@ export const hasTTLFiles = (containerUrl) => {
  * @memberof utils
  * @function hasFiles
  * @param {string} containerUrl - URL of location in question
- * @returns {Array|null} [directory, files] or null - an Array of Objects consisting of the directory container and the rest of the files or null
+ * @returns {Array|null} [directory, files] or null - an Array of Objects consisting of the
+ * directory container and the rest of the files or null
  */
 
 export const hasFiles = (containerUrl) => {
@@ -85,14 +87,17 @@ export const hasFiles = (containerUrl) => {
 };
 
 /**
- * Function that returns the location of the Solid container containing a specific file type, if exist on user's Pod
+ * Function that returns the location of the Solid container containing a specific file type,
+ * if exist on user's Pod
  * @memberof utils
  * @function fetchUrl
  * @param {Session} session - Solid Session
  * @param {string} fileType - Type of document
- * @param {string} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods, or "cross-fetch")
+ * @param {string} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods,
+ * or "cross-fetch")
  * @param {string} otherPodUrl - Url to other user's Pod or empty string
- * @returns {string|null} url or null - A url of where the container that stores the file is located in or null, if container doesn't exist
+ * @returns {string|null} url or null - A url of where the container that stores the file
+ * is located in or null, if container doesn't exist
  */
 
 export const fetchUrl = (session, fileType, fetchType, otherPodUrl) => {
@@ -121,7 +126,8 @@ export const fetchUrl = (session, fileType, fetchType, otherPodUrl) => {
  * @function setupAcl
  * @param {AclDataset} resourceWithAcl - A Solid Session Dataset with ACL file
  * @param {string} webId - Solid webId
- * @param {Access} accessObject - Solid Access Object which sets ACL permission for read, append, write, and control
+ * @param {Access} accessObject - Solid Access Object which sets ACL permission for
+ * read, append, write, and control
  * @returns {AclDataset} - Solid Session Dataset with updated ACL file
  */
 
@@ -134,12 +140,14 @@ export const setupAcl = (resourceWithAcl, webId, accessObject) => {
 };
 
 /**
- * Function that generates ACL file for container containing a specific document type and turtle file and give the user access and control to the Solid container
+ * Function that generates ACL file for container containing a specific document type
+ * and turtle file and give the user access and control to the Solid container
  * @memberof utils
  * @function createDocAclForUser
  * @param {Session} session - Solid Session
  * @param {string} documentUrl - Url link to document container
- * @returns {Promise} Promise - Generates ACL file for container and give user access and control to it and its contents
+ * @returns {Promise} Promise - Generates ACL file for container and give user access
+ * and control to it and its contents
  */
 
 export const createDocAclForUser = async (session, documentUrl) => {


### PR DESCRIPTION
This branch was built from #53 branch, so changes from the unmerged #53 can also be found in the commits/file changes here. Can be merged into Development after #53 and is reviewed.

This branch was initially created to review/refactor existing codebase without including additional features. Additionally, to keep track of general updates to existing code, a CHANGELOG.md is now included to this branch and hopefully into Development, then Master.

The idea of the changelog was discussed during the March 14, 2023 meeting. Overall, it'll be used to include a general description of all future changes to the codebase in this file (instead of just a commit description), including what it is (like a feature) and their pull request number (i.e. #56), so that everyone can be kept up-to-date. Feedback for what to include in CHANGELOG are welcomed.

However, one feature has been introduced in this PR. I've found out while writing out general instructions for "How to use PASS" ([Google Doc to Instructions](https://docs.google.com/document/d/1VtlBW7fkELDzIkKGdOZ-e12A2rmxB6I2yPFCh1vo820/edit?usp=sharing)), that users can accidentally revoke their own access to their document container using the Permission to Files section.

This is bad since it'll force users to have to manually delete their faulty ACL from their Pod before the container can be accessed again. Not only that, but that their original ACL file will be lost as a result. So the new feature is included as a guard rail that prevent users from doing that. That's the only feature included here, which is addressed in #57.