### PR TITLE
Updating .gitignore for Vite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-/dist
 /node_modules
-/.parcel-cache
 .DS_Store
-/PASS-branches
 /docs
 !/docs/README.md
+


### PR DESCRIPTION
Removing paths to /dist, /PASS-branches, and /.parcel-cache from .gitignore which were left overs from Parcel