### PR TITLE
Issue 66/refactoring form components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,14 +4,14 @@ module.exports = {
     commonjs: true,
     es2021: true
   },
-  extends: ['plugin:react/recommended', 'airbnb', 'prettier'],
+  extends: ['plugin:react/recommended', 'airbnb', 'prettier', 'plugin:jsdoc/recommended'],
   parserOptions: {
     ecmaFeatures: {
       jsx: true
     },
     ecmaVersion: 14
   },
-  plugins: ['prettier'],
+  plugins: ['prettier', 'jsdoc'],
   rules: {
     'react/function-component-definition': ['error', { namedComponents: 'arrow-function' }],
     'react/jsx-props-no-spreading': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'no-console': 'off',
     'jsx-a11y/label-has-associated-control': ['error', { assert: 'either' }],
     'arrow-body-style': ['error', 'as-needed'],
-    'no-param-reassign': ['error', { props: false }]
+    'no-param-reassign': ['error', { props: false }],
+    'jsdoc/valid-types': 'off'
   }
 };

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .DS_Store
 /docs
 !/docs/README.md
-
+/dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.0.2 (March 22, 2023)
+
+## Fixes
+
+- Fixed typo for input elements in Form component relating to file upload (#65)
+
+## Dev Changes
+
+- Refactored FormSection to include section title instead of inside its children component (#66)
+- Reformatted JSDoc to follow recommended linting rules from ESLint plugin for JSDoc (#66)
+
+## Others
+
+- Deployed PASS to GitHub Pages with the link [https://codeforpdx.github.io/PASS/](https://codeforpdx.github.io/PASS/) (domain name will change in future updates) (#59)
+
+---
+
 ## v0.0.1 (March 18, 2023)
 
 ## Features

--- a/jsdoc.config.json
+++ b/jsdoc.config.json
@@ -3,6 +3,10 @@
     "include": ["src"],
     "exclude": ["node_modules", "public"]
   },
+  "templates": {
+    "cleverLinks": true,
+    "monospaceLinks": true
+  },
   "opts": {
     "destination": "docs",
     "recurse": true

--- a/jsdoc.config.json
+++ b/jsdoc.config.json
@@ -7,6 +7,10 @@
     "cleverLinks": true,
     "monospaceLinks": true
   },
+  "plugins": ["node_modules/jsdoc-tsimport-plugin/index.js"],
+  "settings": {
+    "jsdoc": { "mode": "typescript" }
+  },
   "opts": {
     "destination": "docs",
     "recurse": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "jsdoc": "^4.0.0",
+        "jsdoc-tsimport-plugin": "^1.0.5",
         "prettier": "^2.8.4",
         "string_decoder": "^1.3.0",
         "vite": "^4.1.4"
@@ -4492,6 +4493,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/jsdoc-tsimport-plugin": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc-tsimport-plugin/-/jsdoc-tsimport-plugin-1.0.5.tgz",
+      "integrity": "sha512-6mvyF+tXdanf3zxEumTF9Uf/sXGlANP+XohSuiJiOVVWPGxi+3f2a2sy5Ew3W+0PMYUkcGYNxfYd5mMZsIHQpg==",
+      "dev": true
     },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "4.0.0",
@@ -9547,6 +9554,12 @@
           "dev": true
         }
       }
+    },
+    "jsdoc-tsimport-plugin": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc-tsimport-plugin/-/jsdoc-tsimport-plugin-1.0.5.tgz",
+      "integrity": "sha512-6mvyF+tXdanf3zxEumTF9Uf/sXGlANP+XohSuiJiOVVWPGxi+3f2a2sy5Ew3W+0PMYUkcGYNxfYd5mMZsIHQpg==",
+      "dev": true
     },
     "jsdoc-type-pratt-parser": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pass",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pass",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^1.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-config-node": "^4.1.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-jsdoc": "^40.1.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.2.1",
@@ -415,6 +416,20 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.37.0.tgz",
+      "integrity": "sha512-hjK0wnsPCYLlF+HHB4R/RbUjOWeLW2SlarB67+Do5WsKILOkmIZvvPJFbtWSmbypxcjpoECLAMzoao0D4Bg5ZQ==",
+      "dev": true,
+      "dependencies": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~4.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -1608,6 +1623,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
+    },
+    "node_modules/comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2999,6 +3023,72 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "40.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-40.1.0.tgz",
+      "integrity": "sha512-ANvrhiu62VlSorARM0hup60VQsS3hNyp0Ca7cnJDj8tpJzM7tNhBVqMVYXSuLzEmqrpwx6aAh+NAN2DdAGG5fQ==",
+      "dev": true,
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.37.0",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.5.0",
+        "semver": "^7.3.8",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "engines": {
+        "node": "^14 || ^16 || ^17 || ^18 || ^19"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.7.1",
@@ -4403,6 +4493,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/jsdoc/node_modules/escape-string-regexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
@@ -5615,6 +5714,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
+      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
+      "dev": true
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6514,6 +6635,17 @@
         "ky-universal": "^0.8.2"
       }
     },
+    "@es-joy/jsdoccomment": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.37.0.tgz",
+      "integrity": "sha512-hjK0wnsPCYLlF+HHB4R/RbUjOWeLW2SlarB67+Do5WsKILOkmIZvvPJFbtWSmbypxcjpoECLAMzoao0D4Bg5ZQ==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~4.0.0"
+      }
+    },
     "@esbuild/android-arm": {
       "version": "0.16.17",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
@@ -7292,6 +7424,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
       "dev": true
     },
     "concat-map": {
@@ -8438,6 +8576,53 @@
         }
       }
     },
+    "eslint-plugin-jsdoc": {
+      "version": "40.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-40.1.0.tgz",
+      "integrity": "sha512-ANvrhiu62VlSorARM0hup60VQsS3hNyp0Ca7cnJDj8tpJzM7tNhBVqMVYXSuLzEmqrpwx6aAh+NAN2DdAGG5fQ==",
+      "dev": true,
+      "requires": {
+        "@es-joy/jsdoccomment": "~0.37.0",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.5.0",
+        "semver": "^7.3.8",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-jsx-a11y": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.7.1.tgz",
@@ -9363,6 +9548,12 @@
         }
       }
     },
+    "jsdoc-type-pratt-parser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+      "dev": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -10199,6 +10390,28 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
+      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
       "dev": true
     },
     "sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pass",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-config-node": "^4.1.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jsdoc": "^40.1.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "jsdoc": "^4.0.0",
+    "jsdoc-tsimport-plugin": "^1.0.5",
     "prettier": "^2.8.4",
     "string_decoder": "^1.3.0",
     "vite": "^4.1.4"

--- a/src/components/Form/CrossPodQueryForm.jsx
+++ b/src/components/Form/CrossPodQueryForm.jsx
@@ -45,7 +45,7 @@ const CrossPodQueryForm = () => {
       }, 3000);
     } catch (_error) {
       dispatch({ type: 'CLEAR_DOCUMENT_LOCATION' });
-      runNotification('Search failed. Reason: Document not found', 3, state, dispatch);
+      runNotification('Search failed. Reason: Document not found.', 3, state, dispatch);
     }
   };
 
@@ -54,8 +54,12 @@ const CrossPodQueryForm = () => {
   };
 
   return (
-    <FormSection state={state} statusType="Search status" defaultMessage="To be searched...">
-      <strong>Cross Pod Search</strong>
+    <FormSection
+      title="Cross Pod Search"
+      state={state}
+      statusType="Search status"
+      defaultMessage="To be searched..."
+    >
       <form onSubmit={handleCrossPodQuery} autoComplete="off">
         <div style={formRowStyle}>
           <label htmlFor="cross-search-doc">

--- a/src/components/Form/CrossPodQueryForm.jsx
+++ b/src/components/Form/CrossPodQueryForm.jsx
@@ -8,8 +8,8 @@ import FormSection from './FormSection';
 /**
  * CrossPodQueryForm Component - Component that generates the form for cross pod search
  * for a specific document from another user's Solid Pod via Solid Session
+ *
  * @memberof Forms
- * @component
  * @name CrossPodQueryForm
  */
 

--- a/src/components/Form/CrossPodWriteForm.jsx
+++ b/src/components/Form/CrossPodWriteForm.jsx
@@ -6,8 +6,8 @@ import DocumentSelection from './DocumentSelection';
 /**
  * CrossPodWriteForm Component - Component that generates the form for cross pod uploading
  * for a specific document to another user's Solid Pod via Solid Session
+ *
  * @memberof Forms
- * @component
  * @name CrossPodWriteForm
  */
 

--- a/src/components/Form/DeleteDocumentForm.jsx
+++ b/src/components/Form/DeleteDocumentForm.jsx
@@ -8,8 +8,8 @@ import FormSection from './FormSection';
 /**
  * DeleteDocumentForm Component - Component that generates the form for
  * deleting a specific document type from a user's Solid Pod via Solid Session
+ *
  * @memberof Forms
- * @component
  * @name DeleteDocumentForm
  */
 

--- a/src/components/Form/DeleteDocumentForm.jsx
+++ b/src/components/Form/DeleteDocumentForm.jsx
@@ -35,7 +35,7 @@ const DeleteDocumentForm = () => {
         runNotification('Removing file container from Pod...', 7, state, dispatch);
       }, 3000);
     } catch (_error) {
-      runNotification('Deletion failed. Reason: Data not found', 3, state, dispatch);
+      runNotification('Deletion failed. Reason: Data not found.', 3, state, dispatch);
     }
   };
 
@@ -44,8 +44,12 @@ const DeleteDocumentForm = () => {
   };
 
   return (
-    <FormSection state={state} statusType="Deletion status" defaultMessage="To be deleted...">
-      <strong>Delete Document</strong>
+    <FormSection
+      title="Delete Document"
+      state={state}
+      statusType="Deletion status"
+      defaultMessage="To be deleted..."
+    >
       <form onSubmit={handleDeleteDocument} autoComplete="off">
         <div style={formRowStyle}>
           <label htmlFor="delete-doctype">Select document type to delete: </label>

--- a/src/components/Form/DocumentSelection.jsx
+++ b/src/components/Form/DocumentSelection.jsx
@@ -4,8 +4,8 @@ import docTypes from '../../utils/form-helper';
 /**
  * DocumentSelection Component - Sub-component that generates the dropdown
  * box/menu for selecting document type to a user's Solid Pod via Solid Session
+ *
  * @memberof Forms
- * @component
  * @name DocumentSelection
  */
 

--- a/src/components/Form/FetchDocumentForm.jsx
+++ b/src/components/Form/FetchDocumentForm.jsx
@@ -8,8 +8,8 @@ import FormSection from './FormSection';
 /**
  * FetchDocumentForm Component - Component that generates the form for searching
  * a specific document type from a user's Solid Pod via Solid Session
+ *
  * @memberof Forms
- * @component
  * @name FetchDocumentForm
  */
 

--- a/src/components/Form/FetchDocumentForm.jsx
+++ b/src/components/Form/FetchDocumentForm.jsx
@@ -39,7 +39,7 @@ const FetchDocumentForm = () => {
       }, 3000);
     } catch (_error) {
       dispatch({ type: 'CLEAR_DOCUMENT_LOCATION' });
-      runNotification('Search failed. Reason: Document not found', 3, state, dispatch);
+      runNotification('Search failed. Reason: Document not found.', 3, state, dispatch);
     }
   };
 
@@ -48,8 +48,12 @@ const FetchDocumentForm = () => {
   };
 
   return (
-    <FormSection state={state} statusType="Search status" defaultMessage="To be searched...">
-      <strong>Search Document</strong>
+    <FormSection
+      title="Search Document"
+      state={state}
+      statusType="Search status"
+      defaultMessage="To be searched..."
+    >
       <form onSubmit={handleGetDocumentSubmission} autoComplete="off">
         <div style={formRowStyle}>
           <label htmlFor="search-doctype">Select document type to search: </label>

--- a/src/components/Form/FormSection.jsx
+++ b/src/components/Form/FormSection.jsx
@@ -7,6 +7,7 @@ import { StatusNotification } from '../Notification';
 
 /**
  * @typedef {Object} formSectionProps
+ * @property {String} title - Title of form section
  * @property {statusNotificationObject} state - The state for status notification
  * @property {String} statusType - Type of action for PASS
  * @property {String} defaultMessage - Default notification message when inactive
@@ -19,11 +20,12 @@ import { StatusNotification } from '../Notification';
  * @component
  * @name FormSection
  * @param {formSectionProps} formSectionProps - A react prop that consists of that
- * consist of state, statusType, defaultMessage, and children
+ * consist of title, state, statusType, defaultMessage, and children
  */
 
-const FormSection = ({ state, statusType, defaultMessage, children }) => (
+const FormSection = ({ title, state, statusType, defaultMessage, children }) => (
   <section className="panel">
+    <strong>{title}</strong>
     {children}
     <StatusNotification
       notification={state.message}

--- a/src/components/Form/FormSection.jsx
+++ b/src/components/Form/FormSection.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StatusNotification } from '../Notification';
 
 /**
- * @typedef {import('../../hooks').statusNotificationObject} statusNotificationObject
+ * @typedef {import("../../reducers/statusReducer").statusNotificationObject} statusNotificationObject
  */
 
 /**

--- a/src/components/Form/FormSection.jsx
+++ b/src/components/Form/FormSection.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { StatusNotification } from '../Notification';
-import { formSectionProps } from '../../typedefs';
+
+/**
+ * @typedef {import('../../typedefs').formSectionProps} formSectionProps
+ */
 
 /**
  * FormSection Component - Component that wraps Form with StatusNotification

--- a/src/components/Form/FormSection.jsx
+++ b/src/components/Form/FormSection.jsx
@@ -1,29 +1,11 @@
 import React from 'react';
 import { StatusNotification } from '../Notification';
-
-/**
- * @typedef {Object} statusNotificationObject
- * @property {String|null} documentUrl - Url link to document container
- * @property {String} message - Status message for file upload, query, or deletion
- * @property {String|null} timeoutID - Timeout ID for status message
- * @property {Object|null} file - Object that includes file in question
- * @property {Boolean} processing - Boolean on whether application is uploading,
- * fetching, querying data from Solid
- */
-
-/**
- * @typedef {Object} formSectionProps
- * @property {String} title - Title of form section
- * @property {statusNotificationObject} state - The state for status notification
- * @property {String} statusType - Type of action for PASS
- * @property {String} defaultMessage - Default notification message when inactive
- * @property {JSX.Element} children - JSX Element of the wrapped form
- */
+import { formSectionProps } from '../../typedefs';
 
 /**
  * FormSection Component - Component that wraps Form with StatusNotification
+ *
  * @memberof Forms
- * @component
  * @name FormSection
  * @param {formSectionProps} formSectionProps - A react prop that consists of that
  * consist of title, state, statusType, defaultMessage, and children

--- a/src/components/Form/FormSection.jsx
+++ b/src/components/Form/FormSection.jsx
@@ -2,7 +2,13 @@ import React from 'react';
 import { StatusNotification } from '../Notification';
 
 /**
- * @typedef {import("../../reducers/statusReducer").statusNotificationObject} statusNotificationObject
+ * @typedef {Object} statusNotificationObject
+ * @property {String|null} documentUrl - Url link to document container
+ * @property {String} message - Status message for file upload, query, or deletion
+ * @property {String|null} timeoutID - Timeout ID for status message
+ * @property {Object|null} file - Object that includes file in question
+ * @property {Boolean} processing - Boolean on whether application is uploading,
+ * fetching, querying data from Solid
  */
 
 /**

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -64,8 +64,12 @@ const SetAclPermissionForm = () => {
   };
 
   return (
-    <FormSection state={state} statusType="Permission status" defaultMessage="To be set...">
-      <strong>Permission to Files</strong>
+    <FormSection
+      title="Permission to Files"
+      state={state}
+      statusType="Permission status"
+      defaultMessage="To be set..."
+    >
       <form onSubmit={handleAclPermission} autoComplete="off">
         <div style={formRowStyle}>
           <label htmlFor="set-acl-to">

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -8,8 +8,8 @@ import FormSection from './FormSection';
 /**
  * SetAclPermissionForm Component - Component that generates the form for setting
  * document ACL permissions to another user's Solid Pod via Solid Session
+ *
  * @memberof Forms
- * @component
  * @name SetAclPermissionForm
  */
 

--- a/src/components/Form/UploadDocumentForm.jsx
+++ b/src/components/Form/UploadDocumentForm.jsx
@@ -8,8 +8,8 @@ import FormSection from './FormSection';
 /**
  * UploadDocumentForm Component - Component that generates the form for uploading
  * a specific document type to a user's Solid Pod via Solid Session
+ *
  * @memberof Forms
- * @component
  * @name UploadDocumentForm
  */
 

--- a/src/components/Form/UploadDocumentForm.jsx
+++ b/src/components/Form/UploadDocumentForm.jsx
@@ -79,8 +79,12 @@ const UploadDocumentForm = () => {
   };
 
   return (
-    <FormSection state={state} statusType="Writing status" defaultMessage="To be uploaded...">
-      <strong>Upload Document</strong>
+    <FormSection
+      title="Upload Document"
+      state={state}
+      statusType="Writing status"
+      defaultMessage="To be uploaded..."
+    >
       <form onSubmit={handleFormSubmission} autoComplete="off">
         <div style={formRowStyle}>
           <label htmlFor="upload-doc">Select document type to upload: </label>

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -7,6 +7,7 @@ import SetAclPermissionForm from './SetAclPermissionForm';
 
 /**
  * Components and functions related to Forms within project PASS
+ *
  * @namespace Forms
  */
 

--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -5,8 +5,8 @@ import { SOLID_IDENTITY_PROVIDER } from '../../utils';
 /**
  * Login Component - Component that generates Login section for users to a
  * Solid Pod via Solid Session
+ *
  * @memberof Login
- * @component
  * @name Login
  */
 

--- a/src/components/Login/Logout.jsx
+++ b/src/components/Login/Logout.jsx
@@ -4,8 +4,8 @@ import { useSession, LogoutButton } from '@inrupt/solid-ui-react';
 /**
  * Logout Component - Component that generates Logout section for users to a
  * Solid Pod via Solid Session
+ *
  * @memberof Login
- * @component
  * @name Logout
  */
 

--- a/src/components/Login/index.js
+++ b/src/components/Login/index.js
@@ -3,6 +3,7 @@ import Logout from './Logout';
 
 /**
  * Components and functions related to Login/Logout functionality within project PASS
+ *
  * @namespace Login
  */
 

--- a/src/components/Notification/StatusMessage.jsx
+++ b/src/components/Notification/StatusMessage.jsx
@@ -1,18 +1,13 @@
 import React from 'react';
-
-/**
- * @typedef {Object} statusMessageProps
- * @property {String} notification - File status message
- * @property {String} [locationUrl] - URL location of file, if exist
- */
+import { statusMessageProps } from '../../typedefs';
 
 /**
  * StatusMessage Component - Sub-component that shows status message for StatusNotification
+ *
  * @memberof Notifications
- * @component
  * @name StatusMessage
  * @param {statusMessageProps} statusMessageProps - A react prop that consist of notification,
- * and locationUrl, which is optional
+ * and locationUrl, which is optional {@link statusMessageProps}
  */
 
 const StatusMessage = ({ notification, locationUrl }) => {

--- a/src/components/Notification/StatusMessage.jsx
+++ b/src/components/Notification/StatusMessage.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { statusMessageProps } from '../../typedefs';
+
+/**
+ * @typedef {import('../../typedefs').statusMessageProps} statusMessageProps
+ */
 
 /**
  * StatusMessage Component - Sub-component that shows status message for StatusNotification

--- a/src/components/Notification/StatusMessage.jsx
+++ b/src/components/Notification/StatusMessage.jsx
@@ -16,7 +16,7 @@ import React from 'react';
  */
 
 const StatusMessage = ({ notification, locationUrl }) => {
-  if (notification) {
+  if (locationUrl) {
     return (
       <dd className="labelStatus" role="alert">
         {notification}{' '}

--- a/src/components/Notification/StatusNotification.jsx
+++ b/src/components/Notification/StatusNotification.jsx
@@ -1,22 +1,15 @@
 import React from 'react';
 import StatusMessage from './StatusMessage';
-
-/**
- * @typedef {Object} statusNotificationProps
- * @property {String} notification - File status message
- * @property {String} statusType - Type of file status (i.e. file upload, file fetch, file delete)
- * @property {String} defaultMessage - Default message when status is not triggered
- * @property {String} [locationUrl] - URL location of file, if exist
- */
+import { statusNotificationProps } from '../../typedefs';
 
 /**
  * StatusNotification Component - Component that renders status notification and message
  * for file upload, search, delete, etc.
+ *
  * @memberof Notifications
- * @component
  * @name StatusNotification
  * @param {statusNotificationProps} statusNotificationProps - A react prop that consist of notification,
- * statusType, defaultMessage, and locationUrl, which is optional
+ * statusType, defaultMessage, and locationUrl, which is optional (see {@link statusNotificationProps})
  */
 
 const StatusNotification = ({ notification, statusType, defaultMessage, locationUrl = '' }) => (

--- a/src/components/Notification/StatusNotification.jsx
+++ b/src/components/Notification/StatusNotification.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import StatusMessage from './StatusMessage';
-import { statusNotificationProps } from '../../typedefs';
+
+/**
+ * @typedef {import("../../typedefs").statusNotificationProps} statusNotificationProps
+ */
 
 /**
  * StatusNotification Component - Component that renders status notification and message

--- a/src/components/Notification/index.js
+++ b/src/components/Notification/index.js
@@ -3,6 +3,7 @@ import StatusNotification from './StatusNotification';
 
 /**
  * Components and functions related to Status Notification functionality within project PASS
+ *
  * @namespace Notifications
  */
 

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,26 +1,21 @@
 /**
  * The hooks module contains custom hooks to assist with form handling or status notifications
+ *
  * @namespace hooks
  */
 
 import { useReducer, useState } from 'react';
 import statusReducer, { initialStatusState } from '../reducers/statusReducer';
-
-/**
- * @typedef {Object} useFieldObject
- * @property {String} type - Type attribute of HTML input element
- * @property {String} value - The value of input element
- * @property {Function} onChange - Event handler for changes in input element
- * @property {Function} clearValue - Event handler that clears value set for input element
- */
+import { useFieldObject, useStatusNotificationObject } from '../typedefs';
 
 /**
  * Custom hook that provide the value of input element, type attribute of HTML input element,
  * set value of input element onChange, and a clear value function
+ *
  * @memberof hooks
  * @function useField
- * @param {String} type - Type attribute of HTML input element
- * @return {useFieldObject} useFieldObject - An object that contains { type, value, onChange, clearValue }
+ * @param {string} type - Type attribute of HTML input element
+ * @returns {useFieldObject} useFieldObject - An object that contains { type, value, onChange, clearValue }
  */
 
 export const useField = (type) => {
@@ -43,28 +38,12 @@ export const useField = (type) => {
 };
 
 /**
- * @typedef {Object} statusNotificationObject
- * @property {String|null} documentUrl - Url link to document container
- * @property {String} message - Status message for file upload, query, or deletion
- * @property {String|null} timeoutID - Timeout ID for status message
- * @property {Object|null} file - Object that includes file in question
- * @property {Boolean} processing - Boolean on whether application is uploading,
- * fetching, querying data from Solid
- */
-
-/**
- * @typedef {Object} useStatusNotificationObject
- * @property {statusNotificationObject} statusNotificationObject - An object consisting of the
- * state for status notifications
- * @property {React.DispatchWithoutAction} dispatch - React's useReducer dispatch function
- */
-
-/**
  * Custom hook that provide the useStatusNotificationObject as the state and a
  * useReducer dispatch function to alter the state
+ *
  * @memberof hooks
  * @function useStatusNotification
- * @return {useStatusNotificationObject} useStatusNotificationObject - An object that
+ * @returns {useStatusNotificationObject} useStatusNotificationObject - An object that
  * contains the StatusNotification state and React's useReducer dispatch function
  */
 

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -6,7 +6,14 @@
 
 import { useReducer, useState } from 'react';
 import statusReducer, { initialStatusState } from '../reducers/statusReducer';
-import { useFieldObject, useStatusNotificationObject } from '../typedefs';
+
+/**
+ * @typedef {import('../typedefs').useFieldObject} useFieldObject
+ */
+
+/**
+ * @typedef {import('../typedefs').useStatusNotificationObject} useStatusNotificationObject
+ */
 
 /**
  * Custom hook that provide the value of input element, type attribute of HTML input element,

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -43,7 +43,13 @@ export const useField = (type) => {
 };
 
 /**
- * @typedef {import("../reducers/statusReducer").statusNotificationObject} statusNotificationObject
+ * @typedef {Object} statusNotificationObject
+ * @property {String|null} documentUrl - Url link to document container
+ * @property {String} message - Status message for file upload, query, or deletion
+ * @property {String|null} timeoutID - Timeout ID for status message
+ * @property {Object|null} file - Object that includes file in question
+ * @property {Boolean} processing - Boolean on whether application is uploading,
+ * fetching, querying data from Solid
  */
 
 /**

--- a/src/reducers/statusReducer.js
+++ b/src/reducers/statusReducer.js
@@ -4,9 +4,6 @@
  */
 
 /**
- * Initial state for useStatusNotification hook
- * @memberof reducers
- * @name initialStatusState
  * @typedef {Object} statusNotificationObject
  * @property {String|null} documentUrl - Url link to document container
  * @property {String} message - Status message for file upload, query, or deletion
@@ -14,6 +11,13 @@
  * @property {Object|null} file - Object that includes file in question
  * @property {Boolean} processing - Boolean on whether application is uploading,
  * fetching, querying data from Solid
+ */
+
+/**
+ * Initial state for useStatusNotification hook
+ * @memberof reducers
+ * @name initialStatusState
+ * @type {statusNotificationObject}
  */
 
 export const initialStatusState = {

--- a/src/reducers/statusReducer.js
+++ b/src/reducers/statusReducer.js
@@ -1,20 +1,14 @@
+import { statusNotificationObject } from '../typedefs';
+
 /**
  * The reducers module contains Redux-like reducers that assist with status notifications
+ *
  * @namespace reducers
  */
 
 /**
- * @typedef {Object} statusNotificationObject
- * @property {String|null} documentUrl - Url link to document container
- * @property {String} message - Status message for file upload, query, or deletion
- * @property {String|null} timeoutID - Timeout ID for status message
- * @property {Object|null} file - Object that includes file in question
- * @property {Boolean} processing - Boolean on whether application is uploading,
- * fetching, querying data from Solid
- */
-
-/**
  * Initial state for useStatusNotification hook
+ *
  * @memberof reducers
  * @name initialStatusState
  * @type {statusNotificationObject}
@@ -31,10 +25,10 @@ export const initialStatusState = {
 /**
  * @memberof reducers
  * @function statusReducer
- * @param {statusNotificationObject} state - The state for status notification
- * @param {Object} action - useReducer Object for useReducer hook containing
+ * @param {statusNotificationObject} state - The state for status notification {@link statusNotificationObject}
+ * @param {object} action - useReducer Object for useReducer hook containing
  * action.payload for useStatusNotification hook
- * @return {statusNotificationObject} state - The updated state based on useReducer action
+ * @returns {statusNotificationObject} state - The updated state based on useReducer action
  */
 
 const statusReducer = (state, action) => {

--- a/src/reducers/statusReducer.js
+++ b/src/reducers/statusReducer.js
@@ -1,4 +1,6 @@
-import { statusNotificationObject } from '../typedefs';
+/**
+ * @typedef {import('../typedefs').statusNotificationObject} statusNotificationObject
+ */
 
 /**
  * The reducers module contains Redux-like reducers that assist with status notifications

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -1,0 +1,101 @@
+const React = require('react');
+
+/**
+ * @namespace typedefs
+ */
+
+/**
+ * A React props object for the StatusMessage component
+ *
+ * @exports statusMessageProps
+ * @typedef statusMessageProps
+ * @type {object}
+ * @property {string} notification - File status message
+ * @property {string} [locationUrl] - URL location of file, if exist
+ * @memberof typedefs
+ */
+
+/**
+ * A React props object for the StatusNotification component
+ *
+ * @exports statusNotificationProps
+ * @typedef statusNotificationProps
+ * @type {object}
+ * @property {string} notification - File status message
+ * @property {string} statusType - Type of file status (i.e. file upload, file fetch, file delete)
+ * @property {string} defaultMessage - Default message when status is not triggered
+ * @property {string} [locationUrl] - URL location of file, if exist
+ * @memberof typedefs
+ */
+
+/**
+ * An object containing the type, value, onChange function, and clearValue function for
+ * the custom useField hook
+ *
+ * @exports useFieldObject
+ * @typedef useFieldObject
+ * @type {object}
+ * @property {string} type - Type attribute of HTML input element
+ * @property {string} value - The value of input element
+ * @property {Function} onChange - Event handler for changes in input element
+ * @property {Function} clearValue - Event handler that clears value set for input element
+ * @memberof typedefs
+ */
+
+/**
+ * An object containing the status notification state used for both the StatusNotification and
+ * StatusMessage components
+ *
+ * @exports statusNotificationObject
+ * @typedef statusNotificationObject
+ * @type {object}
+ * @property {string|null} documentUrl - Url link to document container
+ * @property {string} message - Status message for file upload, query, or deletion
+ * @property {string|null} timeoutID - Timeout ID for status message
+ * @property {object|null} file - Object that includes file in question
+ * @property {boolean} processing - Boolean on whether application is uploading,
+ * fetching, querying data from Solid
+ * @memberof typedefs
+ */
+
+/**
+ * An object containing the status notification state and useReducer dispatch function from
+ * the custom useStatusNotification hook
+ *
+ * @exports useStatusNotificationObject
+ * @typedef useStatusNotificationObject
+ * @type {object}
+ * @property {statusNotificationObject} statusNotificationObject - An object consisting of the
+ * state for status notifications
+ * @property {React.DispatchWithoutAction} dispatch - React's useReducer dispatch function
+ * @memberof typedefs
+ */
+
+/**
+ * An input object for functions related to file uploads to Solid's Pod
+ *
+ * @exports fileObjectType
+ * @typedef fileObjectType
+ * @property {string} type - Type of document
+ * @property {string} date - Date of upload
+ * @property {string} description - Description of document
+ * @property {object} file - An object which contain infomation about the file being uploaded
+ * as well the document itself
+ * @memberof typedefs
+ */
+
+/**
+ *  A React props object for FormSection component
+ *
+ * @exports formSectionProps
+ * @typedef formSectionProps
+ * @type {object}
+ * @property {string} title - Title of form section
+ * @property {statusNotificationObject} state - The state for status notification
+ * @property {string} statusType - Type of action for PASS
+ * @property {string} defaultMessage - Default notification message when inactive
+ * @property {React.ReactElement} children - JSX Element of the wrapped form
+ * @memberof typedefs
+ */
+
+exports.unused = {};

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -2,6 +2,7 @@ const React = require('react');
 
 /**
  * @namespace typedefs
+ * @module typedefs
  */
 
 /**

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -2,7 +2,6 @@ const React = require('react');
 
 /**
  * @namespace typedefs
- * @module typedefs
  */
 
 /**

--- a/src/utils/form-helper.js
+++ b/src/utils/form-helper.js
@@ -1,11 +1,12 @@
 /**
  * Document Types is an array of strings that represent the different document types for upload, fetch, or delete
+ *
  * @memberof utils
  * @name docTypes
- * @type {Array<String>}
- * @property {String} Bank_Document - Bank Document
- * @property {String} Passport - Passport
- * @property {String} Drivers_License - Drivers License
+ * @type {Array<string>}
+ * @property {string} Bank_Document - Bank Document
+ * @property {string} Passport - Passport
+ * @property {string} Drivers_License - Drivers License
  */
 
 const docTypes = ['Bank Statement', 'Passport', 'Drivers License'];

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,6 +2,7 @@
  * The utils module to help run functions for PASS forms, notifications, and Solid Session.
  * The file session-core contains functions that is exported to PASS, while session-helper
  * contains functions that is only exported to session-core
+ *
  * @module utils
  * @namespace utils
  */

--- a/src/utils/notification-helper.js
+++ b/src/utils/notification-helper.js
@@ -1,5 +1,11 @@
 /**
- * @typedef {import("../reducers/statusReducer").statusNotificationObject} statusNotificationObject
+ * @typedef {Object} statusNotificationObject
+ * @property {String|null} documentUrl - Url link to document container
+ * @property {String} message - Status message for file upload, query, or deletion
+ * @property {String|null} timeoutID - Timeout ID for status message
+ * @property {Object|null} file - Object that includes file in question
+ * @property {Boolean} processing - Boolean on whether application is uploading,
+ * fetching, querying data from Solid
  */
 
 /**

--- a/src/utils/notification-helper.js
+++ b/src/utils/notification-helper.js
@@ -1,23 +1,17 @@
-/**
- * @typedef {Object} statusNotificationObject
- * @property {String|null} documentUrl - Url link to document container
- * @property {String} message - Status message for file upload, query, or deletion
- * @property {String|null} timeoutID - Timeout ID for status message
- * @property {Object|null} file - Object that includes file in question
- * @property {Boolean} processing - Boolean on whether application is uploading,
- * fetching, querying data from Solid
- */
+import React from 'react';
+import { statusNotificationObject } from '../typedefs';
 
 /**
  * Function that runs status messages provided a message, the duration (time in seconds),
  * the timeoutID of previous message (if exist), and the useReducer dispatch function
+ *
  * @memberof utils
  * @function runNotification
- * @param {String} message - File status message for upload, fetch, or delete file
- * @param {Number} time - Duration of message in seconds
- * @param {statusNotificationObject} state - useStatusNotificationObject
+ * @param {string} message - File status message for upload, fetch, or delete file
+ * @param {number} time - Duration of message in seconds
+ * @param {statusNotificationObject} state - The {@link statusNotificationObject}
  * @param {React.DispatchWithoutAction} dispatch - useStatusNotification dispatch function
- * @returns {Void} Void - Status message is displayed via dispatch call
+ * @returns {void} Void - Status message is displayed via dispatch call
  */
 
 const runNotification = (

--- a/src/utils/notification-helper.js
+++ b/src/utils/notification-helper.js
@@ -1,5 +1,8 @@
 import React from 'react';
-import { statusNotificationObject } from '../typedefs';
+
+/**
+ * @typedef {import('../typedefs').statusNotificationObject} statusNotificationObject
+ */
 
 /**
  * Function that runs status messages provided a message, the duration (time in seconds),

--- a/src/utils/session-core.js
+++ b/src/utils/session-core.js
@@ -11,7 +11,8 @@ import {
   deleteFile,
   saveAclFor,
   getSolidDatasetWithAcl,
-  getResourceAcl
+  getResourceAcl,
+  Session
 } from '@inrupt/solid-client';
 import { SCHEMA_INRUPT } from '@inrupt/vocab-common-rdf';
 import {
@@ -22,15 +23,17 @@ import {
   hasTTLFiles,
   createDocAclForUser
 } from './session-helper';
+import { fileObjectType } from '../typedefs';
 
 /**
  * Function that sets permissions for a user's document container's ACL file
+ *
  * @memberof utils
  * @function setDocAclPermission
  * @param {Session} session - Solid Session
- * @param {String} fileType - Type of document
- * @param {String} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods, or "cross-fetch")
- * @param {String} otherPodUrl - Url to other user's Pod or empty string
+ * @param {string} fileType - Type of document
+ * @param {string} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods, or "cross-fetch")
+ * @param {string} otherPodUrl - Url to other user's Pod or empty string
  * @returns {Promise} Promise - Sets permission for otherPodUrl for given document type, if exists, or null
  */
 
@@ -56,21 +59,12 @@ export const setDocAclPermission = async (session, fileType, accessType, otherPo
 };
 
 /**
- * An input object for functions related to file uploads to Solid's Pod
- * @typedef fileObject
- * @property {String} type - Type of document
- * @property {String} date - Date of upload
- * @property {String} description - Description of document
- * @property {Object} file - An object which contain infomation about the file being uploaded
- * as well the document itself
- */
-
-/**
  * Function that uploads file to Pod on Solid
+ *
  * @memberof utils
  * @function uploadDocument
  * @param {Session} session - Solid Session
- * @param {fileObject} fileObject - Object containing information about file from form submission
+ * @param {fileObjectType} fileObject - Object containing information about file from form submission
  * @returns {Promise} Promise - File upload is handled via Solid libraries
  */
 
@@ -113,13 +107,14 @@ export const uploadDocument = async (session, fileObject) => {
 /**
  * Function that fetch the URL of the container containing a specific file uploaded to
  * a user's Pod on Solid, if exist
+ *
  * @memberof utils
  * @function fetchDocuments
  * @param {Session} session - Solid Session
- * @param {String} fileType - Type of document
- * @param {String} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods,
+ * @param {string} fileType - Type of document
+ * @param {string} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods,
  * or "cross-fetch")
- * @param {String} [otherPodUrl] - Url to other user's Pod (set to empty string by default)
+ * @param {string} [otherPodUrl] - Url to other user's Pod (set to empty string by default)
  * @returns {Promise} Promise - Either a string containing the url location of the document,
  * if exist, or throws an Error
  */
@@ -138,10 +133,11 @@ export const fetchDocuments = async (session, fileType, fetchType, otherPodUrl =
 /**
  * Function that deletes all files from a Solid container associated to a file type,
  * if exist, and returns the container's URL
+ *
  * @memberof utils
  * @function deleteDocuments
  * @param {Session} session - Solid Session
- * @param {String} fileType - Type of document
+ * @param {string} fileType - Type of document
  * @returns {Promise} container.url - The URL of document container and the response on
  * whether document file is deleted, if exist, and delete all existing files within it
  */
@@ -164,10 +160,11 @@ export const deleteDocumentFile = async (session, fileType) => {
 
 /**
  * Function that delete a Solid container from Pod on Solid given the container's URL, if exist
+ *
  * @memberof utils
  * @function deleteDocumentContainer
  * @param {Session} session - Solid Session
- * @param {String} documentUrl - Url of document container
+ * @param {string} documentUrl - Url of document container
  * @returns {Promise} Promise - Perform action that deletes container completely from Pod
  */
 

--- a/src/utils/session-core.js
+++ b/src/utils/session-core.js
@@ -24,7 +24,7 @@ import {
 } from './session-helper';
 
 /**
- * @typedef {import('@inrupt/solid-client').Session} Session
+ * @typedef {import('@inrupt/solid-ui-react').SessionContext} Session
  */
 
 /**
@@ -36,7 +36,7 @@ import {
  *
  * @memberof utils
  * @function setDocAclPermission
- * @param {Session} session - Solid Session
+ * @param {Session} session - Solid's Session Object
  * @param {string} fileType - Type of document
  * @param {string} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods, or "cross-fetch")
  * @param {string} otherPodUrl - Url to other user's Pod or empty string
@@ -69,7 +69,7 @@ export const setDocAclPermission = async (session, fileType, accessType, otherPo
  *
  * @memberof utils
  * @function uploadDocument
- * @param {Session} session - Solid Session
+ * @param {Session} session - Solid's Session Object
  * @param {fileObjectType} fileObject - Object containing information about file from form submission
  * @returns {Promise} Promise - File upload is handled via Solid libraries
  */
@@ -116,7 +116,7 @@ export const uploadDocument = async (session, fileObject) => {
  *
  * @memberof utils
  * @function fetchDocuments
- * @param {Session} session - Solid Session
+ * @param {Session} session - Solid's Session Object
  * @param {string} fileType - Type of document
  * @param {string} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods,
  * or "cross-fetch")
@@ -142,7 +142,7 @@ export const fetchDocuments = async (session, fileType, fetchType, otherPodUrl =
  *
  * @memberof utils
  * @function deleteDocuments
- * @param {Session} session - Solid Session
+ * @param {Session} session - Solid's Session Object
  * @param {string} fileType - Type of document
  * @returns {Promise} container.url - The URL of document container and the response on
  * whether document file is deleted, if exist, and delete all existing files within it
@@ -169,8 +169,8 @@ export const deleteDocumentFile = async (session, fileType) => {
  *
  * @memberof utils
  * @function deleteDocumentContainer
- * @param {Session} session - Solid Session
- * @param {string} documentUrl - Url of document container
+ * @param {Session} session - Solid's Session Object
+ * @param {string} documentUrl - Url link to document container
  * @returns {Promise} Promise - Perform action that deletes container completely from Pod
  */
 

--- a/src/utils/session-core.js
+++ b/src/utils/session-core.js
@@ -11,8 +11,7 @@ import {
   deleteFile,
   saveAclFor,
   getSolidDatasetWithAcl,
-  getResourceAcl,
-  Session
+  getResourceAcl
 } from '@inrupt/solid-client';
 import { SCHEMA_INRUPT } from '@inrupt/vocab-common-rdf';
 import {
@@ -23,7 +22,14 @@ import {
   hasTTLFiles,
   createDocAclForUser
 } from './session-helper';
-import { fileObjectType } from '../typedefs';
+
+/**
+ * @typedef {import('@inrupt/solid-client').Session} Session
+ */
+
+/**
+ * @typedef {import('../typedefs').fileObjectType} fileObjectType
+ */
 
 /**
  * Function that sets permissions for a user's document container's ACL file

--- a/src/utils/session-helper.js
+++ b/src/utils/session-helper.js
@@ -17,7 +17,7 @@ import {
  */
 
 /**
- * @typedef {import ('@inrupt/solid-client').Session} Session
+ * @typedef {import('@inrupt/solid-ui-react').SessionContext} Session
  */
 
 /**
@@ -35,7 +35,7 @@ export const SOLID_IDENTITY_PROVIDER = 'https://opencommons.net';
  *
  * @memberof utils
  * @function placeFileInContainer
- * @param {Session} session - Solid Session
+ * @param {Session} session - Solid's Session Object
  * @param {object} fileObject - Object of file being uploaded to Solid
  * @param {string} containerUrl - URL location of Pod container
  * @returns {Promise} Promise - Places and saves uploaded file onto Solid Pod via a container
@@ -109,7 +109,7 @@ export const hasFiles = (containerUrl) => {
  *
  * @memberof utils
  * @function fetchUrl
- * @param {Session} session - Solid Session
+ * @param {Session} session - Solid's Session Object
  * @param {string} fileType - Type of document
  * @param {string} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods,
  * or "cross-fetch")
@@ -164,7 +164,7 @@ export const setupAcl = (resourceWithAcl, webId, accessObject) => {
  *
  * @memberof utils
  * @function createDocAclForUser
- * @param {Session} session - Solid Session
+ * @param {Session} session - Solid's Session Object
  * @param {string} documentUrl - Url link to document container
  * @returns {Promise} Promise - Generates ACL file for container and give user access
  * and control to it and its contents

--- a/src/utils/session-helper.js
+++ b/src/utils/session-helper.js
@@ -5,11 +5,20 @@ import {
   createAcl,
   setAgentResourceAccess,
   saveAclFor,
-  setAgentDefaultAccess,
-  AclDataset,
-  Access,
-  Session
+  setAgentDefaultAccess
 } from '@inrupt/solid-client';
+
+/**
+ * @typedef {import('@inrupt/solid-client').Access} Access
+ */
+
+/**
+ * @typedef {import('@inrupt/solid-client').AclDataset} AclDataset
+ */
+
+/**
+ * @typedef {import ('@inrupt/solid-client').Session} Session
+ */
 
 /**
  * The URL to a specific Solid Provider

--- a/src/utils/session-helper.js
+++ b/src/utils/session-helper.js
@@ -5,24 +5,30 @@ import {
   createAcl,
   setAgentResourceAccess,
   saveAclFor,
-  setAgentDefaultAccess
+  setAgentDefaultAccess,
+  AclDataset,
+  Access,
+  Session
 } from '@inrupt/solid-client';
 
 /**
  * The URL to a specific Solid Provider
+ *
  * @name SOLID_IDENTITY_PROVIDER
- * @type {String}
+ * @type {string}
+ * @memberof utils
  */
 
 export const SOLID_IDENTITY_PROVIDER = 'https://opencommons.net';
 
 /**
  * Function that helps place uploaded file from user into the user's Pod via a Solid container
+ *
  * @memberof utils
  * @function placeFileInContainer
  * @param {Session} session - Solid Session
- * @param {Object} fileObject - Object of file being uploaded to Solid
- * @param {String} containerUrl - URL location of Pod container
+ * @param {object} fileObject - Object of file being uploaded to Solid
+ * @param {string} containerUrl - URL location of Pod container
  * @returns {Promise} Promise - Places and saves uploaded file onto Solid Pod via a container
  */
 
@@ -36,10 +42,11 @@ export const placeFileInContainer = async (session, fileObject, containerUrl) =>
 
 /**
  * Function that checks if container URL contains TTL files
+ *
  * @memberof utils
  * @function hasTTLFiles
- * @param {String} containerUrl - URL of a Solid container
- * @returns {Object|null} ttlFiles or null - An object of the first ttl file in location or null,
+ * @param {string} containerUrl - URL of a Solid container
+ * @returns {object|null} ttlFiles or null - An object of the first ttl file in location or null,
  * if the ttl file does not exist
  */
 
@@ -59,9 +66,10 @@ export const hasTTLFiles = (containerUrl) => {
 
 /**
  * Function checks if container URL contains any files
+ *
  * @memberof utils
  * @function hasFiles
- * @param {String} containerUrl - URL of location in question
+ * @param {string} containerUrl - URL of location in question
  * @returns {Array|null} [directory, files] or null - an Array of Objects consisting of the
  * directory container and the rest of the files or null
  */
@@ -89,14 +97,15 @@ export const hasFiles = (containerUrl) => {
 /**
  * Function that returns the location of the Solid container containing a specific file type,
  * if exist on user's Pod
+ *
  * @memberof utils
  * @function fetchUrl
  * @param {Session} session - Solid Session
- * @param {String} fileType - Type of document
- * @param {String} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods,
+ * @param {string} fileType - Type of document
+ * @param {string} fetchType - Type of fetch (to own Pod, or "self-fetch" or to other Pods,
  * or "cross-fetch")
- * @param {String} otherPodUrl - Url to other user's Pod or empty string
- * @returns {String|null} url or null - A url of where the container that stores the file
+ * @param {string} otherPodUrl - Url to other user's Pod or empty string
+ * @returns {string|null} url or null - A url of where the container that stores the file
  * is located in or null, if container doesn't exist
  */
 
@@ -122,10 +131,11 @@ export const fetchUrl = (session, fileType, fetchType, otherPodUrl) => {
 
 /**
  * Function that setups ACL permissions for a Solid dataset or resource with an ACL file
+ *
  * @memberof utils
  * @function setupAcl
  * @param {AclDataset} resourceWithAcl - A Solid Session Dataset with ACL file
- * @param {String} webId - Solid webId
+ * @param {string} webId - Solid webId
  * @param {Access} accessObject - Solid Access Object which sets ACL permission for
  * read, append, write, and control
  * @returns {AclDataset} - Solid Session Dataset with updated ACL file
@@ -142,10 +152,11 @@ export const setupAcl = (resourceWithAcl, webId, accessObject) => {
 /**
  * Function that generates ACL file for container containing a specific document type
  * and turtle file and give the user access and control to the Solid container
+ *
  * @memberof utils
  * @function createDocAclForUser
  * @param {Session} session - Solid Session
- * @param {String} documentUrl - Url link to document container
+ * @param {string} documentUrl - Url link to document container
  * @returns {Promise} Promise - Generates ACL file for container and give user access
  * and control to it and its contents
  */


### PR DESCRIPTION
Major revision to JSDoc based on recommended linting rules with ESLint plugin for JSDoc and minor changes to FormSection and Form components. Notable changes include:

- Minor refactoring to FormSection to include section title from it's children by moving title from Form components to FormSection
- Reorganized JSDoc based on ESLint
- Moved all JSDoc typedefs into dedicated typedefs.js file in /src

Considering to move the version from v0.0.1 to v0.0.2, we now have an updated prototype deployed on GitHub Pages that's relatively stable.