### PR TITLE
Issue 34 - add caching for npm dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: npm
 
       - name: Build
         run: |


### PR DESCRIPTION
fixing issue #34 

enabled caching on setup-node by adding ``` cache: npm ```

https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

