### PR TITLE
Update to Issue 43 - Confirmation Modal for logout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@inrupt/solid-client-authn-browser": "^1.12.3",
         "@inrupt/solid-ui-react": "^2.8.2",
         "@inrupt/vocab-common-rdf": "^1.0.5",
+        "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.12.2",
         "@mui/styled-engine-sc": "^5.12.0",
         "@mui/system": "^5.12.1",
@@ -3002,6 +3003,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.11.16",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.11.16.tgz",
+      "integrity": "sha512-oKkx9z9Kwg40NtcIajF9uOXhxiyTZrrm9nmIJ4UjkU2IdHpd4QVLbCc/5hZN/y0C6qzi2Zlxyr9TGddQx2vx2A==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {
@@ -13657,6 +13683,14 @@
       "version": "5.12.3",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.12.3.tgz",
       "integrity": "sha512-yiJZ+knaknPHuRKhRk4L6XiwppwkAahVal3LuYpvBH7GkA2g+D9WLEXOEnNYtVFUggyKf6fWGLGnx0iqzkU5YA=="
+    },
+    "@mui/icons-material": {
+      "version": "5.11.16",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.11.16.tgz",
+      "integrity": "sha512-oKkx9z9Kwg40NtcIajF9uOXhxiyTZrrm9nmIJ4UjkU2IdHpd4QVLbCc/5hZN/y0C6qzi2Zlxyr9TGddQx2vx2A==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
+      }
     },
     "@mui/material": {
       "version": "5.12.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@inrupt/solid-client-authn-browser": "^1.12.3",
     "@inrupt/solid-ui-react": "^2.8.2",
     "@inrupt/vocab-common-rdf": "^1.0.5",
+    "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.12.2",
     "@mui/styled-engine-sc": "^5.12.0",
     "@mui/system": "^5.12.1",

--- a/src/components/Login/Logout.jsx
+++ b/src/components/Login/Logout.jsx
@@ -1,5 +1,17 @@
+// React Imports
 import React, { useState } from 'react';
-import { useSession, LogoutButton } from '@inrupt/solid-ui-react';
+// Solid Imports
+import { useSession } from '@inrupt/solid-ui-react';
+// Material UI Imports
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
+import LogoutIcon from '@mui/icons-material/Logout';
+// Custom Component Imports
+import LogoutModal from './LogoutModal';
+
+
 
 /**
  * Logout Component - Component that generates Logout section for users to a
@@ -9,45 +21,59 @@ import { useSession, LogoutButton } from '@inrupt/solid-ui-react';
  * @name Logout
  */
 
-const Logout = () => {
-  const { session } = useSession();
-  const [showConfirmation, setShowConfirmation] = useState(false);
-  localStorage.setItem('loggedIn', true);
 
-  // Event handler for logging out of PASS and removing items from localStorage
+
+const Logout = () => {
+
+  const { session } = useSession();
+  localStorage.setItem('loggedIn', true);
+  // state for LogoutModal popup
+  const [showConfirmation, setShowConfirmation] = useState(false);
+
+  // Event handler for logging out of SOLID POD and removing items from localStorage
   const handleLogout = () => {
     localStorage.removeItem('loggedIn');
     localStorage.removeItem('redirectUrl');
     localStorage.removeItem('restorePath');
     localStorage.removeItem('issuerConfig:https://opencommons.net');
+    setShowConfirmation(false);
   };
+
 
   return (
     <section id="logout" className="panel">
-      <div className="row">
+      <Box className="row">
+
         <label id="labelLogout" htmlFor="btnLogout">
           Click the following logout button to log out of your pod:{' '}
         </label>
-        <button type="button" onClick={() => setShowConfirmation(true)}>
+        <Button
+          id="btnLogout"
+          variant="outlined"
+          size="small"
+          type="button"
+          color="error"
+          endIcon={<LogoutIcon />}
+          onClick={() => setShowConfirmation(true)}
+        >
           Log Out
-        </button>
-        <dialog open={showConfirmation}>
-          <p>Do you want to log out now?</p>
-          <div style={{ display: 'flex', justifyContent: 'center', gap: '20px' }}>
-            <LogoutButton onLogout={handleLogout} />
-            <button type="button" onClick={() => setShowConfirmation(false)}>
-              Cancel
-            </button>
-          </div>
-        </dialog>
-        <p className="labelStatus" role="alert">
+        </Button>
+
+        <Typography variant="body1" className="labelStatus" role="alert">
           Your session is now logged in with the WebID [
-          <a href={session.info.webId} target="_blank" rel="noreferrer">
+          <Link href={session.info.webId} target="_blank" rel="noreferrer">
             {session.info.webId}
-          </a>
+          </Link>
           ].
-        </p>
-      </div>
+        </Typography>
+
+        {/* modal/popup renders when showConfirmation state is true */}
+        <LogoutModal
+          showConfirmation={showConfirmation}
+          setShowConfirmation={setShowConfirmation}
+          handleLogout={handleLogout}
+        />
+      </Box>
     </section>
   );
 };

--- a/src/components/Login/LogoutModal.jsx
+++ b/src/components/Login/LogoutModal.jsx
@@ -1,0 +1,67 @@
+// React Imports
+import React from 'react';
+// Solid Imports
+import { LogoutButton } from '@inrupt/solid-ui-react';
+// Material UI Imports
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import ClearIcon from '@mui/icons-material/Clear';
+import CheckIcon from '@mui/icons-material/Check';
+// SEE COMMENT IN COMPONENT BELOW for next import
+// import useMediaQuery from '@mui/material/useMediaQuery';
+
+
+
+/**
+ * LogoutModal Component - Popup modal for users to confirm
+ * they actually want to logout of their Solid Pod
+ *
+ * @memberof Login
+ * @name LogoutModal
+ */
+
+
+
+const LogoutModal = ({ showConfirmation, setShowConfirmation, handleLogout }) => (
+  // when the MUI theme is Merged, this will make it so the popup is fullscreen on small devices
+  // const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
+
+  <Dialog
+    open={showConfirmation}
+    aria-labelledby="dialog-title"
+    aria-describedby="dialog-description"
+    onClose={() => setShowConfirmation(false)}
+    // fullScreen={fullScreen}
+  >
+    <DialogTitle id="dialog-tile">Log out?</DialogTitle>
+
+    <DialogContent>
+      <DialogContentText id="dialog-description">
+        This will log you out of your pod. Are you sure?
+      </DialogContentText>
+    </DialogContent>
+
+    <DialogActions>
+      <Button
+        variant="outlined"
+        color="error"
+        endIcon={<ClearIcon />}
+        onClick={() => setShowConfirmation(false)}
+      >
+        NO
+      </Button>
+      {/* NECESSARY WRAPPER FOR SOLID/POD LOGOUT FUNCTIONALITY */}
+      <LogoutButton onClick={handleLogout}>
+        <Button variant="outlined" color="success" endIcon={<CheckIcon />} sx={{marginLeft: '1rem'}}>
+          YES
+        </Button>
+      </LogoutButton>
+    </DialogActions>
+  </Dialog>
+);
+
+export default LogoutModal;

--- a/src/components/Login/index.js
+++ b/src/components/Login/index.js
@@ -1,5 +1,6 @@
 import Login from './Login';
 import Logout from './Logout';
+import LogoutModal from './LogoutModal';
 
 /**
  * Components and functions related to Login/Logout functionality within project PASS
@@ -7,4 +8,4 @@ import Logout from './Logout';
  * @namespace Login
  */
 
-export { Login, Logout };
+export { Login, Logout, LogoutModal };


### PR DESCRIPTION
**Updating this confirmation popup:**
<img width="1437" alt="Screenshot 2023-05-04 at 11 40 14 AM" src="https://user-images.githubusercontent.com/71395931/236298483-a8cdc3ad-cbff-4e3d-b742-03b6e1dcc9be.png">
 - that still allowed user to focus and type on background elements, had some accessibility issues, etc
 
 
 **To this:**
<img width="1440" alt="Screenshot 2023-05-04 at 11 41 43 AM" src="https://user-images.githubusercontent.com/71395931/236298709-0dd005a9-e959-4923-9c11-bd205f5d2024.png">
- styled with Material UI (as per current direction - colors and text can be changed)
- added Material Icons to `package.json` as we will need for upcoming styling per UX team anyway, and used some here


Created as it's own component `LogoutModal.jsx`.

One future possibility is to refactor this to just be a base `Modal` component that we could reuse more often by passing in `Title`, `Text`, and any necessary `CallToAction`s (like buttons/links/etc.)

As of now, this component lives in the `Login` folder.  If we ever refactor to just be a modal component - move that to a new folder?