### PR TITLE
Fixing ESLint Pathing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview",
     "docs": "jsdoc --readme ./docs/README.md -c jsdoc.config.json",
     "docs:clear": "node clearDocs.js",
-    "lint": "eslint src/**/*.js[x]",
-    "lint:fix": "eslint --fix src/**/*.js[x]",
+    "lint": "eslint \"src/**/*.js[x]\"",
+    "lint:fix": "eslint --fix \"src/**/*.js[x]\"",
     "prettier:check": "prettier --check src/**/*.js src/**/*.jsx",
     "prettier:run": "prettier --write src/**/*.js --write src/**/*.jsx",
     "dev:pod": "community-solid-server"

--- a/src/utils/session-helper.js
+++ b/src/utils/session-helper.js
@@ -46,8 +46,10 @@ import { SCHEMA_INRUPT } from '@inrupt/vocab-common-rdf';
 
 // Vite exposes static env variables in the `import.meta.env` object
 // https://vitejs.dev/guide/env-and-mode.html
-const OIDUrl = import.meta.env.MODE === 'development' ? import.meta.env.VITE_SOLID_IDENTITY_PROVIDER_DEV : 
-  import.meta.env.VITE_SOLID_IDENTITY_PROVIDER_PRODUCTION;
+const OIDUrl =
+  import.meta.env.MODE === 'development'
+    ? import.meta.env.VITE_SOLID_IDENTITY_PROVIDER_DEV
+    : import.meta.env.VITE_SOLID_IDENTITY_PROVIDER_PRODUCTION;
 export const SOLID_IDENTITY_PROVIDER = OIDUrl;
 
 /**


### PR DESCRIPTION
It seems like ESLint wasn't pathed correctly. It does not follow the same syntax as Prettier for processing files.

However, this issue is now fixed with the following changes in package.json:

```
    "lint": "eslint \"src/**/*.js[x]\"",
    "lint:fix": "eslint --fix \"src/**/*.js[x]\"", 
```

Had ran Prettier again to make sure that it was working properly as well. It updated and formatted the new lines from @timbot1789 in session-helper from the recent PR after running npm run prettier:run after finding out it's not formatted correctly using npm run prettier:check.