### PR TITLE
Issue 115/create footer component

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -1,0 +1,113 @@
+// React Imports
+import React from 'react';
+// Material UI Imports
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Container from '@mui/material/Container';
+import Grid from '@mui/material/Grid';
+import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+// Material Icons Imports
+import TwitterIcon from '@mui/icons-material/Twitter';
+import FacebookIcon from '@mui/icons-material/Facebook';
+import InstagramIcon from '@mui/icons-material/Instagram';
+
+const Footer = () => {
+  const theme = useTheme();
+
+  return (
+    <Box
+      component="footer"
+      sx={{
+        position: 'sticky',
+        top: '100%',
+        textAlign: 'center',
+        bgcolor: `${theme.palette.primary.main}`
+      }}
+      py={5}
+    >
+      <Container maxWidth="lg">
+        <Grid container columnSpacing={0} my={2}>
+          <Grid item xs={7} sx={{borderRight: 2, borderColor: theme.palette.tertiary.main, pr: 12}}>
+            <Typography variant="h5" color={`${theme.palette.tertiary.main}`}>
+              Want to partner with PASS?
+            </Typography>
+            <Typography variant="body1" color="#fff">
+              If your organization is interested in partnering with PASS and would like to discuss
+              further, contact us below.
+            </Typography>
+            <Button variant="contained" color="secondary" sx={{ my: '1rem' }}>
+              Partnership Proposal
+            </Button>
+          </Grid>
+          <Grid item xs={2}>
+            <Typography color={`${theme.palette.tertiary.main}`}>PASS LOGO</Typography>
+            <Typography color="#fff" mb={5}>tagline</Typography>
+            <Typography color={`${theme.palette.tertiary.main}`}>Follow Us</Typography>
+            <Link href="https://twitter.com/" target="_blank" rel="noopener" color="#fff" mr={1}>
+              <TwitterIcon />
+            </Link>
+            <Link href="https://www.facebook.com/" target="_blank" rel="noopener" color="#fff">
+              <FacebookIcon />
+            </Link>
+            <Link
+              href="https://www.instagram.com/"
+              target="_blank"
+              rel="noopener"
+              color="#fff"
+              ml={1}
+            >
+              <InstagramIcon />
+            </Link>
+          </Grid>
+          <Grid item xs={2}>
+            <Typography color={`${theme.palette.tertiary.main}`}>Built By:</Typography>
+            <Link
+              href="https://www.codeforpdx.org/"
+              target="_blank"
+              rel="noopener"
+              underline="none"
+            >
+              <Typography variant="body2" color="#fff">
+                C4PDX LOGO
+              </Typography>
+            </Link>
+            <Typography variant="body2" color={`${theme.palette.tertiary.main}`} mb={5}>
+              ©{new Date().getFullYear()}{' '}
+              <Link
+                href="https://www.codeforpdx.org/"
+                target="_blank"
+                rel="noopener"
+                underline="none"
+                color={`${theme.palette.tertiary.main}`}
+              >
+                Code for PDX
+              </Link>
+            </Typography>
+            <Typography variant="body2">
+              <Link
+                href="https://www.codeforpdx.org/"
+                underline="none"
+                color="#fff"
+              >
+                Privacy Policy
+              </Link>
+            </Typography>
+            <Typography variant="body2">
+              <Link
+                href="https://www.codeforpdx.org/"
+                underline="none"
+                color="#fff"
+              >
+                Terms and Conditions
+              </Link>
+            </Typography>
+          </Grid>
+        </Grid>
+      </Container>
+    </Box>
+  );
+};
+
+export default Footer;

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -13,6 +13,17 @@ import TwitterIcon from '@mui/icons-material/Twitter';
 import FacebookIcon from '@mui/icons-material/Facebook';
 import InstagramIcon from '@mui/icons-material/Instagram';
 
+
+
+/**
+ * Footer Component - Footer Component for PASS
+ * 
+ * @memberof Footer
+ * @name Footer
+ */
+
+
+
 const Footer = () => {
   const theme = useTheme();
 

--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -7,6 +7,7 @@ import Paper from '@mui/material/Paper';
 import { useRedirectUrl } from '../../hooks';
 import { SOLID_IDENTITY_PROVIDER } from '../../utils';
 import AppHeader from '../AppHeader';
+import Footer from '../Footer/Footer';
 
 /**
  * Login Component - Component that generates Login section for users to a
@@ -20,7 +21,7 @@ const Login = () => {
   const redirectUrl = useRedirectUrl();
 
   return (
-    <>
+    <Box sx={{minHeight: '100vh'}}>
       <AppHeader />
       <Container component="main" maxWidth="xs">
         <Box
@@ -57,7 +58,8 @@ const Login = () => {
           </Paper>
         </Box>
       </Container>
-    </>
+      <Footer />
+    </Box>
   );
 };
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -18,9 +18,9 @@ const theme = createTheme({
       contrastText: '#fff'
     },
     tertiary: {
-      light: '#29ab4c',
-      main: '#128a38',
-      dark: '#005a1a',
+      light: '#dbc584',
+      main: '#DEBC59',
+      dark: '#dbb032',
       contrastText: '#fff'
     },
     status: {


### PR DESCRIPTION
**Description**
---
This PR implements a `<footer>` so we can start laying out pages/views.  UX designers have not done a footer design yet, so this is subject to change.


**Updates**
---
<img width="1440" alt="Screenshot 2023-05-08 at 8 28 09 PM" src="https://user-images.githubusercontent.com/71395931/236988512-9f9cc47e-2c8c-4b26-848d-53c5c15c2d6d.png">


**Related Issue**
---
Closes Issue #115


**Future Thoughts**
---
- Would need PASS logo and tagline, and also the CodeForPDX logo (or rebranded logo) to complete the way it is now. 
- Left placeholder links for possible legal notices
- Will need to be refactored a little to stack vertically for mobile devices instead of horizontally (didn't tackle in this PR, as we need to lift an `isMobileView` state up and create a window resize event listener.)