### PR TITLE
Issue 119/logout issue

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -78,6 +78,7 @@ const App = () => {
     }
 
     if (session.info.isLoggedIn) {
+      localStorage.setItem('loggedIn', true);
       fetchData();
     }
   }, [session.info.isLoggedIn]);

--- a/src/components/Login/Logout.jsx
+++ b/src/components/Login/Logout.jsx
@@ -10,6 +10,7 @@ import Typography from '@mui/material/Typography';
 import LogoutIcon from '@mui/icons-material/Logout';
 // Custom Component Imports
 import LogoutModal from './LogoutModal';
+import { SOLID_IDENTITY_PROVIDER } from '../../utils';
 
 /**
  * Logout Component - Component that generates Logout section for users to a
@@ -29,7 +30,8 @@ const Logout = () => {
     localStorage.removeItem('loggedIn');
     localStorage.removeItem('redirectUrl');
     localStorage.removeItem('restorePath');
-    localStorage.removeItem('issuerConfig:https://opencommons.net');
+    localStorage.removeItem(`issuerConfig:${SOLID_IDENTITY_PROVIDER}`);
+    localStorage.removeItem(`issuerConfig:${SOLID_IDENTITY_PROVIDER.slice(0, -1)}`);
     setShowConfirmation(false);
   };
 

--- a/src/components/Login/Logout.jsx
+++ b/src/components/Login/Logout.jsx
@@ -11,8 +11,6 @@ import LogoutIcon from '@mui/icons-material/Logout';
 // Custom Component Imports
 import LogoutModal from './LogoutModal';
 
-
-
 /**
  * Logout Component - Component that generates Logout section for users to a
  * Solid Pod via Solid Session
@@ -21,12 +19,8 @@ import LogoutModal from './LogoutModal';
  * @name Logout
  */
 
-
-
 const Logout = () => {
-
   const { session } = useSession();
-  localStorage.setItem('loggedIn', true);
   // state for LogoutModal popup
   const [showConfirmation, setShowConfirmation] = useState(false);
 
@@ -39,11 +33,9 @@ const Logout = () => {
     setShowConfirmation(false);
   };
 
-
   return (
     <section id="logout" className="panel">
       <Box className="row">
-
         <label id="labelLogout" htmlFor="btnLogout">
           Click the following logout button to log out of your pod:{' '}
         </label>

--- a/src/components/Login/LogoutModal.jsx
+++ b/src/components/Login/LogoutModal.jsx
@@ -14,8 +14,6 @@ import CheckIcon from '@mui/icons-material/Check';
 // SEE COMMENT IN COMPONENT BELOW for next import
 // import useMediaQuery from '@mui/material/useMediaQuery';
 
-
-
 /**
  * LogoutModal Component - Popup modal for users to confirm
  * they actually want to logout of their Solid Pod
@@ -23,8 +21,6 @@ import CheckIcon from '@mui/icons-material/Check';
  * @memberof Login
  * @name LogoutModal
  */
-
-
 
 const LogoutModal = ({ showConfirmation, setShowConfirmation, handleLogout }) => (
   // when the MUI theme is Merged, this will make it so the popup is fullscreen on small devices
@@ -55,8 +51,14 @@ const LogoutModal = ({ showConfirmation, setShowConfirmation, handleLogout }) =>
         NO
       </Button>
       {/* NECESSARY WRAPPER FOR SOLID/POD LOGOUT FUNCTIONALITY */}
-      <LogoutButton onClick={handleLogout}>
-        <Button variant="outlined" color="success" endIcon={<CheckIcon />} sx={{marginLeft: '1rem'}}>
+      <LogoutButton>
+        <Button
+          variant="outlined"
+          color="success"
+          endIcon={<CheckIcon />}
+          sx={{ marginLeft: '1rem' }}
+          onClick={handleLogout}
+        >
           YES
         </Button>
       </LogoutButton>

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -82,7 +82,7 @@ export const useRedirectUrl = () => {
   const [redirectUrl, setRedirectUrl] = useState('');
 
   useEffect(() => {
-    if (!localStorage.getItem('redirectUrl')) {
+    if (!localStorage.getItem('redirectUrl') && Boolean(localStorage.getItem('loggedIn'))) {
       localStorage.setItem('redirectUrl', window.location.href.split('#')[0]);
       setRedirectUrl(window.location.href.split('#')[0]);
     } else {


### PR DESCRIPTION
Fixed part of the bug related issue #119 by moving handleLogout function to the children which is an MUI button.

However, this does not remove "loggedIn" stored in the localStorage and is still set to true. When refreshed, App.jsx picks it up and think it's part of a session restore.

So to prevent that, setItem for "loggedIn" is also refactored out from Logout.jsx. It's now part of the useEffect which fetches data from Solid and is triggered when session.info.isLoggedIn is true. This fixes the bug completely.

https://user-images.githubusercontent.com/14917816/237043062-085e2000-49df-4603-8fd6-551422435d21.mov

https://user-images.githubusercontent.com/14917816/237043553-34bbdd65-2c4c-4974-9af8-a2fea4ad4d04.mov

However, you notice, it has not completely clear localStorage as intended by handleLogout from the clips above.

For issueConfig, this is due to the fact it's still using opencommon.net which is hard-coded. I've fixed this using SOLID_IDENTITY_PROVIDER from session for to dynamically pass in the provider.

As for redirectUrl, I've corrected this by including an additional condition to the useRedirectUrl custom hook to trigger only if "loggedIn" exist in localStorage and is set to true.

Now it completely removes all things related only to PASS from localStorage as intended by handleLogout.

https://user-images.githubusercontent.com/14917816/237049299-3e53592b-ad2f-4528-aa0f-fbdecc39ced2.mov