### PR TITLE
Adding @returns to updateTTLFile JSDoc

### DIFF
--- a/src/utils/session-helper.js
+++ b/src/utils/session-helper.js
@@ -230,6 +230,8 @@ export const createDocAclForUser = async (session, documentUrl) => {
  * @param {URL} containerUrl - Url link to document container
  * @param {fileObjectType} fileObject - Object containing information about file
  * from form submission (see {@link fileObjectType})
+ * @returns {Promise} Promise - Perform an update to an existing document.ttl by
+ * setting a new expiration date, description, and date modified
  */
 
 export const updateTTLFile = async (session, containerUrl, fileObject) => {


### PR DESCRIPTION
Noticed the missing `@returns` from the updateTTLFile function's JSDoc when reviewing PR #123, so I've added one for that function. Very minor PR.