### PR TITLE
Issue-170/ Refactor Footer for decent mobile view

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -110,7 +110,7 @@ const RenderCopyrightAndLinksSection = ({ isReallySmallScreen }) => {
       justifyContent="space-around"
     >
       {legalLinks.map((link) => (
-        <Typography variant="body2" color="tertiary.main">
+        <Typography key={link.title} variant="body2" color="tertiary.main">
           {link.text ?? null}
           <Link
             href={link.href}
@@ -159,7 +159,7 @@ const Footer = () => {
           divider={
             <Divider
               orientation={isReallySmallScreen ? 'horizontal' : 'vertical'}
-              flexItem={isReallySmallScreen ? null : 'flexItem'}
+              flexItem={isReallySmallScreen ? null : true}
               color={theme.palette.tertiary.main}
               sx={isReallySmallScreen ? { height: '3px', width: 3 / 4 } : { width: '3px' }}
             />

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -4,9 +4,11 @@ import React from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
-import Grid from '@mui/material/Grid';
+import Divider from '@mui/material/Divider';
 import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 // Material Icons Imports
 import TwitterIcon from '@mui/icons-material/Twitter';
@@ -22,6 +24,7 @@ import InstagramIcon from '@mui/icons-material/Instagram';
 
 const Footer = () => {
   const theme = useTheme();
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
   return (
     <Box
@@ -30,18 +33,23 @@ const Footer = () => {
         position: 'sticky',
         top: '100%',
         textAlign: 'center',
-        bgcolor: `${theme.palette.primary.main}`
+        bgcolor: theme.palette.primary.main
       }}
       py={5}
     >
-      <Container maxWidth="lg">
-        <Grid container columnSpacing={0} my={2}>
-          <Grid
-            item
-            xs={7}
-            sx={{ borderRight: 2, borderColor: theme.palette.tertiary.main, pr: 12 }}
-          >
-            <Typography variant="h5" color={`${theme.palette.tertiary.main}`}>
+      <Container maxWidth={isSmallScreen ? "sm" : "lg"}>
+        <Stack
+          spacing={2}
+          divider={
+            <Divider
+              color={theme.palette.tertiary.main}
+              sx={{ height: '3px' }}
+            />
+          }
+        >
+          {/* CALL TO ACTION section */}
+          <Box>
+            <Typography variant="h5" color={theme.palette.tertiary.main}>
               Want to partner with PASS?
             </Typography>
             <Typography variant="body1" color="#fff">
@@ -51,65 +59,123 @@ const Footer = () => {
             <Button variant="contained" color="secondary" sx={{ my: '1rem' }}>
               Partnership Proposal
             </Button>
-          </Grid>
-          <Grid item xs={2}>
-            <Typography color={`${theme.palette.tertiary.main}`}>PASS LOGO</Typography>
-            <Typography color="#fff" mb={5}>
-              tagline
-            </Typography>
-            <Typography color={`${theme.palette.tertiary.main}`}>Follow Us</Typography>
-            <Link href="https://twitter.com/" target="_blank" rel="noopener" color="#fff" mr={1}>
-              <TwitterIcon />
-            </Link>
-            <Link href="https://www.facebook.com/" target="_blank" rel="noopener" color="#fff">
-              <FacebookIcon />
-            </Link>
-            <Link
-              href="https://www.instagram.com/"
-              target="_blank"
-              rel="noopener"
-              color="#fff"
-              ml={1}
+          </Box>
+
+          {/* LOGO / FOLLOW US / BUILT BY section */}
+          <Box>
+            <Stack
+              direction={isSmallScreen ? "column" : "row"}
+              spacing={isSmallScreen ? 4 : 12}
+              justifyContent="space-around"
+              alignItems="center"
             >
-              <InstagramIcon />
-            </Link>
-          </Grid>
-          <Grid item xs={2}>
-            <Typography color={`${theme.palette.tertiary.main}`}>Built By:</Typography>
-            <Link
-              href="https://www.codeforpdx.org/"
-              target="_blank"
-              rel="noopener"
-              underline="none"
+              <Stack>
+                <Typography color={theme.palette.tertiary.main}>PASS LOGO</Typography>
+                <Typography color="#fff">tagline</Typography>
+              </Stack>
+              <Stack>
+                <Typography color={theme.palette.tertiary.main}>Follow Us</Typography>
+                <Stack direction="row" spacing={1}>
+                  <Link
+                    href="https://twitter.com/"
+                    target="_blank"
+                    rel="noopener"
+                    color="#fff"
+                  >
+                    <TwitterIcon />
+                  </Link>
+                  <Link
+                    href="https://www.facebook.com/"
+                    target="_blank"
+                    rel="noopener"
+                    color="#fff"
+                  >
+                    <FacebookIcon />
+                  </Link>
+                  <Link
+                    href="https://www.instagram.com/"
+                    target="_blank"
+                    rel="noopener"
+                    color="#fff"
+                  >
+                    <InstagramIcon />
+                  </Link>
+                </Stack>
+              </Stack>
+              <Stack>
+                <Typography color={theme.palette.tertiary.main}>Built By:</Typography>
+                <Link
+                  href="https://www.codeforpdx.org/"
+                  target="_blank"
+                  rel="noopener"
+                >
+                  <Typography variant="body2" color="#fff">
+                    C4PDX LOGO
+                  </Typography>
+                </Link>
+              </Stack>
+            </Stack>
+          </Box>
+
+          {/* COPYRIGHT / LINKS section */}
+          <Box>
+            <Stack
+              direction={isSmallScreen ? 'column-reverse' : 'row'}
+              spacing={2}
+              justifyContent="space-between"
+              divider={
+                <Divider
+                  color={theme.palette.tertiary.main}
+                  sx={{ display: { xs: 'flex', md: 'none' }, height: '3px' }}
+                />
+              }
             >
-              <Typography variant="body2" color="#fff">
-                C4PDX LOGO
+              <Typography variant="body2" color={theme.palette.tertiary.main}>
+                ©{new Date().getFullYear()}
+                <Link
+                  href="https://www.codeforpdx.org/"
+                  target="_blank"
+                  rel="noopener"
+                  underline="none"
+                  color={theme.palette.tertiary.main}
+                  ml={0.5}
+                >
+                  Code for PDX
+                </Link>
               </Typography>
-            </Link>
-            <Typography variant="body2" color={`${theme.palette.tertiary.main}`} mb={5}>
-              ©{new Date().getFullYear()}{' '}
-              <Link
-                href="https://www.codeforpdx.org/"
-                target="_blank"
-                rel="noopener"
-                underline="none"
-                color={`${theme.palette.tertiary.main}`}
+              <Stack
+                direction={isSmallScreen ? 'column' : 'row'}
+                spacing={isSmallScreen ? 0 : 2}
+                divider={
+                  <Divider
+                    color={theme.palette.tertiary.main}
+                    orientation="vertical"
+                    flexItem
+                  />
+                }
               >
-                Code for PDX
-              </Link>
-            </Typography>
-            <Typography variant="body2">
-              <Link href="https://www.codeforpdx.org/" underline="none" color="#fff">
-                Privacy Policy
-              </Link>
-            </Typography>
-            <Typography variant="body2">
-              <Link href="https://www.codeforpdx.org/" underline="none" color="#fff">
-                Terms and Conditions
-              </Link>
-            </Typography>
-          </Grid>
-        </Grid>
+                <Typography variant="body2">
+                  <Link
+                    href="https://www.codeforpdx.org/"
+                    underline="none"
+                    color={theme.palette.tertiary.main}
+                  >
+                    Privacy Policy
+                  </Link>
+                </Typography>
+                <Typography variant="body2">
+                  <Link
+                    href="https://www.codeforpdx.org/"
+                    underline="none"
+                    color={theme.palette.tertiary.main}
+                  >
+                    Terms and Conditions
+                  </Link>
+                </Typography>
+              </Stack>
+            </Stack>
+          </Box>
+        </Stack>
       </Container>
     </Box>
   );

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -16,23 +16,23 @@ import FacebookIcon from '@mui/icons-material/Facebook';
 import InstagramIcon from '@mui/icons-material/Instagram';
 
 // top section of footer
-const RenderCallToActionSection = ({ theme }) => (
-  <Box>
-    <Typography variant="h5" color={theme.palette.tertiary.main}>
+const RenderCallToActionSection = ({ isReallySmallScreen }) => (
+  <Stack width={isReallySmallScreen ? 1 : 3 / 5} alignItems="center" justifyContent="center">
+    <Typography variant="h5" color="tertiary.main">
       Want to partner with PASS?
     </Typography>
-    <Typography variant="body1" color="#fff">
+    <Typography variant="body1" color="#fff" sx={{ width: 3 / 4 }}>
       If your organization is interested in partnering with PASS and would like to discuss further,
       contact us below.
     </Typography>
-    <Button variant="contained" color="secondary" sx={{ my: '1rem' }}>
-      Partnership Proposal
+    <Button variant="contained" color="secondary" sx={{ my: '1rem', width: 1 / 2 }}>
+      Proposal
     </Button>
-  </Box>
+  </Stack>
 );
 
 // middle section of footer
-const RenderCompanyInfoSection = ({ theme, isReallySmallScreen, isSmallScreen }) => {
+const RenderCompanyInfoSection = ({ isReallySmallScreen }) => {
   const socialLinks = [
     {
       href: 'https://twitter.com/',
@@ -49,94 +49,84 @@ const RenderCompanyInfoSection = ({ theme, isReallySmallScreen, isSmallScreen })
   ];
 
   return (
-    <Box>
-      <Stack
-        direction={isReallySmallScreen ? 'column' : 'row'}
-        spacing={isSmallScreen ? 4 : 12}
-        justifyContent="space-around"
-        alignItems="center"
-      >
-        <Stack>
-          <Typography color={theme.palette.tertiary.main}>PASS LOGO</Typography>
-          <Typography color="#fff">tagline</Typography>
+    <Stack
+      width={isReallySmallScreen ? 1 : 1 / 5}
+      spacing={2}
+      justifyContent="space-around"
+      alignItems="center"
+    >
+      <Box>
+        <Typography color="tertiary.main">PASS LOGO</Typography>
+        <Typography color="#fff">tagline</Typography>
+      </Box>
+      <Box>
+        <Typography color="tertiary.main">Follow Us</Typography>
+        <Stack direction="row" spacing={1}>
+          {socialLinks.map(({ href, icon }) => (
+            <Link key={href} href={href} target="_blank" rel="noopener" color="#fff">
+              {icon}
+            </Link>
+          ))}
         </Stack>
-        <Stack>
-          <Typography color={theme.palette.tertiary.main}>Follow Us</Typography>
-          <Stack direction="row" spacing={1}>
-            {socialLinks.map(({ href, icon }) => (
-              <Link key={href} href={href} target="_blank" rel="noopener" color="#fff">
-                {icon}
-              </Link>
-            ))}
-          </Stack>
-        </Stack>
-        <Stack>
-          <Typography color={theme.palette.tertiary.main}>Built By:</Typography>
-          <Link href="https://www.codeforpdx.org/" target="_blank" rel="noopener">
-            <Typography variant="body2" color="#fff">
-              C4PDX LOGO
-            </Typography>
-          </Link>
-        </Stack>
-      </Stack>
-    </Box>
+      </Box>
+      <Box>
+        <Typography color="tertiary.main">Built By:</Typography>
+        <Link href="https://www.codeforpdx.org/" target="_blank" rel="noopener">
+          <Typography variant="body2" color="#fff">
+            C4PDX LOGO
+          </Typography>
+        </Link>
+      </Box>
+    </Stack>
   );
 };
 
 // bottom section of footer
-const RenderCopyrightAndLinksSection = ({ theme, isSmallScreen }) => (
-  <Box>
+const RenderCopyrightAndLinksSection = ({ isReallySmallScreen }) => {
+  const legalLinks = [
+    {
+      href: 'https://www.codeforpdx.org/',
+      title: 'Privacy Policy'
+    },
+    {
+      href: 'https://www.codeforpdx.org/',
+      title: 'Terms and Conditions'
+    },
+    {
+      href: 'https://www.codeforpdx.org/',
+      target: '_blank',
+      rel: 'noopenner',
+      ml: 0.5,
+      text: `©${new Date().getFullYear()}`,
+      title: 'Code for PDX'
+    }
+  ];
+
+  return (
     <Stack
-      direction={isSmallScreen ? 'column-reverse' : 'row'}
+      orientation="column"
+      width={isReallySmallScreen ? 1 : 1 / 5}
       spacing={2}
-      justifyContent="space-between"
-      divider={
-        <Divider
-          color={theme.palette.tertiary.main}
-          sx={{ display: { xs: 'flex', md: 'none' }, height: '3px' }}
-        />
-      }
+      justifyContent="space-around"
     >
-      <Typography variant="body2" color={theme.palette.tertiary.main}>
-        ©{new Date().getFullYear()}
-        <Link
-          href="https://www.codeforpdx.org/"
-          target="_blank"
-          rel="noopener"
-          underline="none"
-          color={theme.palette.tertiary.main}
-          ml={0.5}
-        >
-          Code for PDX
-        </Link>
-      </Typography>
-      <Stack
-        direction={isSmallScreen ? 'column' : 'row'}
-        spacing={isSmallScreen ? 0 : 2}
-        divider={<Divider color={theme.palette.tertiary.main} orientation="vertical" flexItem />}
-      >
-        <Typography variant="body2">
+      {legalLinks.map((link) => (
+        <Typography variant="body2" color="tertiary.main">
+          {link.text ?? null}
           <Link
-            href="https://www.codeforpdx.org/"
+            href={link.href}
             underline="none"
-            color={theme.palette.tertiary.main}
+            color="tertiary.main"
+            target={link.target ?? null}
+            rel={link.rel ?? null}
+            ml={link.ml ?? null}
           >
-            Privacy Policy
+            {link.title}
           </Link>
         </Typography>
-        <Typography variant="body2">
-          <Link
-            href="https://www.codeforpdx.org/"
-            underline="none"
-            color={theme.palette.tertiary.main}
-          >
-            Terms and Conditions
-          </Link>
-        </Typography>
-      </Stack>
+      ))}
     </Stack>
-  </Box>
-);
+  );
+};
 
 /**
  * Footer Component - Footer Component for PASS
@@ -157,22 +147,27 @@ const Footer = () => {
         position: 'sticky',
         top: '100%',
         textAlign: 'center',
-        bgcolor: theme.palette.primary.main
+        bgcolor: 'primary.main'
       }}
       py={5}
     >
-      <Container maxWidth={isSmallScreen ? 'sm' : 'lg'}>
+      <Container maxWidth={isSmallScreen ? 'md' : 'lg'}>
         <Stack
-          spacing={2}
-          divider={<Divider color={theme.palette.tertiary.main} sx={{ height: '3px' }} />}
+          alignItems="center"
+          direction={isReallySmallScreen ? 'column' : 'row'}
+          spacing={isSmallScreen ? 1 : 4}
+          divider={
+            <Divider
+              orientation={isReallySmallScreen ? 'horizontal' : 'vertical'}
+              flexItem={isReallySmallScreen ? null : 'flexItem'}
+              color={theme.palette.tertiary.main}
+              sx={isReallySmallScreen ? { height: '3px', width: 3 / 4 } : { width: '3px' }}
+            />
+          }
         >
-          <RenderCallToActionSection theme={theme} />
-          <RenderCompanyInfoSection
-            theme={theme}
-            isSmallScreen={isSmallScreen}
-            isReallySmallScreen={isReallySmallScreen}
-          />
-          <RenderCopyrightAndLinksSection theme={theme} isSmallScreen={isSmallScreen} />
+          <RenderCallToActionSection isReallySmallScreen={isReallySmallScreen} />
+          <RenderCompanyInfoSection isReallySmallScreen={isReallySmallScreen} />
+          <RenderCopyrightAndLinksSection isReallySmallScreen={isReallySmallScreen} />
         </Stack>
       </Container>
     </Box>

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -15,26 +15,19 @@ import TwitterIcon from '@mui/icons-material/Twitter';
 import FacebookIcon from '@mui/icons-material/Facebook';
 import InstagramIcon from '@mui/icons-material/Instagram';
 
-/**
- * Footer Component - Footer Component for PASS
- *
- * @memberof Footer
- * @name Footer
- */
-
-
 const theme = useTheme();
 const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 const isReallySmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
+// top section of footer
 const RenderCallToActionSection = () => (
   <Box>
     <Typography variant="h5" color={theme.palette.tertiary.main}>
       Want to partner with PASS?
     </Typography>
     <Typography variant="body1" color="#fff">
-      If your organization is interested in partnering with PASS and would like to discuss
-      further, contact us below.
+      If your organization is interested in partnering with PASS and would like to discuss further,
+      contact us below.
     </Typography>
     <Button variant="contained" color="secondary" sx={{ my: '1rem' }}>
       Partnership Proposal
@@ -42,6 +35,7 @@ const RenderCallToActionSection = () => (
   </Box>
 );
 
+// middle section of footer
 const RenderCompanyInfoSection = () => (
   <Box>
     <Stack
@@ -80,6 +74,7 @@ const RenderCompanyInfoSection = () => (
   </Box>
 );
 
+// bottom section of footer
 const RenderCopyrightAndLinksSection = () => (
   <Box>
     <Stack
@@ -134,7 +129,13 @@ const RenderCopyrightAndLinksSection = () => (
   </Box>
 );
 
-// MAIN FUNCTION/RENDER RETURNED BY THIS FILE
+/**
+ * Footer Component - Footer Component for PASS
+ *
+ * @memberof Footer
+ * @name Footer
+ */
+
 const Footer = () => (
   <Box
     component="footer"

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -15,12 +15,8 @@ import TwitterIcon from '@mui/icons-material/Twitter';
 import FacebookIcon from '@mui/icons-material/Facebook';
 import InstagramIcon from '@mui/icons-material/Instagram';
 
-const theme = useTheme();
-const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
-const isReallySmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
-
 // top section of footer
-const RenderCallToActionSection = () => (
+const RenderCallToActionSection = ({ theme }) => (
   <Box>
     <Typography variant="h5" color={theme.palette.tertiary.main}>
       Want to partner with PASS?
@@ -36,46 +32,59 @@ const RenderCallToActionSection = () => (
 );
 
 // middle section of footer
-const RenderCompanyInfoSection = () => (
-  <Box>
-    <Stack
-      direction={isReallySmallScreen ? 'column' : 'row'}
-      spacing={isSmallScreen ? 4 : 12}
-      justifyContent="space-around"
-      alignItems="center"
-    >
-      <Stack>
-        <Typography color={theme.palette.tertiary.main}>PASS LOGO</Typography>
-        <Typography color="#fff">tagline</Typography>
-      </Stack>
-      <Stack>
-        <Typography color={theme.palette.tertiary.main}>Follow Us</Typography>
-        <Stack direction="row" spacing={1}>
-          <Link href="https://twitter.com/" target="_blank" rel="noopener" color="#fff">
-            <TwitterIcon />
-          </Link>
-          <Link href="https://www.facebook.com/" target="_blank" rel="noopener" color="#fff">
-            <FacebookIcon />
-          </Link>
-          <Link href="https://www.instagram.com/" target="_blank" rel="noopener" color="#fff">
-            <InstagramIcon />
+const RenderCompanyInfoSection = ({ theme, isReallySmallScreen, isSmallScreen }) => {
+  const socialLinks = [
+    {
+      href: 'https://twitter.com/',
+      icon: <TwitterIcon />
+    },
+    {
+      href: 'https://www.facebook.com/',
+      icon: <FacebookIcon />
+    },
+    {
+      href: 'https://www.instagram.com/',
+      icon: <InstagramIcon />
+    }
+  ];
+
+  return (
+    <Box>
+      <Stack
+        direction={isReallySmallScreen ? 'column' : 'row'}
+        spacing={isSmallScreen ? 4 : 12}
+        justifyContent="space-around"
+        alignItems="center"
+      >
+        <Stack>
+          <Typography color={theme.palette.tertiary.main}>PASS LOGO</Typography>
+          <Typography color="#fff">tagline</Typography>
+        </Stack>
+        <Stack>
+          <Typography color={theme.palette.tertiary.main}>Follow Us</Typography>
+          <Stack direction="row" spacing={1}>
+            {socialLinks.map(({ href, icon }) => (
+              <Link key={href} href={href} target="_blank" rel="noopener" color="#fff">
+                {icon}
+              </Link>
+            ))}
+          </Stack>
+        </Stack>
+        <Stack>
+          <Typography color={theme.palette.tertiary.main}>Built By:</Typography>
+          <Link href="https://www.codeforpdx.org/" target="_blank" rel="noopener">
+            <Typography variant="body2" color="#fff">
+              C4PDX LOGO
+            </Typography>
           </Link>
         </Stack>
       </Stack>
-      <Stack>
-        <Typography color={theme.palette.tertiary.main}>Built By:</Typography>
-        <Link href="https://www.codeforpdx.org/" target="_blank" rel="noopener">
-          <Typography variant="body2" color="#fff">
-            C4PDX LOGO
-          </Typography>
-        </Link>
-      </Stack>
-    </Stack>
-  </Box>
-);
+    </Box>
+  );
+};
 
 // bottom section of footer
-const RenderCopyrightAndLinksSection = () => (
+const RenderCopyrightAndLinksSection = ({ theme, isSmallScreen }) => (
   <Box>
     <Stack
       direction={isSmallScreen ? 'column-reverse' : 'row'}
@@ -136,28 +145,38 @@ const RenderCopyrightAndLinksSection = () => (
  * @name Footer
  */
 
-const Footer = () => (
-  <Box
-    component="footer"
-    sx={{
-      position: 'sticky',
-      top: '100%',
-      textAlign: 'center',
-      bgcolor: theme.palette.primary.main
-    }}
-    py={5}
-  >
-    <Container maxWidth={isSmallScreen ? 'sm' : 'lg'}>
-      <Stack
-        spacing={2}
-        divider={<Divider color={theme.palette.tertiary.main} sx={{ height: '3px' }} />}
-      >
-        <RenderCallToActionSection />
-        <RenderCompanyInfoSection />
-        <RenderCopyrightAndLinksSection />
-      </Stack>
-    </Container>
-  </Box>
-);
+const Footer = () => {
+  const theme = useTheme();
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
+  const isReallySmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+
+  return (
+    <Box
+      component="footer"
+      sx={{
+        position: 'sticky',
+        top: '100%',
+        textAlign: 'center',
+        bgcolor: theme.palette.primary.main
+      }}
+      py={5}
+    >
+      <Container maxWidth={isSmallScreen ? 'sm' : 'lg'}>
+        <Stack
+          spacing={2}
+          divider={<Divider color={theme.palette.tertiary.main} sx={{ height: '3px' }} />}
+        >
+          <RenderCallToActionSection theme={theme} />
+          <RenderCompanyInfoSection
+            theme={theme}
+            isSmallScreen={isSmallScreen}
+            isReallySmallScreen={isReallySmallScreen}
+          />
+          <RenderCopyrightAndLinksSection theme={theme} isSmallScreen={isSmallScreen} />
+        </Stack>
+      </Container>
+    </Box>
+  );
+};
 
 export default Footer;

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -15,6 +15,7 @@ import TwitterIcon from '@mui/icons-material/Twitter';
 import FacebookIcon from '@mui/icons-material/Facebook';
 import InstagramIcon from '@mui/icons-material/Instagram';
 
+
 /**
  * Footer Component - Footer Component for PASS
  *
@@ -22,10 +23,149 @@ import InstagramIcon from '@mui/icons-material/Instagram';
  * @name Footer
  */
 
+
 const Footer = () => {
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
+  const isReallySmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
+
+  const renderCallToActionSection = () => (
+    <Box>
+      <Typography variant="h5" color={theme.palette.tertiary.main}>
+        Want to partner with PASS?
+      </Typography>
+      <Typography variant="body1" color="#fff">
+        If your organization is interested in partnering with PASS and would like to discuss
+        further, contact us below.
+      </Typography>
+      <Button variant="contained" color="secondary" sx={{ my: '1rem' }}>
+        Partnership Proposal
+      </Button>
+    </Box>
+  )
+
+
+  const renderCompanyInfoSection = () => (
+    <Box>
+      <Stack
+        direction={isReallySmallScreen ? "column" : "row"}
+        spacing={isSmallScreen ? 4 : 12}
+        justifyContent="space-around"
+        alignItems="center"
+      >
+        <Stack>
+          <Typography color={theme.palette.tertiary.main}>PASS LOGO</Typography>
+          <Typography color="#fff">tagline</Typography>
+        </Stack>
+        <Stack>
+          <Typography color={theme.palette.tertiary.main}>Follow Us</Typography>
+          <Stack direction="row" spacing={1}>
+            <Link
+              href="https://twitter.com/"
+              target="_blank"
+              rel="noopener"
+              color="#fff"
+            >
+              <TwitterIcon />
+            </Link>
+            <Link
+              href="https://www.facebook.com/"
+              target="_blank"
+              rel="noopener"
+              color="#fff"
+            >
+              <FacebookIcon />
+            </Link>
+            <Link
+              href="https://www.instagram.com/"
+              target="_blank"
+              rel="noopener"
+              color="#fff"
+            >
+              <InstagramIcon />
+            </Link>
+          </Stack>
+        </Stack>
+        <Stack>
+          <Typography color={theme.palette.tertiary.main}>Built By:</Typography>
+          <Link
+            href="https://www.codeforpdx.org/"
+            target="_blank"
+            rel="noopener"
+          >
+            <Typography variant="body2" color="#fff">
+              C4PDX LOGO
+            </Typography>
+          </Link>
+        </Stack>
+      </Stack>
+    </Box>
+  )
+
+
+  const renderCopyrightAndLinksSection = () => (
+    <Box>
+      <Stack
+        direction={isSmallScreen ? 'column-reverse' : 'row'}
+        spacing={2}
+        justifyContent="space-between"
+        divider={
+          <Divider
+            color={theme.palette.tertiary.main}
+            sx={{ display: { xs: 'flex', md: 'none' }, height: '3px' }}
+          />
+        }
+      >
+        <Typography variant="body2" color={theme.palette.tertiary.main}>
+          ©{new Date().getFullYear()}
+          <Link
+            href="https://www.codeforpdx.org/"
+            target="_blank"
+            rel="noopener"
+            underline="none"
+            color={theme.palette.tertiary.main}
+            ml={0.5}
+          >
+            Code for PDX
+          </Link>
+        </Typography>
+        <Stack
+          direction={isSmallScreen ? 'column' : 'row'}
+          spacing={isSmallScreen ? 0 : 2}
+          divider={
+            <Divider
+              color={theme.palette.tertiary.main}
+              orientation="vertical"
+              flexItem
+            />
+          }
+        >
+          <Typography variant="body2">
+            <Link
+              href="https://www.codeforpdx.org/"
+              underline="none"
+              color={theme.palette.tertiary.main}
+            >
+              Privacy Policy
+            </Link>
+          </Typography>
+          <Typography variant="body2">
+            <Link
+              href="https://www.codeforpdx.org/"
+              underline="none"
+              color={theme.palette.tertiary.main}
+            >
+              Terms and Conditions
+            </Link>
+          </Typography>
+        </Stack>
+      </Stack>
+    </Box>
+  )
+
+
+  // main return of this footer component
   return (
     <Box
       component="footer"
@@ -47,134 +187,9 @@ const Footer = () => {
             />
           }
         >
-          {/* CALL TO ACTION section */}
-          <Box>
-            <Typography variant="h5" color={theme.palette.tertiary.main}>
-              Want to partner with PASS?
-            </Typography>
-            <Typography variant="body1" color="#fff">
-              If your organization is interested in partnering with PASS and would like to discuss
-              further, contact us below.
-            </Typography>
-            <Button variant="contained" color="secondary" sx={{ my: '1rem' }}>
-              Partnership Proposal
-            </Button>
-          </Box>
-
-          {/* LOGO / FOLLOW US / BUILT BY section */}
-          <Box>
-            <Stack
-              direction={isSmallScreen ? "column" : "row"}
-              spacing={isSmallScreen ? 4 : 12}
-              justifyContent="space-around"
-              alignItems="center"
-            >
-              <Stack>
-                <Typography color={theme.palette.tertiary.main}>PASS LOGO</Typography>
-                <Typography color="#fff">tagline</Typography>
-              </Stack>
-              <Stack>
-                <Typography color={theme.palette.tertiary.main}>Follow Us</Typography>
-                <Stack direction="row" spacing={1}>
-                  <Link
-                    href="https://twitter.com/"
-                    target="_blank"
-                    rel="noopener"
-                    color="#fff"
-                  >
-                    <TwitterIcon />
-                  </Link>
-                  <Link
-                    href="https://www.facebook.com/"
-                    target="_blank"
-                    rel="noopener"
-                    color="#fff"
-                  >
-                    <FacebookIcon />
-                  </Link>
-                  <Link
-                    href="https://www.instagram.com/"
-                    target="_blank"
-                    rel="noopener"
-                    color="#fff"
-                  >
-                    <InstagramIcon />
-                  </Link>
-                </Stack>
-              </Stack>
-              <Stack>
-                <Typography color={theme.palette.tertiary.main}>Built By:</Typography>
-                <Link
-                  href="https://www.codeforpdx.org/"
-                  target="_blank"
-                  rel="noopener"
-                >
-                  <Typography variant="body2" color="#fff">
-                    C4PDX LOGO
-                  </Typography>
-                </Link>
-              </Stack>
-            </Stack>
-          </Box>
-
-          {/* COPYRIGHT / LINKS section */}
-          <Box>
-            <Stack
-              direction={isSmallScreen ? 'column-reverse' : 'row'}
-              spacing={2}
-              justifyContent="space-between"
-              divider={
-                <Divider
-                  color={theme.palette.tertiary.main}
-                  sx={{ display: { xs: 'flex', md: 'none' }, height: '3px' }}
-                />
-              }
-            >
-              <Typography variant="body2" color={theme.palette.tertiary.main}>
-                ©{new Date().getFullYear()}
-                <Link
-                  href="https://www.codeforpdx.org/"
-                  target="_blank"
-                  rel="noopener"
-                  underline="none"
-                  color={theme.palette.tertiary.main}
-                  ml={0.5}
-                >
-                  Code for PDX
-                </Link>
-              </Typography>
-              <Stack
-                direction={isSmallScreen ? 'column' : 'row'}
-                spacing={isSmallScreen ? 0 : 2}
-                divider={
-                  <Divider
-                    color={theme.palette.tertiary.main}
-                    orientation="vertical"
-                    flexItem
-                  />
-                }
-              >
-                <Typography variant="body2">
-                  <Link
-                    href="https://www.codeforpdx.org/"
-                    underline="none"
-                    color={theme.palette.tertiary.main}
-                  >
-                    Privacy Policy
-                  </Link>
-                </Typography>
-                <Typography variant="body2">
-                  <Link
-                    href="https://www.codeforpdx.org/"
-                    underline="none"
-                    color={theme.palette.tertiary.main}
-                  >
-                    Terms and Conditions
-                  </Link>
-                </Typography>
-              </Stack>
-            </Stack>
-          </Box>
+          {renderCallToActionSection()}
+          {renderCompanyInfoSection()}
+          {renderCopyrightAndLinksSection()}
         </Stack>
       </Container>
     </Box>

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -15,7 +15,6 @@ import TwitterIcon from '@mui/icons-material/Twitter';
 import FacebookIcon from '@mui/icons-material/Facebook';
 import InstagramIcon from '@mui/icons-material/Instagram';
 
-
 /**
  * Footer Component - Footer Component for PASS
  *
@@ -24,176 +23,140 @@ import InstagramIcon from '@mui/icons-material/Instagram';
  */
 
 
-const Footer = () => {
-  const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
-  const isReallySmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+const theme = useTheme();
+const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
+const isReallySmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
+const RenderCallToActionSection = () => (
+  <Box>
+    <Typography variant="h5" color={theme.palette.tertiary.main}>
+      Want to partner with PASS?
+    </Typography>
+    <Typography variant="body1" color="#fff">
+      If your organization is interested in partnering with PASS and would like to discuss
+      further, contact us below.
+    </Typography>
+    <Button variant="contained" color="secondary" sx={{ my: '1rem' }}>
+      Partnership Proposal
+    </Button>
+  </Box>
+);
 
-  const renderCallToActionSection = () => (
-    <Box>
-      <Typography variant="h5" color={theme.palette.tertiary.main}>
-        Want to partner with PASS?
-      </Typography>
-      <Typography variant="body1" color="#fff">
-        If your organization is interested in partnering with PASS and would like to discuss
-        further, contact us below.
-      </Typography>
-      <Button variant="contained" color="secondary" sx={{ my: '1rem' }}>
-        Partnership Proposal
-      </Button>
-    </Box>
-  )
-
-
-  const renderCompanyInfoSection = () => (
-    <Box>
-      <Stack
-        direction={isReallySmallScreen ? "column" : "row"}
-        spacing={isSmallScreen ? 4 : 12}
-        justifyContent="space-around"
-        alignItems="center"
-      >
-        <Stack>
-          <Typography color={theme.palette.tertiary.main}>PASS LOGO</Typography>
-          <Typography color="#fff">tagline</Typography>
-        </Stack>
-        <Stack>
-          <Typography color={theme.palette.tertiary.main}>Follow Us</Typography>
-          <Stack direction="row" spacing={1}>
-            <Link
-              href="https://twitter.com/"
-              target="_blank"
-              rel="noopener"
-              color="#fff"
-            >
-              <TwitterIcon />
-            </Link>
-            <Link
-              href="https://www.facebook.com/"
-              target="_blank"
-              rel="noopener"
-              color="#fff"
-            >
-              <FacebookIcon />
-            </Link>
-            <Link
-              href="https://www.instagram.com/"
-              target="_blank"
-              rel="noopener"
-              color="#fff"
-            >
-              <InstagramIcon />
-            </Link>
-          </Stack>
-        </Stack>
-        <Stack>
-          <Typography color={theme.palette.tertiary.main}>Built By:</Typography>
-          <Link
-            href="https://www.codeforpdx.org/"
-            target="_blank"
-            rel="noopener"
-          >
-            <Typography variant="body2" color="#fff">
-              C4PDX LOGO
-            </Typography>
+const RenderCompanyInfoSection = () => (
+  <Box>
+    <Stack
+      direction={isReallySmallScreen ? 'column' : 'row'}
+      spacing={isSmallScreen ? 4 : 12}
+      justifyContent="space-around"
+      alignItems="center"
+    >
+      <Stack>
+        <Typography color={theme.palette.tertiary.main}>PASS LOGO</Typography>
+        <Typography color="#fff">tagline</Typography>
+      </Stack>
+      <Stack>
+        <Typography color={theme.palette.tertiary.main}>Follow Us</Typography>
+        <Stack direction="row" spacing={1}>
+          <Link href="https://twitter.com/" target="_blank" rel="noopener" color="#fff">
+            <TwitterIcon />
+          </Link>
+          <Link href="https://www.facebook.com/" target="_blank" rel="noopener" color="#fff">
+            <FacebookIcon />
+          </Link>
+          <Link href="https://www.instagram.com/" target="_blank" rel="noopener" color="#fff">
+            <InstagramIcon />
           </Link>
         </Stack>
       </Stack>
-    </Box>
-  )
+      <Stack>
+        <Typography color={theme.palette.tertiary.main}>Built By:</Typography>
+        <Link href="https://www.codeforpdx.org/" target="_blank" rel="noopener">
+          <Typography variant="body2" color="#fff">
+            C4PDX LOGO
+          </Typography>
+        </Link>
+      </Stack>
+    </Stack>
+  </Box>
+);
 
-
-  const renderCopyrightAndLinksSection = () => (
-    <Box>
+const RenderCopyrightAndLinksSection = () => (
+  <Box>
+    <Stack
+      direction={isSmallScreen ? 'column-reverse' : 'row'}
+      spacing={2}
+      justifyContent="space-between"
+      divider={
+        <Divider
+          color={theme.palette.tertiary.main}
+          sx={{ display: { xs: 'flex', md: 'none' }, height: '3px' }}
+        />
+      }
+    >
+      <Typography variant="body2" color={theme.palette.tertiary.main}>
+        ©{new Date().getFullYear()}
+        <Link
+          href="https://www.codeforpdx.org/"
+          target="_blank"
+          rel="noopener"
+          underline="none"
+          color={theme.palette.tertiary.main}
+          ml={0.5}
+        >
+          Code for PDX
+        </Link>
+      </Typography>
       <Stack
-        direction={isSmallScreen ? 'column-reverse' : 'row'}
-        spacing={2}
-        justifyContent="space-between"
-        divider={
-          <Divider
-            color={theme.palette.tertiary.main}
-            sx={{ display: { xs: 'flex', md: 'none' }, height: '3px' }}
-          />
-        }
+        direction={isSmallScreen ? 'column' : 'row'}
+        spacing={isSmallScreen ? 0 : 2}
+        divider={<Divider color={theme.palette.tertiary.main} orientation="vertical" flexItem />}
       >
-        <Typography variant="body2" color={theme.palette.tertiary.main}>
-          ©{new Date().getFullYear()}
+        <Typography variant="body2">
           <Link
             href="https://www.codeforpdx.org/"
-            target="_blank"
-            rel="noopener"
             underline="none"
             color={theme.palette.tertiary.main}
-            ml={0.5}
           >
-            Code for PDX
+            Privacy Policy
           </Link>
         </Typography>
-        <Stack
-          direction={isSmallScreen ? 'column' : 'row'}
-          spacing={isSmallScreen ? 0 : 2}
-          divider={
-            <Divider
-              color={theme.palette.tertiary.main}
-              orientation="vertical"
-              flexItem
-            />
-          }
-        >
-          <Typography variant="body2">
-            <Link
-              href="https://www.codeforpdx.org/"
-              underline="none"
-              color={theme.palette.tertiary.main}
-            >
-              Privacy Policy
-            </Link>
-          </Typography>
-          <Typography variant="body2">
-            <Link
-              href="https://www.codeforpdx.org/"
-              underline="none"
-              color={theme.palette.tertiary.main}
-            >
-              Terms and Conditions
-            </Link>
-          </Typography>
-        </Stack>
+        <Typography variant="body2">
+          <Link
+            href="https://www.codeforpdx.org/"
+            underline="none"
+            color={theme.palette.tertiary.main}
+          >
+            Terms and Conditions
+          </Link>
+        </Typography>
       </Stack>
-    </Box>
-  )
+    </Stack>
+  </Box>
+);
 
-
-  // main return of this footer component
-  return (
-    <Box
-      component="footer"
-      sx={{
-        position: 'sticky',
-        top: '100%',
-        textAlign: 'center',
-        bgcolor: theme.palette.primary.main
-      }}
-      py={5}
-    >
-      <Container maxWidth={isSmallScreen ? "sm" : "lg"}>
-        <Stack
-          spacing={2}
-          divider={
-            <Divider
-              color={theme.palette.tertiary.main}
-              sx={{ height: '3px' }}
-            />
-          }
-        >
-          {renderCallToActionSection()}
-          {renderCompanyInfoSection()}
-          {renderCopyrightAndLinksSection()}
-        </Stack>
-      </Container>
-    </Box>
-  );
-};
+// MAIN FUNCTION/RENDER RETURNED BY THIS FILE
+const Footer = () => (
+  <Box
+    component="footer"
+    sx={{
+      position: 'sticky',
+      top: '100%',
+      textAlign: 'center',
+      bgcolor: theme.palette.primary.main
+    }}
+    py={5}
+  >
+    <Container maxWidth={isSmallScreen ? 'sm' : 'lg'}>
+      <Stack
+        spacing={2}
+        divider={<Divider color={theme.palette.tertiary.main} sx={{ height: '3px' }} />}
+      >
+        <RenderCallToActionSection />
+        <RenderCompanyInfoSection />
+        <RenderCopyrightAndLinksSection />
+      </Stack>
+    </Container>
+  </Box>
+);
 
 export default Footer;


### PR DESCRIPTION
**Description**
---
This PR creates a decent rendering of the current version of the `footer` for small screens.


**Updates**
---
<img width="1440" alt="Screenshot 2023-05-21 at 12 49 15 PM" src="https://github.com/codeforpdx/PASS/assets/71395931/eb37fede-55e0-44e3-b231-8ee4e4a2c237">
<img width="1440" alt="Screenshot 2023-05-21 at 12 49 28 PM" src="https://github.com/codeforpdx/PASS/assets/71395931/4e05f093-fb01-4966-a64a-495ea8ceb79f">
<img width="1439" alt="Screenshot 2023-05-21 at 12 49 44 PM" src="https://github.com/codeforpdx/PASS/assets/71395931/1ec22b89-7fa5-45aa-8ac2-51e9546f830a">




**Related Issue**
---
Closes Issue #170 


**Future Thoughts**
---
- Still need a finalized design and thoughts on what should be in the footer, but this is a decent skeleton for now