### PR TITLE
add margin to top of footer

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -143,13 +143,14 @@ const Footer = () => {
   return (
     <Box
       component="footer"
+      mt={3}
+      py={5}
       sx={{
         position: 'sticky',
         top: '100%',
         textAlign: 'center',
         bgcolor: 'primary.main'
       }}
-      py={5}
     >
       <Container maxWidth={isSmallScreen ? 'md' : 'lg'}>
         <Stack


### PR DESCRIPTION
Realized the `footer` was rendered right up against the bottom of last component on page. 

Added same margin to top of `footer` that seemingly is equal to the margin on bottom of `navbar`.

Closes issue #170 