### PR TITLE
Clean up warning messages in Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,16 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    needs: build
     permissions:
       contents: read
     steps: 
       - name: Code Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
       - name: Install Dependencies
         run: npm ci
       - name: eslint
@@ -71,12 +75,16 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: build
     permissions:
       contents: read
     steps: 
       - name: Code Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
       - name: Install Dependencies
         run: npm ci
       - name: vitest


### PR DESCRIPTION
Github was generating some warnings when running, one about outdated actions, the other about the wrong version of node being used in the unit tests. This fixes them.

Also, lint and test no longer depend on build succeeding. The change should let those tests run faster.