### PR TITLE
Optimizing functions in session-core and updating JSDoc comments

### DIFF
--- a/src/components/Form/CrossPodWriteForm.jsx
+++ b/src/components/Form/CrossPodWriteForm.jsx
@@ -87,7 +87,7 @@ const CrossPodWriteForm = () => {
     >
       <form onSubmit={handleCrossPodUpload} autoComplete="off">
         <div style={formRowStyle}>
-          <label htmlFor="cross-upload-doc">Search document from username: </label>
+          <label htmlFor="cross-upload-doc">Upload document to username: </label>
           <br />
           <br />
           <input

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -37,7 +37,9 @@ const SetAclPermissionForm = () => {
     event.preventDefault();
     dispatch({ type: 'SET_PROCESSING' });
     const docType = event.target.document.value;
-    const permissionType = event.target.setAclPerms.value;
+    const permissions = event.target.setAclPerms.value
+      ? { read: event.target.setAclPerms.value === 'Give' }
+      : undefined;
     let podUsername = event.target.setAclTo.value;
 
     if (!podUsername) {
@@ -68,7 +70,7 @@ const SetAclPermissionForm = () => {
       return;
     }
 
-    if (!permissionType) {
+    if (permissions === undefined) {
       runNotification('Set permissions failed. Reason: Permissions not set.', 5, state, dispatch);
       setTimeout(() => {
         clearInputFields();
@@ -77,10 +79,10 @@ const SetAclPermissionForm = () => {
     }
 
     try {
-      await setDocAclPermission(session, docType, permissionType, podUsername);
+      await setDocAclPermission(session, docType, permissions, podUsername);
 
       runNotification(
-        `${permissionType} permission to ${podUsername} for ${docType}.`,
+        `${permissions.read ? 'Give' : 'Revoke'} permission to ${podUsername} for ${docType}.`,
         5,
         state,
         dispatch

--- a/src/components/Form/SetAclPermsDocContainerForm.jsx
+++ b/src/components/Form/SetAclPermsDocContainerForm.jsx
@@ -40,7 +40,13 @@ const SetAclPermsDocContainerForm = () => {
   const handleAclPermission = async (event) => {
     event.preventDefault();
     dispatch({ type: 'SET_PROCESSING' });
-    const permissionType = event.target.setAclPerms.value;
+    const permissions = event.target.setAclPerms.value
+      ? {
+          read: event.target.setAclPerms.value === 'Give',
+          write: event.target.setAclPerms.value === 'Give',
+          append: event.target.setAclPerms.value === 'Give'
+        }
+      : undefined;
     let podUsername = event.target.setAclTo.value;
 
     if (!podUsername) {
@@ -71,7 +77,7 @@ const SetAclPermsDocContainerForm = () => {
       return;
     }
 
-    if (!permissionType) {
+    if (permissions === undefined) {
       runNotification('Set permissions failed. Reason: Permissions not set.', 5, state, dispatch);
       setTimeout(() => {
         clearInputFields();
@@ -80,10 +86,12 @@ const SetAclPermsDocContainerForm = () => {
     }
 
     try {
-      await setDocContainerAclPermission(session, permissionType, podUsername);
+      await setDocContainerAclPermission(session, permissions, podUsername);
 
       runNotification(
-        `${permissionType} permission to ${podUsername} for Documents Container.`,
+        `${
+          permissions.read ? 'Give' : 'Revoke'
+        } permission to ${podUsername} for Documents Container.`,
         5,
         state,
         dispatch

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -115,7 +115,7 @@ const React = require('react');
  * @property {string} person - Full name of user
  * @property {string} givenName - First/given name of user
  * @property {string} familyName - Last/family name of user
- * @property {URL} podURL - URL of user's Solid Pod
+ * @property {URL} podUrl - URL of user's Solid Pod
  * @property {Date|null} dateModified - The last active date using PASS
  * @memberof typedefs
  */

--- a/src/utils/cryptography/credentials-helper.js
+++ b/src/utils/cryptography/credentials-helper.js
@@ -9,7 +9,7 @@ import {
   setThing,
   getStringNoLocale
 } from '@inrupt/solid-client';
-import { createDocAclForUser } from '../network/session-helper';
+import { setDocAclForUser } from '../network/session-helper';
 import { RDF_PREDICATES } from '../../constants';
 
 /**
@@ -81,9 +81,9 @@ const savePassUserCredentials = async (dataSets, session) => {
     control: true
   };
 
-  await createDocAclForUser(session, containerUrl, keyAccessAcl);
-  await createDocAclForUser(session, privateKeyUrl, keyAccessAcl);
-  await createDocAclForUser(session, publicKeyUrl, keyAccessAcl);
+  await setDocAclForUser(session, containerUrl, 'create', session.info.webId, keyAccessAcl);
+  await setDocAclForUser(session, privateKeyUrl, 'create', session.info.webId, keyAccessAcl);
+  await setDocAclForUser(session, publicKeyUrl, 'create', session.info.webId, keyAccessAcl);
 };
 
 const getUserSigningKeyInternal = async (session) => {

--- a/src/utils/network/session-core.js
+++ b/src/utils/network/session-core.js
@@ -69,22 +69,13 @@ import { getUserSigningKey, signDocumentTtlFile } from '../cryptography/credenti
 
 export const setDocAclPermission = async (session, fileType, accessType, otherPodUsername) => {
   const documentUrl = getContainerUrl(session, fileType, 'self-fetch');
-
   const podResouceWithAcl = await getSolidDatasetWithAcl(documentUrl, { fetch: session.fetch });
 
   const resourceAcl = getResourceAcl(podResouceWithAcl);
   const webId = `https://${otherPodUsername}.${
     SOLID_IDENTITY_PROVIDER.split('/')[2]
   }/profile/card#me`;
-  let accessObject;
-  switch (accessType) {
-    case 'Give':
-      accessObject = { read: true };
-      break;
-    default:
-      accessObject = { read: false };
-      break;
-  }
+  const accessObject = accessType === 'Give' ? { read: true } : { read: false };
 
   const updatedAcl = setupAcl(resourceAcl, webId, accessObject);
   await saveAclFor(podResouceWithAcl, updatedAcl, { fetch: session.fetch });
@@ -117,15 +108,10 @@ export const setDocContainerAclPermission = async (session, accessType, otherPod
     SOLID_IDENTITY_PROVIDER.split('/')[2]
   }/profile/card#me`;
 
-  let accessObject;
-  switch (accessType) {
-    case 'Give':
-      accessObject = { read: true, write: true, append: true };
-      break;
-    default:
-      accessObject = { read: false, write: false, append: false };
-      break;
-  }
+  const accessObject =
+    accessType === 'Give'
+      ? { read: true, write: true, append: true }
+      : { read: false, write: false, append: false };
 
   urlsToSet.forEach(async (url) => {
     const podResourceWithAcl = await getSolidDatasetWithAcl(url, { fetch: session.fetch });
@@ -152,9 +138,10 @@ export const setDocContainerAclPermission = async (session, accessType, otherPod
  * being used
  * @param {fileObjectType} fileObject - Object containing information about file
  * from form submission (see {@link fileObjectType})
- * @param {boolean} verifyDocument - True if document submission should include user verification
- * @param {string} [otherPodUsername] - If cross pod interaction, this is the username of the
- * other user, set to an empty string by default
+ * @param {boolean} verifyDocument - True if document submission should include
+ * user verification
+ * @param {string} [otherPodUsername] - If cross pod interaction, this is the
+ * username of the other user, set to an empty string by default
  * @returns {Promise} Promise - File upload is handled via Solid libraries
  */
 
@@ -166,8 +153,9 @@ export const uploadDocument = async (
   verifyDocument,
   otherPodUsername = ''
 ) => {
-  let containerUrl;
   const fileName = fileObject.file.name;
+
+  let containerUrl;
   if (uploadType === UPLOAD_TYPES.SELF) {
     containerUrl = getContainerUrl(session, fileObject.type, 'self-fetch');
   } else {
@@ -182,8 +170,9 @@ export const uploadDocument = async (
   const ttlFileExists = hasTTLFiles(datasetFromUrl);
 
   // Guard clause will throw function if container already exist with ttl file
+  // ttl file indicates update instead of upload document
   if (ttlFileExists) {
-    throw new Error('Container already exists');
+    throw new Error('TTL file already exists');
   }
 
   // Place file into Pod container and generate new ttl file for container
@@ -213,7 +202,7 @@ export const uploadDocument = async (
   }
 
   if (uploadType === UPLOAD_TYPES.SELF) {
-    // Generate ACL file for container
+    // Generate ACL file for new container
     await createDocAclForUser(session, containerUrl);
   }
 };
@@ -228,11 +217,11 @@ export const uploadDocument = async (
  * being used
  * @param {fileObjectType} fileObject - Object containing information about file
  * from form submission (see {@link fileObjectType})
- * @param {string} [otherPodUsername] - If cross pod interaction, this is the URL of the
- * other user, set to an empty string by default
- * @returns {Promise} fileExist - A boolean for if file exist on Solid Pod,
- * updates the file if confirmed, or if file doesn't exist, uploads new file to
- * Solid Pod if confirmed
+ * @param {string} [otherPodUsername] - If cross pod interaction, this is the URL
+ * of the other user, set to an empty string by default
+ * @returns {Promise<boolean>} fileExist - A boolean for if file exist on Solid
+ * Pod and updates the file if accepted, or if file doesn't exist, uploads a new
+ * file to Solid Pod if accepted
  */
 
 export const updateDocument = async (session, uploadType, fileObject, otherPodUsername = '') => {
@@ -252,24 +241,15 @@ export const updateDocument = async (session, uploadType, fileObject, otherPodUs
   const [, files] = getContainerUrlAndFiles(solidDataset);
   const fileExist = files.map((file) => file.url).includes(documentUrl);
 
-  if (fileExist) {
-    if (window.confirm(`File ${fileName} exist in Pod container, do you wish to update it?`)) {
-      await overwriteFile(documentUrl, fileObject.file, { fetch: session.fetch });
-      await updateTTLFile(session, containerUrl, fileObject);
-    } else {
-      throw new Error('File update cancelled.');
-    }
+  const confirmationMessage = fileExist
+    ? `File ${fileName} exist in Pod container, do you wish to update it?`
+    : `File ${fileName} does not exist in Pod container, do you wish to upload it?`;
 
-    return fileExist;
-  }
-
-  if (
-    window.confirm(`File ${fileName} does not exist in Pod container, do you wish to upload it?`)
-  ) {
+  if (window.confirm(confirmationMessage)) {
     await overwriteFile(documentUrl, fileObject.file, { fetch: session.fetch });
     await updateTTLFile(session, containerUrl, fileObject);
   } else {
-    throw new Error('New file upload cancelled.');
+    throw new Error(fileExist ? 'File update cancelled.' : 'New file upload cancelled.');
   }
 
   return fileExist;
@@ -285,9 +265,9 @@ export const updateDocument = async (session, uploadType, fileObject, otherPodUs
  * @param {string} fileType - Type of document
  * @param {string} fetchType - Type of fetch (to own Pod, or "self-fetch" or to
  * other Pods, or "cross-fetch")
- * @param {string} [otherPodUsername] - Url to other user's Pod (set to empty string by
- * default)
- * @returns {Promise} Promise - Either a string containing the url location of
+ * @param {string} [otherPodUsername] - Url to other user's Pod (set to empty string
+ * by default)
+ * @returns {Promise<URL>} Promise - Either a string containing the url location of
  * the document, if exist, or throws an Error
  */
 
@@ -313,10 +293,10 @@ export const getDocuments = async (session, fileType, fetchType, otherPodUsernam
  * @param {string} fileType - Type of document
  * @param {string} fetchType - Type of fetch (to own Pod, or "self-fetch" or to
  * other Pods, or "cross-fetch")
- * @param {string} [otherPodUsername] - Username to other user's Pod (set to empty string by
- * default)
- * @returns {Promise} Promise - Either a string containing the url location of
- * the container, if permitted, or throws an Error
+ * @param {string} [otherPodUsername] - Username to other user's Pod (set to empty
+ * string by default)
+ * @returns {Promise<URL>} Promise - Either a string containing the url location
+ * of the container, if permitted, or throws an Error
  */
 
 export const checkContainerPermission = async (session, otherPodUsername) => {
@@ -341,8 +321,8 @@ export const checkContainerPermission = async (session, otherPodUsername) => {
  * @function deleteDocuments
  * @param {Session} session - Solid's Session Object (see {@link Session})
  * @param {string} fileType - Type of document
- * @returns {Promise} container.url - The URL of document container and the
- * response on whether document file is deleted, if exist, and delete all
+ * @returns {Promise<URL>} container.url - The URL of document container and the
+ * response on whether document file is deleted, if exist, then deletes all
  * existing files within it
  */
 
@@ -484,8 +464,8 @@ export const generateUsersList = async (session) => {
  * @param {Session} session - Solid's Session Object {@link Session}
  * @param {userListObject[]} userList - An array of {@link userListObject}
  * which stores the name and their Pod URL
- * @returns {Promise} Promise - An array of users with last active time included
- * to user list
+ * @returns {Promise<userListObject[]>} Promise - An array of users with last active
+ * time included to user list
  */
 
 export const getUserListActivity = async (session, userList) => {
@@ -519,8 +499,8 @@ export const getUserListActivity = async (session, userList) => {
  * @memberof utils
  * @function getUsersFromPod
  * @param {Session} session - Solid's Session Object {@link Session}
- * @returns {Promise} Promise - An array of users from their Pod into PASS, if
- * users list exist
+ * @returns {Promise<userListObject[]>} Promise - An array of users from their
+ * Pod into PASS, if users list exist
  */
 
 export const getUsersFromPod = async (session) => {
@@ -557,8 +537,8 @@ export const getUsersFromPod = async (session) => {
  * @param {Session} session - Solid's Session Object {@link Session}
  * @param {string} userToDelete - Name of user to be removed from list
  * @param {URL} userToDeleteUrl - URL of the user's Pod you wish to delete
- * @returns {Promise} Promise - Removes user with userToDeleteUrl from users list in
- * their Solid Pod
+ * @returns {Promise<userListObject[]>} userList - Removes user with userToDeleteUrl
+ * from users list in their Solid Pod and returns userList
  */
 
 export const deleteUserFromPod = async (session, userToDelete, userToDeleteUrl) => {
@@ -591,8 +571,8 @@ export const deleteUserFromPod = async (session, userToDelete, userToDeleteUrl) 
  * @function addUserToPod
  * @param {Session} session - Solid's Session Object {@link Session}
  * @param {object} userObject - Object containing the user's name and Pod URL
- * @returns {Promise} Promise - Adds users with their Pod URL onto users list in
- * their Solid Pod
+ * @returns {Promise<userListObject[]>} userList - Adds users with their Pod URL
+ * onto users list in their Solid Pod and returns userList
  */
 
 export const addUserToPod = async (session, userObject) => {
@@ -700,13 +680,15 @@ export const updateUserActivity = async (session) => {
 */
 
 /**
- * Function that sends a message to another user's Pod inbox
+ * Function that sends a message to another user's Pod inbox and saves a copy in
+ * user's own inbox
  *
  * @memberof utils
  * @function sendMessageTTL
  * @param {Session} session - Solid's Session Object {@link Session}
  * @param {object} messageObject - An object containing inputs for the the message
- * @returns {Promise} Promise - Updates last active time of user to lastActive.ttl
+ * @returns {Promise} Promise - Sends a TTL file to another user's Pod inbox and
+ * saves a copy on your inbox
  */
 
 export const sendMessageTTL = async (session, messageObject) => {

--- a/src/utils/network/session-helper.js
+++ b/src/utils/network/session-helper.js
@@ -13,7 +13,9 @@ import {
   getProfileAll,
   getThing,
   getStringNoLocale,
-  saveSolidDatasetInContainer
+  saveSolidDatasetInContainer,
+  getResourceAcl,
+  getSolidDatasetWithAcl
 } from '@inrupt/solid-client';
 import sha256 from 'crypto-js/sha256';
 import getDriversLicenseData from '../barcode/barcode-scan';
@@ -211,17 +213,21 @@ export const setupAcl = (resourceWithAcl, webId, accessObject) => {
  * container
  *
  * @memberof utils
- * @function createDocAclForUser
+ * @function setDocAclForUser
  * @param {Session} session - Solid's Session Object (see {@link Session})
  * @param {URL} documentUrl - Url link to document container
- * @param {object} accessObject - Access Object to use when creating the file
+ * @param {string} generateType - A string for "create" or "update"
+ * @param {URL} webId - The webId of the user permissions are set to
+ * @param {Access} accessObject - Access Object to use when creating the file
  * @returns {Promise} Promise - Generates ACL file for container and give user
  * access and control to it and its contents
  */
 
-export const createDocAclForUser = async (
+export const setDocAclForUser = async (
   session,
   documentUrl,
+  generateType,
+  webId,
   accessObject = {
     read: true,
     append: true,
@@ -229,12 +235,14 @@ export const createDocAclForUser = async (
     control: true
   }
 ) => {
-  const podResourceWithoutAcl = await getSolidDataset(documentUrl, { fetch: session.fetch });
-
-  const resourceAcl = createAcl(podResourceWithoutAcl);
-
-  const newAcl = setupAcl(resourceAcl, session.info.webId, accessObject);
-  await saveAclFor(podResourceWithoutAcl, newAcl, { fetch: session.fetch });
+  const podResource =
+    generateType === 'create'
+      ? await getSolidDataset(documentUrl, { fetch: session.fetch })
+      : await getSolidDatasetWithAcl(documentUrl, { fetch: session.fetch });
+  const resourceAcl =
+    generateType === 'create' ? createAcl(podResource) : getResourceAcl(podResource);
+  const newAcl = setupAcl(resourceAcl, webId, accessObject);
+  await saveAclFor(podResource, newAcl, { fetch: session.fetch });
 };
 
 /**

--- a/test/utils/session-helper.test.js
+++ b/test/utils/session-helper.test.js
@@ -1,3 +1,9 @@
+import {
+  addMockResourceAclTo,
+  createAcl,
+  getResourceAcl,
+  mockSolidDatasetFrom
+} from '@inrupt/solid-client';
 import { expect, vi, it, describe } from 'vitest';
 import { createResourceTtlFile } from '../../src/utils/network/session-helper';
 import { UPLOAD_TYPES } from '../../src/constants';
@@ -20,5 +26,64 @@ describe('createResourceTtlFile', () => {
     const result = await createResourceTtlFile(fileObjectMock, documentUrl);
     expect(mockText).toBeCalledTimes(1);
     expect(Object.keys(result.predicates)).toHaveLength(7);
+  });
+});
+
+describe('setDocAclForUser', () => {
+  const documentUrl = 'https://example.com';
+  let generateType;
+  const mockPodResource = mockSolidDatasetFrom(documentUrl);
+  const mockPodResourceWithAcl = addMockResourceAclTo(mockPodResource);
+  const mockNewResourceAcl = createAcl(mockPodResource);
+  const mockResourceAcl = getResourceAcl(mockPodResourceWithAcl);
+
+  const getSolidDataset = vi.fn();
+  getSolidDataset.mockResolvedValue(mockPodResource);
+
+  const getSolidDatasetWithAcl = vi.fn();
+  getSolidDatasetWithAcl.mockResolvedValue(mockPodResourceWithAcl);
+
+  const mockCreateAcl = vi.fn();
+  mockCreateAcl.mockReturnValue(mockNewResourceAcl);
+
+  const mockGetResourceAcl = vi.fn();
+  mockGetResourceAcl.mockReturnValue(mockResourceAcl);
+
+  it("generate podResource and resourceAcl with generateType 'create'", async () => {
+    generateType = 'create';
+    const podResource =
+      generateType === 'create'
+        ? await getSolidDataset(documentUrl)
+        : await getSolidDatasetWithAcl(documentUrl);
+
+    expect(getSolidDataset).toHaveBeenCalledWith(documentUrl);
+    expect(podResource).toEqual(mockPodResource);
+
+    const resourceAcl =
+      generateType === 'create' ? mockCreateAcl(podResource) : mockGetResourceAcl(podResource);
+
+    expect(mockCreateAcl).toHaveBeenCalledWith(podResource);
+    expect(resourceAcl).toEqual(mockNewResourceAcl);
+  });
+
+  it("generate podResource and resourceAcl with generateType 'update'", async () => {
+    generateType = 'update';
+    const podResource =
+      generateType === 'create'
+        ? await getSolidDataset(documentUrl)
+        : await getSolidDatasetWithAcl(documentUrl);
+
+    await expect(Promise.resolve(podResource)).resolves.toBe(
+      generateType === 'create' ? mockPodResource : mockPodResourceWithAcl
+    );
+
+    expect(getSolidDatasetWithAcl).toHaveBeenCalledWith(documentUrl);
+    expect(podResource).toEqual(mockPodResourceWithAcl);
+
+    const resourceAcl =
+      generateType === 'create' ? mockCreateAcl(podResource) : mockGetResourceAcl(podResource);
+
+    expect(mockGetResourceAcl).toHaveBeenCalledWith(podResource);
+    expect(resourceAcl).toEqual(mockResourceAcl);
   });
 });


### PR DESCRIPTION
This PR provides minor optimizations to code existing in session-core and updates JSDoc comments related to functions in session-core with no breaking changes. Helper functions from session-helper has been adjusted to allow for these optimizations.

## New unit tests

Considering this PR affects `setDocAclForUser` from session-helper the most, a unit test for the function has been built for it.

This unit tests checks for whether certain variables are generated correctly in preparation for running the helper function setupAcl, which takes in resourceAcl, webId, and accessObject.

The variable resourceAcl is dependent on a new variable called `generateType`, which either creates a new ACL file via `getSolidDataset` and `createAcl` or update an existing ACL file via `getSolidDatasetWithAcl` and `getResourceAcl`.