### PR TITLE
Issue 188/check permission styling updates

### DIFF
--- a/src/components/Form/CheckAclPermsDocContainerForm.jsx
+++ b/src/components/Form/CheckAclPermsDocContainerForm.jsx
@@ -2,6 +2,11 @@
 import React, { useContext } from 'react';
 // Inrupt Library Imports
 import { useSession } from '@inrupt/solid-ui-react';
+// Material UI Imports
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import FormControl from '@mui/material/FormControl';
+import TextField from '@mui/material/TextField';
 // Utility Imports
 import { SOLID_IDENTITY_PROVIDER, checkContainerPermission, runNotification } from '../../utils';
 // Custom Hook Imports
@@ -42,6 +47,7 @@ const CheckAclPermsDocContainerForm = () => {
       podUsername = selectedUser;
     }
 
+    // TODO: Determine if this is necessary as MUI provides its own verification
     if (!podUsername) {
       runNotification(
         'Check permissions failed. Reason: Username not provided.',
@@ -60,7 +66,7 @@ const CheckAclPermsDocContainerForm = () => {
       String(session.info.webId.split('profile')[0])
     ) {
       runNotification(
-        'Check permissions failed. Reason: User already have access to their own Documents container.',
+        'Check permissions failed. Reason: User already has access to their own Documents container.',
         5,
         state,
         dispatch
@@ -93,10 +99,6 @@ const CheckAclPermsDocContainerForm = () => {
     }
   };
 
-  const formRowStyle = {
-    margin: '20px 0'
-  };
-
   return (
     <FormSection
       title="Check Permission to Documents Container"
@@ -104,19 +106,30 @@ const CheckAclPermsDocContainerForm = () => {
       statusType="Permission status"
       defaultMessage="To be set..."
     >
-      <form onSubmit={handleAclPermission} autoComplete="off">
-        <div style={formRowStyle}>
-          <label htmlFor="set-acl-to">
-            Check permissions to username&apos;s Documents container:{' '}
-          </label>
-          <br />
-          <br />
-          <input id="set-acl-to" size="25" name="setAclTo" {...user} placeholder={selectedUser} />
-        </div>
-        <button disabled={state.processing} type="submit">
-          Check Permission
-        </button>
-      </form>
+      <Box display="flex" justifyContent="center" sx={{ minWidth: 120 }}>
+        <form onSubmit={handleAclPermission} autoComplete="off">
+          <FormControl fullWidth>
+            <TextField
+              id="set-acl-to"
+              name="setAclTo"
+              {...user}
+              placeholder={selectedUser}
+              label="Search username"
+              required
+            />
+            <br />
+            <Button
+              variant="contained"
+              fullWidth
+              disabled={state.processing}
+              type="submit"
+              color="primary"
+            >
+              Check Permission
+            </Button>
+          </FormControl>
+        </form>
+      </Box>
     </FormSection>
   );
 };

--- a/src/components/Form/CheckAclPermsDocContainerForm.jsx
+++ b/src/components/Form/CheckAclPermsDocContainerForm.jsx
@@ -108,7 +108,7 @@ const CheckAclPermsDocContainerForm = () => {
     >
       <Box display="flex" justifyContent="center">
         <form onSubmit={handleAclPermission} autoComplete="off">
-          <FormControl fullWidth>
+          <FormControl>
             <TextField
               id="set-acl-to"
               name="setAclTo"

--- a/src/components/Form/CheckAclPermsDocContainerForm.jsx
+++ b/src/components/Form/CheckAclPermsDocContainerForm.jsx
@@ -106,7 +106,7 @@ const CheckAclPermsDocContainerForm = () => {
       statusType="Permission status"
       defaultMessage="To be set..."
     >
-      <Box display="flex" justifyContent="center" sx={{ minWidth: 120 }}>
+      <Box display="flex" justifyContent="center">
         <form onSubmit={handleAclPermission} autoComplete="off">
           <FormControl fullWidth>
             <TextField
@@ -118,13 +118,7 @@ const CheckAclPermsDocContainerForm = () => {
               required
             />
             <br />
-            <Button
-              variant="contained"
-              fullWidth
-              disabled={state.processing}
-              type="submit"
-              color="primary"
-            >
+            <Button variant="contained" disabled={state.processing} type="submit" color="primary">
               Check Permission
             </Button>
           </FormControl>

--- a/src/components/Form/CrossPodQueryForm.jsx
+++ b/src/components/Form/CrossPodQueryForm.jsx
@@ -104,7 +104,7 @@ const CrossPodQueryForm = () => {
           <InputLabel id="cross-search-doctype">
             <em>Select Document Type</em>
           </InputLabel>
-          <FormControl>
+          <FormControl fullWidth>
             <DocumentSelection htmlId="cross-search-doctype" />
             <br />
             <Button variant="contained" disabled={state.processing} type="submit" color="primary">

--- a/src/components/Form/CrossPodQueryForm.jsx
+++ b/src/components/Form/CrossPodQueryForm.jsx
@@ -91,7 +91,7 @@ const CrossPodQueryForm = () => {
     >
       <Box display="flex" justifyContent="center">
         <form onSubmit={handleCrossPodQuery} autoComplete="off">
-          <FormControl fullWidth>
+          <FormControl>
             <TextField
               id="cross-search-doc"
               name="crossPodQuery"
@@ -104,7 +104,7 @@ const CrossPodQueryForm = () => {
           <InputLabel id="cross-search-doctype">
             <em>Select Document Type</em>
           </InputLabel>
-          <FormControl fullWidth>
+          <FormControl>
             <DocumentSelection htmlId="cross-search-doctype" />
             <br />
             <Button variant="contained" disabled={state.processing} type="submit" color="primary">

--- a/src/components/Form/CrossPodQueryForm.jsx
+++ b/src/components/Form/CrossPodQueryForm.jsx
@@ -89,7 +89,7 @@ const CrossPodQueryForm = () => {
       statusType="Search status"
       defaultMessage="To be searched..."
     >
-      <Box display="flex" justifyContent="center" sx={{ minWidth: 120 }}>
+      <Box display="flex" justifyContent="center">
         <form onSubmit={handleCrossPodQuery} autoComplete="off">
           <FormControl fullWidth>
             <TextField

--- a/src/components/Form/DeleteDocumentForm.jsx
+++ b/src/components/Form/DeleteDocumentForm.jsx
@@ -67,7 +67,7 @@ const DeleteDocumentForm = () => {
           <InputLabel id="delete-doctype">
             <em>Select Document Type</em>
           </InputLabel>
-          <FormControl fullWidth>
+          <FormControl>
             <DocumentSelection htmlId="delete-doctype" />
             <br />
             <Button variant="contained" disabled={state.processing} type="submit" color="primary">

--- a/src/components/Form/DeleteDocumentForm.jsx
+++ b/src/components/Form/DeleteDocumentForm.jsx
@@ -62,7 +62,7 @@ const DeleteDocumentForm = () => {
       statusType="Deletion status"
       defaultMessage="To be deleted..."
     >
-      <Box display="flex" justifyContent="center" sx={{ minWidth: 120 }}>
+      <Box display="flex" justifyContent="center">
         <form onSubmit={handleDeleteDocument}>
           <InputLabel id="delete-doctype">
             <em>Select Document Type</em>

--- a/src/components/Form/FetchDocumentForm.jsx
+++ b/src/components/Form/FetchDocumentForm.jsx
@@ -71,7 +71,7 @@ const FetchDocumentForm = () => {
           <InputLabel id="search-doctype">
             <em>Select Document Type</em>
           </InputLabel>
-          <FormControl fullWidth>
+          <FormControl>
             <DocumentSelection htmlId="search-doctype" />
             <br />
             <Button variant="contained" disabled={state.processing} type="submit" color="primary">

--- a/src/components/Form/FetchDocumentForm.jsx
+++ b/src/components/Form/FetchDocumentForm.jsx
@@ -66,7 +66,7 @@ const FetchDocumentForm = () => {
       statusType="Search status"
       defaultMessage="To be searched..."
     >
-      <Box display="flex" justifyContent="center" sx={{ minWidth: 120 }}>
+      <Box display="flex" justifyContent="center">
         <form onSubmit={handleGetDocumentSubmission}>
           <InputLabel id="search-doctype">
             <em>Select Document Type</em>

--- a/src/components/Form/FetchDocumentForm.jsx
+++ b/src/components/Form/FetchDocumentForm.jsx
@@ -71,7 +71,7 @@ const FetchDocumentForm = () => {
           <InputLabel id="search-doctype">
             <em>Select Document Type</em>
           </InputLabel>
-          <FormControl>
+          <FormControl fullWidth>
             <DocumentSelection htmlId="search-doctype" />
             <br />
             <Button variant="contained" disabled={state.processing} type="submit" color="primary">

--- a/src/components/Form/FormSection.jsx
+++ b/src/components/Form/FormSection.jsx
@@ -32,6 +32,7 @@ const FormSection = ({ title, state, statusType, defaultMessage, children }) => 
         justifyContent: 'center',
         alignItems: 'center'
       }}
+      
     >
       <Paper
         elevation={2}

--- a/src/components/Form/FormSection.jsx
+++ b/src/components/Form/FormSection.jsx
@@ -32,7 +32,6 @@ const FormSection = ({ title, state, statusType, defaultMessage, children }) => 
         justifyContent: 'center',
         alignItems: 'center'
       }}
-      
     >
       <Paper
         elevation={2}

--- a/src/components/Users/UserSection.jsx
+++ b/src/components/Users/UserSection.jsx
@@ -31,7 +31,6 @@ const UserSection = ({ loadingUsers, loadingActive }) => {
           <Box
             sx={{
               marginTop: 3,
-              minWidth: 120,
               display: 'flex',
               flexDirection: 'column'
             }}


### PR DESCRIPTION
Applying MUI to "Check Permission to Documents Container", based on styling previous components.

TODO: Consider whether to shorten response messages. Example: `Check permissions failed. Reason: User already has access to their own Documents container.` is possibly overly verbose. Potentially refactor into an alert/pop-up in a future pull request.

![2023-05-29](https://github.com/codeforpdx/PASS/assets/83156697/843b209b-41be-4157-abf8-d308214dd443)
