### PR TITLE
Issue 195/set file perms styling updates

### DIFF
--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -2,6 +2,17 @@
 import React, { useContext } from 'react';
 // Inrupt Library Imports
 import { useSession } from '@inrupt/solid-ui-react';
+// Material UI Imports
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormLabel from '@mui/material/FormLabel';
+import InputLabel from '@mui/material/InputLabel';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 // Utility Imports
 import { SOLID_IDENTITY_PROVIDER, runNotification, setDocAclPermission } from '../../utils';
 // Custom Hook Imports
@@ -98,10 +109,6 @@ const SetAclPermissionForm = () => {
     }
   };
 
-  const formRowStyle = {
-    margin: '20px 0'
-  };
-
   /* eslint-disable jsx-a11y/label-has-associated-control */
   return (
     <FormSection
@@ -110,34 +117,55 @@ const SetAclPermissionForm = () => {
       statusType="Permission status"
       defaultMessage="To be set..."
     >
-      <form onSubmit={handleAclPermission} autoComplete="off">
-        <div style={formRowStyle}>
-          <label htmlFor="set-acl-to">Set permissions to username: </label>
+      <Box display="flex" justifyContent="center">
+        <form onSubmit={handleAclPermission} autoComplete="off">
+          <FormControl>
+            <Typography htmlFor="set-acl-to">Set permissions to username:</Typography>
+            <TextField
+              id="set-acl-to"
+              name="setAclTo"
+              {...username}
+              placeholder={selectedUser}
+              label="Search username"
+              required
+            />
+          </FormControl>
+          <InputLabel id="set-acl-doctype">
+            <em>Select Document Type</em>
+          </InputLabel>
+          <FormControl fullWidth>
+            <DocumentSelection htmlId="set-acl-doctype" />
+          </FormControl>
           <br />
-          <br />
-          <input
-            id="set-acl-to"
-            size="25"
-            name="setAclTo"
-            {...username}
-            placeholder={selectedUser}
-          />
-        </div>
-        <div style={formRowStyle}>
-          <label htmlFor="set-acl-doctype">Select Document Type</label>
-          <DocumentSelection htmlId="set-acl-doctype" />{' '}
-        </div>
-        <div style={formRowStyle}>
-          <p>Select permission setting:</p>
-          <input type="radio" id="set-acl-perm-give" name="setAclPerms" value="Give" />
-          <label htmlFor="set-acl-perm-give">Give</label>
-          <input type="radio" id="set-acl-perm-revoke" name="setAclPerms" value="Revoke" />
-          <label htmlFor="set-acl-perm-revoke">Revoke</label>
-        </div>
-        <button disabled={state.processing} type="submit">
-          Set Permission
-        </button>
-      </form>
+          <FormControl fullWidth>
+            <FormLabel id="set-acl-perm-label">Select permission setting:</FormLabel>
+            <RadioGroup
+              row
+              aria-labelledby="set-acl-perm-label"
+              name="set-acl-perm"
+              sx={{ display: 'flex', justifyContent: 'center' }}
+            >
+              <FormControlLabel
+                value="Give"
+                control={<Radio />}
+                label="Give"
+                id="set-acl-perm-give"
+                name="setAclPerms"
+              />
+              <FormControlLabel
+                value="Revoke"
+                control={<Radio />}
+                label="Revoke"
+                id="set-acl-perm-revoke"
+                name="setAclPerms"
+              />
+            </RadioGroup>
+            <Button variant="contained" disabled={state.processing} type="submit" color="primary">
+              Set Permission
+            </Button>
+          </FormControl>
+        </form>
+      </Box>
     </FormSection>
   );
   /* eslint-enable jsx-a11y/label-has-associated-control */

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -130,7 +130,7 @@ const SetAclPermissionForm = () => {
               required
             />
           </FormControl>
-          <InputLabel id="set-acl-doctype">
+          <InputLabel htmlFor="set-acl-doctype">
             <em>Select Document Type</em>
           </InputLabel>
           <FormControl fullWidth>
@@ -138,7 +138,7 @@ const SetAclPermissionForm = () => {
           </FormControl>
           <br />
           <FormControl fullWidth>
-            <FormLabel id="set-acl-perm-label">Select permission setting:</FormLabel>
+            <FormLabel htmlFor="set-acl-perm-label">Select permission setting:</FormLabel>
             <RadioGroup
               row
               aria-labelledby="set-acl-perm-label"


### PR DESCRIPTION
Applying MUI to "Permission to Files" based on styling previous components.

Note that both `fullWidth`s on the `FormControl`s affect the layout.

Also note that `Select Document Type` remains unstyled, just as with previous merges. As it is an imported function that affects multiple components, it will be updated once those have had their initial styling. This is to limit the chance of errors and breaking functionality. Styling will ultimately look similar to the enter username function.

TODO: Consider whether to shorten response messages. Example: `Set permissions failed. Reason: Current user Pod cannot change container permissions to itself` is possibly overly verbose. Could potentially refactor into an alert/pop-up in a future pull request.

Closes #195 

![2023-06-03 (1)](https://github.com/codeforpdx/PASS/assets/83156697/05c12478-35ab-4e38-a249-580997c06dc7)
