### PR TITLE
Simplify Module Mocks in test cases

### DIFF
--- a/__mocks__/@inrupt/solid-client.js
+++ b/__mocks__/@inrupt/solid-client.js
@@ -1,0 +1,15 @@
+import { vi } from 'vitest'
+import { mockSolidDatasetFrom, addMockResourceAclTo } from '@inrupt/solid-client';
+
+export * from '@inrupt/solid-client';
+
+const exampleUrl = 'https://example.com'
+
+export const getPodUrlAll = vi.fn(() => Promise.resolve([]));
+export const saveAclFor = vi.fn((url) => Promise.resolve(
+  {
+    ...addMockResourceAclTo(mockSolidDatasetFrom(url)),
+    internal_accessTo: exampleUrl
+  }));
+export const saveSolidDatasetAt = vi.fn((url) => Promise.resolve(addMockResourceAclTo(mockSolidDatasetFrom(url))));
+export const getSolidDataset = vi.fn((url) => Promise.resolve(addMockResourceAclTo(mockSolidDatasetFrom(url))));

--- a/test/components/NavBar/OidcLoginComponent.test.jsx
+++ b/test/components/NavBar/OidcLoginComponent.test.jsx
@@ -4,6 +4,16 @@ import React from 'react';
 import { expect, it, vi, afterEach } from 'vitest';
 import OidcLoginComponent from '../../../src/components/NavBar/OidcLoginComponent';
 
+vi.mock('@inrupt/solid-ui-react', () => ({
+  LoginButton: ({ children, oidcIssuer, redirectUrl }) => (
+    <div>
+      {oidcIssuer}
+      {redirectUrl}
+      {children}
+    </div>
+  )
+}));
+
 afterEach(() => {
   vi.clearAllMocks();
   cleanup();
@@ -15,15 +25,6 @@ it('renders correctly', () => {
 });
 
 it('sets OIDC provider on login', async () => {
-  vi.mock('@inrupt/solid-ui-react', () => ({
-    LoginButton: ({ children, oidcIssuer, redirectUrl }) => (
-      <div>
-        {oidcIssuer}
-        {redirectUrl}
-        {children}
-      </div>
-    )
-  }));
   const user = userEvent.setup();
   const { container, getByLabelText } = render(<OidcLoginComponent />);
   const input = getByLabelText('OIDC Input Field').querySelector('input');

--- a/test/model-helpers/User.test.js
+++ b/test/model-helpers/User.test.js
@@ -1,32 +1,12 @@
-import {
-  getPodUrlAll,
-  mockSolidDatasetFrom,
-  saveSolidDatasetAt,
-  getSolidDataset,
-  setAgentResourceAccess,
-  setPublicResourceAccess,
-  buildThing,
-  createThing
-} from '@inrupt/solid-client';
+import * as solidClient from '@inrupt/solid-client';
 import { expect, vi, it, describe, afterEach, beforeEach } from 'vitest';
 import { createUser, parseUserFromThing, updateUserActivity } from '../../src/model-helpers/User';
 import { RDF_PREDICATES } from '../../src/constants';
 
-vi.mock('@inrupt/solid-client', async () => {
-  const actual = await vi.importActual('@inrupt/solid-client');
-  return {
-    ...actual,
-    getPodUrlAll: vi.fn(),
-    saveAclFor: vi.fn(),
-    saveSolidDatasetAt: vi.fn(() => Promise.resolve()),
-    getSolidDataset: vi.fn((url) => Promise.resolve(mockSolidDatasetFrom(url))),
-    setAgentResourceAccess: vi.fn(),
-    setAgentDefaultAccess: vi.fn(),
-    setPublicResourceAccess: vi.fn()
-  };
-});
+vi.mock('@inrupt/solid-client');
 
 const mockPodUrl = 'https://pod.example.com/';
+const { getPodUrlAll, saveSolidDatasetAt, getSolidDataset, buildThing, createThing } = solidClient;
 let session = {};
 
 describe('createUser', () => {
@@ -80,6 +60,8 @@ describe('updateUserActivity', () => {
     );
   });
   it('creates new activity dataset if it does not exist', async () => {
+    vi.spyOn(solidClient, 'setAgentResourceAccess');
+    vi.spyOn(solidClient, 'setPublicResourceAccess');
     getSolidDataset.mockRejectedValueOnce(Error('dataset does not exist'));
     await updateUserActivity(session, mockPodUrl);
     expect(saveSolidDatasetAt).toBeCalledWith(
@@ -87,8 +69,8 @@ describe('updateUserActivity', () => {
       expect.objectContaining({ type: 'Dataset' }),
       expect.objectContaining({ fetch: session.fetch })
     );
-    expect(setAgentResourceAccess).toBeCalled();
-    expect(setPublicResourceAccess).toBeCalled();
+    expect(solidClient.setAgentResourceAccess).toBeCalled();
+    expect(solidClient.setPublicResourceAccess).toBeCalled();
   });
 });
 

--- a/test/utils/FormSubmissionHelper.test.js
+++ b/test/utils/FormSubmissionHelper.test.js
@@ -7,6 +7,15 @@ import {
 } from '../../src/utils';
 import { INTERACTION_TYPES } from '../../src/constants';
 
+vi.mock('../../src/utils/network/session-core', () => ({
+  updateDocument: vi.fn(),
+  uploadDocument: vi.fn()
+}));
+
+vi.mock('../../src/utils/frontend/notification-helper', () => ({
+  default: vi.fn()
+}));
+
 describe('FormSubmissionHelper', async () => {
   const sessionMock = {};
   const clearInputFieldsMock = vi.fn();
@@ -22,13 +31,6 @@ describe('FormSubmissionHelper', async () => {
   });
 
   describe('Validations', () => {
-    vi.mock('../../src/utils/network/session-core', () => ({
-      updateDocument: vi.fn(),
-      uploadDocument: vi.fn()
-    }));
-    vi.mock('../../src/utils/frontend/notification-helper', () => ({
-      default: vi.fn()
-    }));
     const stateMock = {
       file: null
     };
@@ -56,13 +58,6 @@ describe('FormSubmissionHelper', async () => {
   });
 
   describe('Networking', () => {
-    vi.mock('../../src/utils/network/session-core', () => ({
-      updateDocument: vi.fn(),
-      uploadDocument: vi.fn()
-    }));
-    vi.mock('../../src/utils/frontend/notification-helper', () => ({
-      default: vi.fn()
-    }));
     const stateMock = {
       file: {
         name: 'mock'

--- a/test/utils/session-helper.test.js
+++ b/test/utils/session-helper.test.js
@@ -1,9 +1,3 @@
-import {
-  addMockResourceAclTo,
-  createAcl,
-  getResourceAcl,
-  mockSolidDatasetFrom
-} from '@inrupt/solid-client';
 import { expect, vi, it, describe } from 'vitest';
 import { createResourceTtlFile } from '../../src/utils/network/session-helper';
 import { INTERACTION_TYPES } from '../../src/constants';
@@ -26,64 +20,5 @@ describe('createResourceTtlFile', () => {
     const result = await createResourceTtlFile(fileObjectMock, documentUrl);
     expect(mockText).toBeCalledTimes(1);
     expect(Object.keys(result.predicates)).toHaveLength(7);
-  });
-});
-
-describe('setDocAclForUser', () => {
-  const documentUrl = 'https://example.com';
-  let generateType;
-  const mockPodResource = mockSolidDatasetFrom(documentUrl);
-  const mockPodResourceWithAcl = addMockResourceAclTo(mockPodResource);
-  const mockNewResourceAcl = createAcl(mockPodResource);
-  const mockResourceAcl = getResourceAcl(mockPodResourceWithAcl);
-
-  const getSolidDataset = vi.fn();
-  getSolidDataset.mockResolvedValue(mockPodResource);
-
-  const getSolidDatasetWithAcl = vi.fn();
-  getSolidDatasetWithAcl.mockResolvedValue(mockPodResourceWithAcl);
-
-  const mockCreateAcl = vi.fn();
-  mockCreateAcl.mockReturnValue(mockNewResourceAcl);
-
-  const mockGetResourceAcl = vi.fn();
-  mockGetResourceAcl.mockReturnValue(mockResourceAcl);
-
-  it("generate podResource and resourceAcl with generateType 'create'", async () => {
-    generateType = 'create';
-    const podResource =
-      generateType === 'create'
-        ? await getSolidDataset(documentUrl)
-        : await getSolidDatasetWithAcl(documentUrl);
-
-    expect(getSolidDataset).toHaveBeenCalledWith(documentUrl);
-    expect(podResource).toEqual(mockPodResource);
-
-    const resourceAcl =
-      generateType === 'create' ? mockCreateAcl(podResource) : mockGetResourceAcl(podResource);
-
-    expect(mockCreateAcl).toHaveBeenCalledWith(podResource);
-    expect(resourceAcl).toEqual(mockNewResourceAcl);
-  });
-
-  it("generate podResource and resourceAcl with generateType 'update'", async () => {
-    generateType = 'update';
-    const podResource =
-      generateType === 'create'
-        ? await getSolidDataset(documentUrl)
-        : await getSolidDatasetWithAcl(documentUrl);
-
-    await expect(Promise.resolve(podResource)).resolves.toBe(
-      generateType === 'create' ? mockPodResource : mockPodResourceWithAcl
-    );
-
-    expect(getSolidDatasetWithAcl).toHaveBeenCalledWith(documentUrl);
-    expect(podResource).toEqual(mockPodResourceWithAcl);
-
-    const resourceAcl =
-      generateType === 'create' ? mockCreateAcl(podResource) : mockGetResourceAcl(podResource);
-
-    expect(mockGetResourceAcl).toHaveBeenCalledWith(podResource);
-    expect(resourceAcl).toEqual(mockResourceAcl);
   });
 });


### PR DESCRIPTION
I've noticed that a lot of our test files are going to be mocking the same functions from inrupt's libraries. Vitest lets us add default module mocks in a top level `__mocks__` folder. I added a file for `solid-client` with some sensible defaults.

Now most unit tests can just put `vi.mock('@inrupt/solid-client');` at the top of their file, and have their tests behave a bit more cleanly.

The defaults are a bit simple for now. We may want to replace them with more complex implementations later. It's also probably best to limit these mocks to networking functions, since the network is hard to replicate in testing.