### PR TITLE
Issue 255 - Fixing update/upload new file bug

### DIFF
--- a/src/utils/frontend/FormSubmissionHelper.js
+++ b/src/utils/frontend/FormSubmissionHelper.js
@@ -48,11 +48,11 @@ const makeHandleFormSubmission =
       clearInputFields(event);
     } catch (e) {
       try {
-        runNotification('Updating on Pod...', 3, state, dispatch);
+        runNotification('Uploading new/updated content on Pod...', 3, state, dispatch);
 
         await updateDocument(session, uploadType, fileObject, crossPodUsername);
 
-        runNotification(`File updated on Pod.`, 5, state, dispatch);
+        runNotification(`File uploaded on Pod.`, 5, state, dispatch);
         clearInputFields(event);
       } catch (error) {
         runNotification(`Operation failed. Reason: ${error.message}`, 5, state, dispatch);

--- a/src/utils/network/storage-helper.js
+++ b/src/utils/network/storage-helper.js
@@ -1,0 +1,118 @@
+import {
+  buildThing,
+  getSolidDataset,
+  getThingAll,
+  saveSolidDatasetAt,
+  saveSolidDatasetInContainer,
+  setThing
+} from '@inrupt/solid-client';
+import { RDF_PREDICATES } from '../../constants';
+import { getUserSigningKey, signDocumentTtlFile } from '../cryptography/credentials-helper';
+import { createResourceTtlFile, placeFileInContainer } from './session-helper';
+
+/**
+ * @typedef {import("@inrupt/solid-client-authn-browser").Session} Session
+ */
+
+/**
+ * @typedef {import("../../typedefs").fileObjectType} fileObjectType
+ */
+
+/**
+ * Function that updates ttl file in Solid container for endDate (expiration
+ * date) and description while also including datetime of all instances when
+ * document was modified
+ *
+ * @memberof utils
+ * @function updateFile
+ * @param {Session} session - Solid's Session Object (see {@link Session})
+ * @param {URL} containerUrl - Url link to document container
+ * @param {boolean} verifyDocument - True if document submission should include
+ * user verification
+ * @param {fileObjectType} fileObject - Object containing information about file
+ * from form submission (see {@link fileObjectType})
+ * @returns {Promise} Promise - Perform an update to an existing document.ttl by
+ * setting a new expiration date, description, and date modified
+ */
+
+export const updateFile = async (session, containerUrl, verifyDocument, fileObject) => {
+  let solidDataset = await getSolidDataset(`${containerUrl}document.ttl`, { fetch: session.fetch });
+  const ttlFileThingAll = getThingAll(solidDataset);
+  const fileName = fileObject.file.name;
+  let ttlFileThing = ttlFileThingAll.find(
+    (item) =>
+      item.predicates[RDF_PREDICATES.url]?.namedNodes[0] ===
+      `${containerUrl}${fileName.replace("'", '').replace(' ', '%20')}`
+  );
+
+  ttlFileThing = buildThing(ttlFileThing)
+    .setStringNoLocale(RDF_PREDICATES.endDate, fileObject.date)
+    .setStringNoLocale(RDF_PREDICATES.description, fileObject.description)
+    .setDatetime(RDF_PREDICATES.dateModified, new Date())
+    .build();
+  solidDataset = setThing(solidDataset, ttlFileThing);
+
+  // TODO: would need to think about how to implement new signature.ttl if file is updated
+  // since old signature.ttl will no longer be valid
+  await saveSolidDatasetAt(`${containerUrl}document.ttl`, solidDataset, { fetch: session.fetch });
+
+  const signingKey = verifyDocument ? await getUserSigningKey(session) : null;
+  const signatureDataset = signingKey
+    ? await signDocumentTtlFile(signingKey, solidDataset, session, containerUrl)
+    : null;
+
+  if (signatureDataset) {
+    await saveSolidDatasetInContainer(containerUrl, signatureDataset, {
+      slugSuggestion: 'signature.ttl',
+      contentType: 'text/turtle',
+      fetch: session.fetch
+    });
+  }
+};
+
+/**
+ * Function that uploads a new file to Pod and appends ttl file in Solid container
+ * for endDate (expiration date) and description
+ *
+ * @memberof utils
+ * @function uploadNewFile
+ * @param {Session} session - Solid's Session Object (see {@link Session})
+ * @param {URL} containerUrl - Url link to document container
+ * @param {boolean} verifyDocument - True if document submission should include
+ * user verification
+ * @param {fileObjectType} fileObject - Object containing information about file
+ * from form submission (see {@link fileObjectType})
+ * @returns {Promise} Promise - Perform an update to an existing document.ttl by
+ * setting a new expiration date, description, and date modified
+ */
+
+export const uploadNewFile = async (session, containerUrl, verifyDocument, fileObject) => {
+  await placeFileInContainer(session, fileObject, containerUrl);
+
+  let solidDataset = await getSolidDataset(`${containerUrl}document.ttl`, { fetch: session.fetch });
+  const ttlFileLength = getThingAll(solidDataset).length;
+
+  const fileName = fileObject.file.name;
+  const newTTLFileThing = await createResourceTtlFile(
+    fileObject,
+    `${containerUrl}${fileName.replace("'", '').replace(' ', '%20')}`,
+    `document${ttlFileLength - 1}` // will need a better way to make unique name after initial document upload
+  );
+
+  solidDataset = setThing(solidDataset, newTTLFileThing);
+
+  await saveSolidDatasetAt(`${containerUrl}document.ttl`, solidDataset, { fetch: session.fetch });
+
+  const signingKey = verifyDocument ? await getUserSigningKey(session) : null;
+  const signatureDataset = signingKey
+    ? await signDocumentTtlFile(signingKey, solidDataset, session, containerUrl)
+    : null;
+
+  if (signatureDataset) {
+    await saveSolidDatasetInContainer(containerUrl, signatureDataset, {
+      slugSuggestion: 'signature.ttl',
+      contentType: 'text/turtle',
+      fetch: session.fetch
+    });
+  }
+};

--- a/test/utils/session-helper.test.js
+++ b/test/utils/session-helper.test.js
@@ -34,7 +34,7 @@ describe('createResourceTtlFile', () => {
       }
     };
 
-    const result = await createResourceTtlFile(fileObjectMock, documentUrl);
+    const result = await createResourceTtlFile(fileObjectMock, documentUrl, 'document');
     expect(mockText).toBeCalledTimes(1);
     expect(Object.keys(result.predicates)).toHaveLength(7);
   });


### PR DESCRIPTION
Relevant to PR #249 where the full refactor to this functionality will take place. Changes here will ultimately be changed to the version implemented there. The old implementation of upload new file/update file has been buggy for a while, but has not been revisited. Now that we're starting to refactor session-core with uploadDocument being one of the targets, it's a good time to make sure the functionality under the hood is implemented correctly so that it could be used as the starting point for optimizations and subsequent refactors.

This PR fixes that issue by implementing what originally intended for that flow (see [#249 (comment)](https://github.com/codeforpdx/PASS/pull/249#discussion_r1230327778) for context).

First file upload works like before since the container initially starts empty, so `updateDocument` was not called when `uploadDocument` is triggered. A new Thing has been generated for document.ttl at `#document`. This Thing will simply be a reference to itself rather than the document files like with container.ttl. All subsequent Things will be named something else like `#document1` or `#document2`, etc. But a more robust naming scheme would need to be flushed out in case we're going to keep this feature during the refactor in PR #249.

<img width="1440" alt="Screen Shot 2023-06-15 at 0 03 30" src="https://github.com/codeforpdx/PASS/assets/14917816/0c696c68-8ec3-404c-b26c-929646680ca1">

A second file upload triggers `updateDocument` since container is no longer empty. But unlike when the container is empty, all subsequent calls for `updateDocument` triggers confirmation window which enables the user to cancel if desired.

Assuming the user continues and not cancel the operation, since the file name for the second upload is different, `uploadNewFile` within `updateDocument` is triggered instead of `updateFile`. Compared to `uploadDocument` which generates a new `document.ttl` after uploading a file, `uploadNewFile` instead appends to the existing `document.ttl`.

<img width="1440" alt="Screen Shot 2023-06-15 at 0 05 18" src="https://github.com/codeforpdx/PASS/assets/14917816/0b330587-1933-47cf-8475-a852bdb62327">

Uploading an updated version of the first file will trigger `updateFile` when uploading and the old file will be overwritten by the new one. The Thing related to the first file will also be updated based on what was filled out and a new dateModified field is included to show that it has been updated.

<img width="1440" alt="Screen Shot 2023-06-15 at 0 11 02" src="https://github.com/codeforpdx/PASS/assets/14917816/524582e8-1d22-4472-9147-49aafa46f405">

<img width="1440" alt="Screen Shot 2023-06-15 at 0 16 46" src="https://github.com/codeforpdx/PASS/assets/14917816/91e4acfd-38da-4179-b65b-9677fc0224de">

Other changes include edits to the message for new file upload and file updates so that the message is now "Uploading new/updated content on Pod..." in `FormSubmissionHelper` and a new parameter for `createResourceTtlFile `so that a unique name could be used for the Thing being generated instead of being hard-coded to 'document'.