### PR TITLE
Issue 267/loading documents spinner

### DIFF
--- a/src/components/Documents/DocumentTable.jsx
+++ b/src/components/Documents/DocumentTable.jsx
@@ -1,15 +1,17 @@
 // React Imports
 import React, { useContext } from 'react';
-// Inrupt Library Imports
+// Material UI Imports
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
+// Component Imports
 import { DocumentListContext } from '../../contexts';
 import { StyledTableCell } from '../Table/TableStyles';
 import DocumentTableRow from './DocumentTableRow';
+import Loading from '../Notification/Loading';
 
 /**
  * DocumentTable Component - Displays a table containing all documents accessible in a pod
@@ -30,7 +32,9 @@ const DocumentTable = () => {
     'Delete'
   ];
 
-  return loadingDocuments ? null : (
+  return loadingDocuments ? (
+    <Loading loadingItem="documents" />
+  ) : (
     <TableContainer component={Paper} sx={{ marginTop: '3rem', marginBottom: '3rem' }}>
       <Table aria-label="Documents Table">
         <TableHead>

--- a/src/components/Notification/Loading.jsx
+++ b/src/components/Notification/Loading.jsx
@@ -1,0 +1,40 @@
+// React Imports
+import React from 'react';
+// Material UI Imports
+import Box from '@mui/material/Box';
+import LinearProgress from '@mui/material/LinearProgress';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+
+/**
+ * Loading Component - Displays a div containing title of what is being
+ * loaded and an animated loading progress bar. Must pass loadingItem attribute
+ * as a string of the "title" of what is being loaded.
+ *
+ * @memberof Notification
+ * @name Loading
+ * @returns {React.ReactElement} a div of what is currently loading
+ */
+
+const Loading = ({ loadingItem }) => (
+  <Box
+    sx={{
+      marginTop: 18,
+      marginBottom: 18,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      textAlign: 'center',
+      padding: '20px'
+    }}
+  >
+    <Paper elevation={2} sx={{ display: 'inline-block', mx: '2px', padding: '20px' }}>
+      <Typography variant="h5" component="h2" mb={2} align="center">
+        Loading {loadingItem}...
+      </Typography>
+      <LinearProgress />
+    </Paper>
+  </Box>
+);
+
+export default Loading;

--- a/src/routes/Clients.jsx
+++ b/src/routes/Clients.jsx
@@ -4,15 +4,12 @@ import React, { useState, useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 // Material UI Imports
 import AddIcon from '@mui/icons-material/Add';
-import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
-import LinearProgress from '@mui/material/LinearProgress';
-import Paper from '@mui/material/Paper';
-import Typography from '@mui/material/Typography';
 // Component Imports
 import AddClientModal from '../components/Clients/AddClientModal';
 import ClientList from '../components/Clients/ClientList';
+import Loading from '../components/Notification/Loading';
 import { UserListContext } from '../contexts';
 
 /**
@@ -33,24 +30,7 @@ const Clients = () => {
 
   return loadingUsers ? (
     <Container>
-      <Box
-        sx={{
-          marginTop: 18,
-          marginBottom: 18,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          textAlign: 'center',
-          padding: '20px'
-        }}
-      >
-        <Paper elevation={2} sx={{ display: 'inline-block', mx: '2px', padding: '20px' }}>
-          <Typography variant="h5" component="h2" mb={2} align="center">
-            Loading clients...
-          </Typography>
-          <LinearProgress />
-        </Paper>
-      </Box>
+      <Loading loadingItem="clients" />
     </Container>
   ) : (
     <Container>


### PR DESCRIPTION
# This PR closes #267 

This PR:
1. Pulls the "loading clients" feature out of `Clients` and into it's own component `Loading` in the `Notifications` folder.
2. Imports that into `Clients` to display when the client table is loading
3. Imports that into `Forms` to display it when the document table is loading

---

### To successfully use `Loading`:

Make sure to use the `loadingItem` prop with a string.   i.e. `<Loading loadingItem="clients" />` 

