### PR TITLE
Issue 266/placeholder when no documents

### DIFF
--- a/src/components/Clients/ClientList.jsx
+++ b/src/components/Clients/ClientList.jsx
@@ -27,6 +27,7 @@ const ClientList = () => {
     <EmptyListNotification type="clients" />
   );
 
+  // MAIN RETURN OF COMPONENT
   return loadingUsers ? <LoadingAnimation loadingItem="clients" /> : determineClientListTable;
 };
 

--- a/src/components/Clients/ClientList.jsx
+++ b/src/components/Clients/ClientList.jsx
@@ -3,6 +3,7 @@ import React, { useContext } from 'react';
 // Material UI Imports
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
+import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 // Context Imports
 import { UserListContext } from '../../contexts';
@@ -25,18 +26,15 @@ const ClientList = () => {
     <ClientListTable statusType="Status" defaultMessage="No actions performed" />
   ) : (
     // render if no clients
-    <Container>
-      <Box
-        sx={{
-          marginTop: 3,
-          minWidth: 120,
-          display: 'flex',
-          flexDirection: 'column'
-        }}
-      >
-        <Typography variant="h6" component="h2" mb={2} align="center" color="secondary">
-          Add clients to your list
-        </Typography>
+    <Container sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+      <Box sx={{ marginTop: '3rem', marginBottom: '3rem' }}>
+        <Paper elevation={2} sx={{ display: 'inline-block', mx: '2px', padding: '20px' }}>
+          <Typography variant="h6" component="h2" mb={2} align="center" color="secondary">
+            No clients found.
+            <br />
+            Added clients will be listed here.
+          </Typography>
+        </Paper>
       </Box>
     </Container>
   );

--- a/src/components/Clients/ClientList.jsx
+++ b/src/components/Clients/ClientList.jsx
@@ -4,8 +4,7 @@ import React, { useContext } from 'react';
 import { UserListContext } from '../../contexts';
 // Component Imports
 import ClientListTable from './ClientListTable';
-import EmptyListNotification from '../Notification/EmptyListNotification';
-import LoadingAnimation from '../Notification/LoadingAnimation';
+import { EmptyListNotification, LoadingAnimation } from '../Notification';
 
 /**
  * ClientList Component - Component that generates ClientList section for PASS

--- a/src/components/Clients/ClientList.jsx
+++ b/src/components/Clients/ClientList.jsx
@@ -1,14 +1,11 @@
 // React Imports
 import React, { useContext } from 'react';
-// Material UI Imports
-import Box from '@mui/material/Box';
-import Container from '@mui/material/Container';
-import Paper from '@mui/material/Paper';
-import Typography from '@mui/material/Typography';
 // Context Imports
 import { UserListContext } from '../../contexts';
 // Component Imports
 import ClientListTable from './ClientListTable';
+import EmptyListNotification from '../Notification/EmptyListNotification';
+import LoadingAnimation from '../Notification/LoadingAnimation';
 
 /**
  * ClientList Component - Component that generates ClientList section for PASS
@@ -20,24 +17,17 @@ import ClientListTable from './ClientListTable';
 
 const ClientList = () => {
   const { userListObject } = useContext(UserListContext);
+  const { loadingUsers } = useContext(UserListContext);
 
-  return userListObject.userList?.length ? (
+  const determineClientListTable = userListObject.userList?.length ? (
     // render if clients
     <ClientListTable statusType="Status" defaultMessage="No actions performed" />
   ) : (
     // render if no clients
-    <Container sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-      <Box sx={{ marginTop: '3rem', marginBottom: '3rem' }}>
-        <Paper elevation={2} sx={{ display: 'inline-block', mx: '2px', padding: '20px' }}>
-          <Typography variant="h6" component="h2" mb={2} align="center" color="secondary">
-            No clients found.
-            <br />
-            Added clients will be listed here.
-          </Typography>
-        </Paper>
-      </Box>
-    </Container>
+    <EmptyListNotification type="clients" />
   );
+
+  return loadingUsers ? <LoadingAnimation loadingItem="clients" /> : determineClientListTable;
 };
 
 export default ClientList;

--- a/src/components/Documents/DocumentTable.jsx
+++ b/src/components/Documents/DocumentTable.jsx
@@ -1,7 +1,6 @@
 // React Imports
 import React, { useContext } from 'react';
 // Material UI Imports
-import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
 import Table from '@mui/material/Table';
@@ -9,11 +8,11 @@ import TableBody from '@mui/material/TableBody';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import Typography from '@mui/material/Typography';
 // Component Imports
 import { DocumentListContext } from '../../contexts';
 import { StyledTableCell } from '../Table/TableStyles';
 import DocumentTableRow from './DocumentTableRow';
+import EmptyListNotification from '../Notification/EmptyListNotification';
 import LoadingAnimation from '../Notification/LoadingAnimation';
 
 /**
@@ -23,6 +22,7 @@ import LoadingAnimation from '../Notification/LoadingAnimation';
  * @name DocumentTable
  * @returns {React.ReactElement} a table of documents
  */
+
 const DocumentTable = () => {
   const { documentListObject, loadingDocuments } = useContext(DocumentListContext);
   const columnTitlesArray = [
@@ -59,20 +59,10 @@ const DocumentTable = () => {
     </Container>
   ) : (
     // render if no documents
-    <Container sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-      <Box sx={{ marginTop: '3rem', marginBottom: '3rem' }}>
-        <Paper elevation={2} sx={{ display: 'inline-block', mx: '2px', padding: '20px' }}>
-          <Typography variant="h6" component="h2" mb={2} align="center" color="secondary">
-            No documents found.
-            <br />
-            Uploaded documents will be listed here.
-          </Typography>
-        </Paper>
-      </Box>
-    </Container>
+    <EmptyListNotification type="documents" />
   );
 
-  // MAIN RETURN OF FUNCTION
+  // MAIN RETURN OF COMPONENT
   return loadingDocuments ? <LoadingAnimation loadingItem="documents" /> : determineDocumentsTable;
 };
 

--- a/src/components/Documents/DocumentTable.jsx
+++ b/src/components/Documents/DocumentTable.jsx
@@ -3,13 +3,13 @@ import React, { useContext } from 'react';
 // Material UI Imports
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
+import Paper from '@mui/material/Paper';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
-import Paper from '@mui/material/Paper';
 // Component Imports
 import { DocumentListContext } from '../../contexts';
 import { StyledTableCell } from '../Table/TableStyles';
@@ -37,38 +37,37 @@ const DocumentTable = () => {
 
   const determineDocumentsTable = documentListObject?.docList?.length ? (
     // render if documents
-    <TableContainer component={Paper} sx={{ marginTop: '3rem', marginBottom: '3rem' }}>
-      <Table aria-label="Documents Table">
-        <TableHead>
-          <TableRow>
-            {columnTitlesArray.map((columnTitle) => (
-              <StyledTableCell key={columnTitle} align="center">
-                {columnTitle}
-              </StyledTableCell>
+    <Container>
+      <TableContainer component={Paper} sx={{ marginTop: '3rem', marginBottom: '3rem' }}>
+        <Table aria-label="Documents Table">
+          <TableHead>
+            <TableRow>
+              {columnTitlesArray.map((columnTitle) => (
+                <StyledTableCell key={columnTitle} align="center">
+                  {columnTitle}
+                </StyledTableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {documentListObject?.docList.map((document) => (
+              <DocumentTableRow key={document.name} document={document} />
             ))}
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {documentListObject?.docList.map((document) => (
-            <DocumentTableRow key={document.name} document={document} />
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Container>
   ) : (
     // render if no documents
-    <Container>
-      <Box
-        sx={{
-          marginTop: 3,
-          minWidth: 120,
-          display: 'flex',
-          flexDirection: 'column'
-        }}
-      >
-        <Typography variant="h6" component="h2" mb={2} align="center" color="secondary">
-          Upload documents to your list
-        </Typography>
+    <Container sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+      <Box sx={{ marginTop: '3rem', marginBottom: '3rem' }}>
+        <Paper elevation={2} sx={{ display: 'inline-block', mx: '2px', padding: '20px' }}>
+          <Typography variant="h6" component="h2" mb={2} align="center" color="secondary">
+            No documents found.
+            <br />
+            Uploaded documents will be listed here.
+          </Typography>
+        </Paper>
       </Box>
     </Container>
   );

--- a/src/components/Documents/DocumentTable.jsx
+++ b/src/components/Documents/DocumentTable.jsx
@@ -12,8 +12,7 @@ import TableRow from '@mui/material/TableRow';
 import { DocumentListContext } from '../../contexts';
 import { StyledTableCell } from '../Table/TableStyles';
 import DocumentTableRow from './DocumentTableRow';
-import EmptyListNotification from '../Notification/EmptyListNotification';
-import LoadingAnimation from '../Notification/LoadingAnimation';
+import { EmptyListNotification, LoadingAnimation } from '../Notification';
 
 /**
  * DocumentTable Component - Displays a table containing all documents accessible in a pod

--- a/src/components/Documents/DocumentTable.jsx
+++ b/src/components/Documents/DocumentTable.jsx
@@ -11,7 +11,7 @@ import Paper from '@mui/material/Paper';
 import { DocumentListContext } from '../../contexts';
 import { StyledTableCell } from '../Table/TableStyles';
 import DocumentTableRow from './DocumentTableRow';
-import Loading from '../Notification/Loading';
+import LoadingAnimation from '../Notification/LoadingAnimation';
 
 /**
  * DocumentTable Component - Displays a table containing all documents accessible in a pod
@@ -33,7 +33,7 @@ const DocumentTable = () => {
   ];
 
   return loadingDocuments ? (
-    <Loading loadingItem="documents" />
+    <LoadingAnimation loadingItem="documents" />
   ) : (
     <TableContainer component={Paper} sx={{ marginTop: '3rem', marginBottom: '3rem' }}>
       <Table aria-label="Documents Table">

--- a/src/components/Documents/DocumentTable.jsx
+++ b/src/components/Documents/DocumentTable.jsx
@@ -1,11 +1,14 @@
 // React Imports
 import React, { useContext } from 'react';
 // Material UI Imports
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
 // Component Imports
 import { DocumentListContext } from '../../contexts';
@@ -32,9 +35,8 @@ const DocumentTable = () => {
     'Delete'
   ];
 
-  return loadingDocuments ? (
-    <LoadingAnimation loadingItem="documents" />
-  ) : (
+  const determineDocumentsTable = documentListObject?.docList?.length ? (
+    // render if documents
     <TableContainer component={Paper} sx={{ marginTop: '3rem', marginBottom: '3rem' }}>
       <Table aria-label="Documents Table">
         <TableHead>
@@ -53,7 +55,26 @@ const DocumentTable = () => {
         </TableBody>
       </Table>
     </TableContainer>
+  ) : (
+    // render if no documents
+    <Container>
+      <Box
+        sx={{
+          marginTop: 3,
+          minWidth: 120,
+          display: 'flex',
+          flexDirection: 'column'
+        }}
+      >
+        <Typography variant="h6" component="h2" mb={2} align="center" color="secondary">
+          Upload documents to your list
+        </Typography>
+      </Box>
+    </Container>
   );
+
+  // MAIN RETURN OF FUNCTION
+  return loadingDocuments ? <LoadingAnimation loadingItem="documents" /> : determineDocumentsTable;
 };
 
 export default DocumentTable;

--- a/src/components/Documents/DocumentTableRow.jsx
+++ b/src/components/Documents/DocumentTableRow.jsx
@@ -53,7 +53,7 @@ const DocumentTableRow = ({ document }) => {
       <StyledTableCell align="center">
         {uploadDate ? uploadDate.toDateString() : ''}
       </StyledTableCell>
-      <StyledTableCell align="center">{endDate ? endDate.toDateString() : ''}</StyledTableCell>
+      <StyledTableCell align="center">{endDate ? endDate.toDateString() : 'N/A'}</StyledTableCell>
       <StyledTableCell align="center">
         <IconButton type="button" onClick={() => handleShowDocumentLocal(fileUrl)}>
           <FileOpenIcon />

--- a/src/components/Notification/EmptyListNotification.jsx
+++ b/src/components/Notification/EmptyListNotification.jsx
@@ -1,0 +1,39 @@
+// React Imports
+import React from 'react';
+// Material UI Imports
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+
+/**
+ * EmptyListNotification Component - Component
+ * that displays a message to the user letting
+ * them know their data list is empty, and thus
+ * nothing is being rendered.
+ *
+ * @memberof Notification
+ * @name EmptyListNotification
+ */
+
+const EmptyListNotification = ({ type }) => {
+  const str1 = `No ${type} found.`;
+  const str2 = type === 'clients' ? 'Added' : 'Uploaded';
+  const str3 = `${str2} ${type} will be listed here.`;
+
+  return (
+    <Container sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+      <Box sx={{ my: '3rem' }}>
+        <Paper elevation={2} sx={{ display: 'inline-block', mx: '2px', padding: '20px' }}>
+          <Typography variant="h6" component="h2" mb={2} align="center" color="secondary">
+            {str1}
+            <br />
+            {str3}
+          </Typography>
+        </Paper>
+      </Box>
+    </Container>
+  );
+};
+
+export default EmptyListNotification;

--- a/src/components/Notification/LoadingAnimation.jsx
+++ b/src/components/Notification/LoadingAnimation.jsx
@@ -19,8 +19,7 @@ import Typography from '@mui/material/Typography';
 const LoadingAnimation = ({ loadingItem }) => (
   <Box
     sx={{
-      marginTop: 18,
-      marginBottom: 18,
+      my: '3rem',
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',

--- a/src/components/Notification/LoadingAnimation.jsx
+++ b/src/components/Notification/LoadingAnimation.jsx
@@ -7,16 +7,16 @@ import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 
 /**
- * Loading Component - Displays a div containing title of what is being
+ * LoadingAnimation Component - Displays a div containing title of what is being
  * loaded and an animated loading progress bar. Must pass loadingItem attribute
  * as a string of the "title" of what is being loaded.
  *
  * @memberof Notification
- * @name Loading
+ * @name LoadingAnimation
  * @returns {React.ReactElement} a div of what is currently loading
  */
 
-const Loading = ({ loadingItem }) => (
+const LoadingAnimation = ({ loadingItem }) => (
   <Box
     sx={{
       marginTop: 18,
@@ -37,4 +37,4 @@ const Loading = ({ loadingItem }) => (
   </Box>
 );
 
-export default Loading;
+export default LoadingAnimation;

--- a/src/components/Notification/index.js
+++ b/src/components/Notification/index.js
@@ -1,6 +1,8 @@
+import EmptyListNotification from './EmptyListNotification';
+import InactivityMessage from './InactivityMessage';
+import LoadingAnimation from './LoadingAnimation';
 import StatusMessage from './StatusMessage';
 import StatusNotification from './StatusNotification';
-import InactivityMessage from './InactivityMessage';
 
 /**
  * Components and functions related to Status Notification functionality within
@@ -9,4 +11,10 @@ import InactivityMessage from './InactivityMessage';
  * @namespace Notifications
  */
 
-export { StatusMessage, StatusNotification, InactivityMessage };
+export {
+  EmptyListNotification,
+  InactivityMessage,
+  LoadingAnimation,
+  StatusMessage,
+  StatusNotification
+};

--- a/src/routes/Clients.jsx
+++ b/src/routes/Clients.jsx
@@ -9,7 +9,7 @@ import Container from '@mui/material/Container';
 // Component Imports
 import AddClientModal from '../components/Clients/AddClientModal';
 import ClientList from '../components/Clients/ClientList';
-import Loading from '../components/Notification/Loading';
+import LoadingAnimation from '../components/Notification/LoadingAnimation';
 import { UserListContext } from '../contexts';
 
 /**
@@ -30,7 +30,7 @@ const Clients = () => {
 
   return loadingUsers ? (
     <Container>
-      <Loading loadingItem="clients" />
+      <LoadingAnimation loadingItem="clients" />
     </Container>
   ) : (
     <Container>

--- a/src/routes/Clients.jsx
+++ b/src/routes/Clients.jsx
@@ -1,5 +1,5 @@
 // React Imports
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 // React Router Imports
 import { useLocation } from 'react-router-dom';
 // Material UI Imports
@@ -9,8 +9,6 @@ import Container from '@mui/material/Container';
 // Component Imports
 import AddClientModal from '../components/Clients/AddClientModal';
 import ClientList from '../components/Clients/ClientList';
-import LoadingAnimation from '../components/Notification/LoadingAnimation';
-import { UserListContext } from '../contexts';
 
 /**
  * Clients Component - Component that generates Clients Page for PASS
@@ -23,16 +21,10 @@ const Clients = () => {
   // state for AddClientModal component
   const [showModal, setShowModal] = useState(false);
 
-  const { loadingUsers } = useContext(UserListContext);
-
   const location = useLocation();
   localStorage.setItem('restorePath', location.pathname);
 
-  return loadingUsers ? (
-    <Container>
-      <LoadingAnimation loadingItem="clients" />
-    </Container>
-  ) : (
+  return (
     <Container>
       <Button
         variant="contained"

--- a/src/routes/Documents.jsx
+++ b/src/routes/Documents.jsx
@@ -2,7 +2,6 @@
 import React, { useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 // Material UI Imports
-import Container from '@mui/material/Container';
 import Button from '@mui/material/Button';
 import Remove from '@mui/icons-material/Remove';
 import Box from '@mui/material/Box';
@@ -59,9 +58,7 @@ const Documents = () => {
       )}
 
       <UploadDocumentForm />
-      <Container>
-        <DocumentTable />
-      </Container>
+      <DocumentTable />
       <SetAclPermsDocContainerForm />
       <SetAclPermissionForm />
     </Box>


### PR DESCRIPTION
# This PR closes #266 

This PR:
1. Pulls the "Add clients to view them here" feature out and into it's own reusable component `EmptyListNotification` in the `Notifications` folder.
2. Imports that into `Documents` to display it when the document list table is empty
3. Imports that into `Clients` to display when the client list table is empty
4. Renames the new `Loading` component to `LoadingAnimation`
5. Moves where the `LoadingAnimation` component is in relation to `Clients` page - making this animation only take place of what is currently loading, not the full page.

---

### To successfully use `EmptyListNotification`:

Make sure to use the `type` prop with a string.   i.e. `<EmptyListNotification type="clients" />` 

---

<img width="618" alt="Screenshot 2023-06-21 at 4 21 22 PM" src="https://github.com/codeforpdx/PASS/assets/71395931/95c80010-ff75-471f-9ecb-9584256d5834">
<img width="1420" alt="Screenshot 2023-06-21 at 4 44 32 PM" src="https://github.com/codeforpdx/PASS/assets/71395931/c2726faf-dff2-447f-9f61-45dfc76adaa7">
