### PR TITLE
Disable Upload button on certain conditions

### DIFF
--- a/src/components/Form/UploadDocumentForm.jsx
+++ b/src/components/Form/UploadDocumentForm.jsx
@@ -36,6 +36,7 @@ const UploadDocumentForm = () => {
   const [verifyFile, setVerifyFile] = useState(false);
   const [file, setFile] = useState(null);
   const [inputKey, setInputKey] = useState(false);
+  const [uploading, setUploading] = useState(false);
   const { addDocument, replaceDocument } = useContext(DocumentListContext);
 
   const handleDocType = (event) => {
@@ -56,20 +57,13 @@ const UploadDocumentForm = () => {
   const handleDocUpload = async (e) => {
     e.preventDefault();
 
-    if (!docType) {
-      runNotification('Upload failed. Reason: No document type selected.', 5, state, dispatch);
-      setTimeout(() => {
-        dispatch({ type: 'CLEAR_PROCESSING' });
-      }, 3000);
-      return;
-    }
-
     const fileDesc = {
       name: file.name,
       type: docType,
       date: expireDate,
       description: docDescription
     };
+    setUploading(true);
     runNotification(`Uploading "${file.name}" to Solid...`, 3, state, dispatch);
 
     try {
@@ -91,6 +85,7 @@ const UploadDocumentForm = () => {
       }
     } finally {
       clearInputFields();
+      setUploading(false);
     }
   };
 
@@ -171,7 +166,7 @@ const UploadDocumentForm = () => {
           </FormControl>
           <br />
           <FormControl fullWidth>
-            <Button variant="contained" disabled={state.processing} type="submit" color="primary">
+            <Button variant="contained" disabled={uploading || !file} type="submit" color="primary">
               Upload file
             </Button>
           </FormControl>

--- a/src/components/Form/UploadDocumentForm.jsx
+++ b/src/components/Form/UploadDocumentForm.jsx
@@ -36,7 +36,6 @@ const UploadDocumentForm = () => {
   const [verifyFile, setVerifyFile] = useState(false);
   const [file, setFile] = useState(null);
   const [inputKey, setInputKey] = useState(false);
-  const [uploading, setUploading] = useState(false);
   const { addDocument, replaceDocument } = useContext(DocumentListContext);
 
   const handleDocType = (event) => {
@@ -63,7 +62,7 @@ const UploadDocumentForm = () => {
       date: expireDate,
       description: docDescription
     };
-    setUploading(true);
+    dispatch({ type: 'SET_PROCESSING' });
     runNotification(`Uploading "${file.name}" to Solid...`, 3, state, dispatch);
 
     try {
@@ -85,7 +84,7 @@ const UploadDocumentForm = () => {
       }
     } finally {
       clearInputFields();
-      setUploading(false);
+      dispatch({ type: 'CLEAR_PROCESSING' });
     }
   };
 
@@ -166,7 +165,12 @@ const UploadDocumentForm = () => {
           </FormControl>
           <br />
           <FormControl fullWidth>
-            <Button variant="contained" disabled={uploading || !file} type="submit" color="primary">
+            <Button
+              variant="contained"
+              disabled={state.processing || !file}
+              type="submit"
+              color="primary"
+            >
               Upload file
             </Button>
           </FormControl>


### PR DESCRIPTION
Disable upload button in the upload documents form if:

- There is no document to upload
- A document is currently being uploaded

This also means we can remove a notification about no document existing.