### PR TITLE
Issue 223/delete client modal scott

### DIFF
--- a/src/components/Clients/AddClientModal.jsx
+++ b/src/components/Clients/AddClientModal.jsx
@@ -35,7 +35,7 @@ const renderWebId = (username) => {
   return `${template[0]}${username}${template[1]}`;
 };
 
-const AddClientModal = ({ showModal, setShowModal }) => {
+const AddClientModal = ({ showAddClientModal, setShowAddClientModal }) => {
   const { session } = useSession();
   const { state, dispatch } = useStatusNotification();
   const [userGivenName, setUserGivenName] = useState('');
@@ -125,12 +125,17 @@ const AddClientModal = ({ showModal, setShowModal }) => {
         setUsername('');
         setWebId('');
         dispatch({ type: 'CLEAR_PROCESSING' });
-      }, 3000);
+        setShowAddClientModal(false);
+      }, 1000);
     }
   };
 
   return (
-    <Dialog open={showModal} aria-labelledby="dialog-title" onClose={() => setShowModal(false)}>
+    <Dialog
+      open={showAddClientModal}
+      aria-labelledby="dialog-title"
+      onClose={() => setShowAddClientModal(false)}
+    >
       <FormSection
         title="Add Client"
         state={state}
@@ -196,7 +201,7 @@ const AddClientModal = ({ showModal, setShowModal }) => {
               variant="outlined"
               color="error"
               endIcon={<ClearIcon />}
-              onClick={() => setShowModal(false)}
+              onClick={() => setShowAddClientModal(false)}
               fullWidth
             >
               CANCEL

--- a/src/components/Clients/AddClientModal.jsx
+++ b/src/components/Clients/AddClientModal.jsx
@@ -68,7 +68,7 @@ const AddClientModal = ({ showAddClientModal, setShowAddClientModal }) => {
       );
       setTimeout(() => {
         dispatch({ type: 'CLEAR_PROCESSING' });
-      }, 3000);
+      }, 2000);
       return;
     }
 
@@ -81,7 +81,7 @@ const AddClientModal = ({ showAddClientModal, setShowAddClientModal }) => {
       );
       setTimeout(() => {
         dispatch({ type: 'CLEAR_PROCESSING' });
-      }, 3000);
+      }, 2000);
       return;
     }
     // ===== END OF ERROR DISPLAY OPTIONS =====
@@ -123,7 +123,7 @@ const AddClientModal = ({ showAddClientModal, setShowAddClientModal }) => {
         setWebId('');
         dispatch({ type: 'CLEAR_PROCESSING' });
         setShowAddClientModal(false);
-      }, 1000);
+      }, 2000);
     }
   };
 

--- a/src/components/Clients/ClientList.jsx
+++ b/src/components/Clients/ClientList.jsx
@@ -27,11 +27,21 @@ const ClientList = () => {
 
   const determineClientListTable = userListObject.userList?.length ? (
     // render if clients
+    <ClientListTable
+      setSelectedClientToDelete={setSelectedClientToDelete}
+      setShowDeleteClientModal={setShowDeleteClientModal}
+    />
+  ) : (
+    // render if no clients
+    <EmptyListNotification type="clients" />
+  );
+
+  // MAIN RETURN OF COMPONENT
+  return loadingUsers ? (
+    <LoadingAnimation loadingItem="clients" />
+  ) : (
     <>
-      <ClientListTable
-        setSelectedClientToDelete={setSelectedClientToDelete}
-        setShowDeleteClientModal={setShowDeleteClientModal}
-      />
+      {determineClientListTable}
       {/* modal/popup renders when showDeleteClientModal state is true */}
       <DeleteClientModal
         showDeleteClientModal={showDeleteClientModal}
@@ -39,13 +49,7 @@ const ClientList = () => {
         selectedClientToDelete={selectedClientToDelete}
       />
     </>
-  ) : (
-    // render if no clients
-    <EmptyListNotification type="clients" />
   );
-
-  // MAIN RETURN OF COMPONENT
-  return loadingUsers ? <LoadingAnimation loadingItem="clients" /> : determineClientListTable;
 };
 
 export default ClientList;

--- a/src/components/Clients/ClientList.jsx
+++ b/src/components/Clients/ClientList.jsx
@@ -1,9 +1,10 @@
 // React Imports
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 // Context Imports
 import { UserListContext } from '../../contexts';
 // Component Imports
 import ClientListTable from './ClientListTable';
+import DeleteClientModal from './DeleteClientModal';
 import { EmptyListNotification, LoadingAnimation } from '../Notification';
 
 /**
@@ -18,9 +19,26 @@ const ClientList = () => {
   const { userListObject } = useContext(UserListContext);
   const { loadingUsers } = useContext(UserListContext);
 
+  // state for DeleteClientModal component
+  const [showDeleteClientModal, setShowDeleteClientModal] = useState(false);
+
+  // state for selected client to delete
+  const [selectedClientToDelete, setSelectedClientToDelete] = useState(null);
+
   const determineClientListTable = userListObject.userList?.length ? (
     // render if clients
-    <ClientListTable />
+    <>
+      <ClientListTable
+        setSelectedClientToDelete={setSelectedClientToDelete}
+        setShowDeleteClientModal={setShowDeleteClientModal}
+      />
+      {/* modal/popup renders when showDeleteClientModal state is true */}
+      <DeleteClientModal
+        showDeleteClientModal={showDeleteClientModal}
+        setShowDeleteClientModal={setShowDeleteClientModal}
+        selectedClientToDelete={selectedClientToDelete}
+      />
+    </>
   ) : (
     // render if no clients
     <EmptyListNotification type="clients" />

--- a/src/components/Clients/ClientList.jsx
+++ b/src/components/Clients/ClientList.jsx
@@ -20,7 +20,7 @@ const ClientList = () => {
 
   const determineClientListTable = userListObject.userList?.length ? (
     // render if clients
-    <ClientListTable statusType="Status" defaultMessage="No actions performed" />
+    <ClientListTable />
   ) : (
     // render if no clients
     <EmptyListNotification type="clients" />

--- a/src/components/Clients/ClientListTable.jsx
+++ b/src/components/Clients/ClientListTable.jsx
@@ -1,5 +1,5 @@
 // React Imports
-import React, { useContext, useState } from 'react';
+import React, { useContext } from 'react';
 // Material UI Imports
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -13,7 +13,6 @@ import { useStatusNotification } from '../../hooks';
 import { UserListContext } from '../../contexts';
 // Component Imports
 import ClientListTableRow from './ClientListTableRow';
-import DeleteClientModal from './DeleteClientModal';
 import { StyledTableCell } from '../Table/TableStyles';
 
 // ===== MAKE CHANGES HERE FOR TABLE HEADER / COLUMN TITLES =====
@@ -26,52 +25,40 @@ const columnTitlesArray = ['Select', 'Client', 'WebID', 'Pin', 'Delete'];
  * @name ClientListTable
  */
 
-const ClientListTable = () => {
+const ClientListTable = ({ setSelectedClientToDelete, setShowDeleteClientModal }) => {
   const { state, dispatch } = useStatusNotification();
   const { userListObject } = useContext(UserListContext);
-  // state for DeleteClientModal component
-  const [showDeleteClientModal, setShowDeleteClientModal] = useState(false);
-  // state for selected client to delete
-  const [selectedClientToDelete, setSelectedClientToDelete] = useState(null);
 
   return (
-    <>
-      <TableContainer component={Paper} sx={{ marginTop: '3rem', marginBottom: '3rem' }}>
-        <Table aria-label="client list table">
-          <TableHead>
-            <TableRow>
-              {columnTitlesArray.map((columnTitle) => (
-                <StyledTableCell key={columnTitle} align="center">
-                  {columnTitle}
-                </StyledTableCell>
-              ))}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {userListObject?.userList.map((client, index) => {
-              const labelId = `clientlist-checkbox-${index}`;
-              return (
-                <ClientListTableRow
-                  key={client.webId}
-                  labelId={labelId}
-                  client={client}
-                  state={state}
-                  dispatch={dispatch}
-                  setShowDeleteClientModal={setShowDeleteClientModal}
-                  setSelectedClientToDelete={setSelectedClientToDelete}
-                />
-              );
-            })}
-          </TableBody>
-        </Table>
-      </TableContainer>
-      {/* modal/popup renders when showDeleteClientModal state is true */}
-      <DeleteClientModal
-        showDeleteClientModal={showDeleteClientModal}
-        setShowDeleteClientModal={setShowDeleteClientModal}
-        selectedClientToDelete={selectedClientToDelete}
-      />
-    </>
+    <TableContainer component={Paper} sx={{ marginTop: '3rem', marginBottom: '3rem' }}>
+      <Table aria-label="client list table">
+        <TableHead>
+          <TableRow>
+            {columnTitlesArray.map((columnTitle) => (
+              <StyledTableCell key={columnTitle} align="center">
+                {columnTitle}
+              </StyledTableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {userListObject?.userList.map((client, index) => {
+            const labelId = `clientlist-checkbox-${index}`;
+            return (
+              <ClientListTableRow
+                key={client.webId}
+                labelId={labelId}
+                client={client}
+                state={state}
+                dispatch={dispatch}
+                setShowDeleteClientModal={setShowDeleteClientModal}
+                setSelectedClientToDelete={setSelectedClientToDelete}
+              />
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
   );
 };
 

--- a/src/components/Clients/ClientListTable.jsx
+++ b/src/components/Clients/ClientListTable.jsx
@@ -1,5 +1,5 @@
 // React Imports
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 // Material UI Imports
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -12,8 +12,8 @@ import { useStatusNotification } from '../../hooks';
 // Context Imports
 import { UserListContext } from '../../contexts';
 // Component Imports
-import { StatusNotification } from '../Notification';
 import ClientListTableRow from './ClientListTableRow';
+import DeleteClientModal from './DeleteClientModal';
 import { StyledTableCell } from '../Table/TableStyles';
 
 // ===== MAKE CHANGES HERE FOR TABLE HEADER / COLUMN TITLES =====
@@ -26,39 +26,52 @@ const columnTitlesArray = ['Select', 'Client', 'WebID', 'Pin', 'Delete'];
  * @name ClientListTable
  */
 
-const ClientListTable = ({ statusType, defaultMessage }) => {
+const ClientListTable = () => {
   const { state, dispatch } = useStatusNotification();
   const { userListObject } = useContext(UserListContext);
+  // state for DeleteClientModal component
+  const [showDeleteClientModal, setShowDeleteClientModal] = useState(false);
+  // state for selected client to delete
+  const [selectedClientToDelete, setSelectedClientToDelete] = useState(null);
 
   return (
-    <TableContainer component={Paper} sx={{ marginTop: '3rem', marginBottom: '3rem' }}>
-      <Table aria-label="client list table">
-        <TableHead>
-          <TableRow>
-            {columnTitlesArray.map((columnTitle) => (
-              <StyledTableCell key={columnTitle} align="center">
-                {columnTitle}
-              </StyledTableCell>
-            ))}
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {userListObject?.userList.map((client, index) => {
-            const labelId = `clientlist-checkbox-${index}`;
-            return (
-              <ClientListTableRow
-                key={client.webId}
-                labelId={labelId}
-                client={client}
-                state={state}
-                dispatch={dispatch}
-              />
-            );
-          })}
-        </TableBody>
-      </Table>
-      <StatusNotification state={state} statusType={statusType} defaultMessage={defaultMessage} />
-    </TableContainer>
+    <>
+      <TableContainer component={Paper} sx={{ marginTop: '3rem', marginBottom: '3rem' }}>
+        <Table aria-label="client list table">
+          <TableHead>
+            <TableRow>
+              {columnTitlesArray.map((columnTitle) => (
+                <StyledTableCell key={columnTitle} align="center">
+                  {columnTitle}
+                </StyledTableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {userListObject?.userList.map((client, index) => {
+              const labelId = `clientlist-checkbox-${index}`;
+              return (
+                <ClientListTableRow
+                  key={client.webId}
+                  labelId={labelId}
+                  client={client}
+                  state={state}
+                  dispatch={dispatch}
+                  setShowDeleteClientModal={setShowDeleteClientModal}
+                  setSelectedClientToDelete={setSelectedClientToDelete}
+                />
+              );
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      {/* modal/popup renders when showDeleteClientModal state is true */}
+      <DeleteClientModal
+        showDeleteClientModal={showDeleteClientModal}
+        setShowDeleteClientModal={setShowDeleteClientModal}
+        selectedClientToDelete={selectedClientToDelete}
+      />
+    </>
   );
 };
 

--- a/src/components/Clients/ClientListTableRow.jsx
+++ b/src/components/Clients/ClientListTableRow.jsx
@@ -13,6 +13,8 @@ import { runNotification } from '../../utils';
 // Context Imports
 import { SelectedUserContext, UserListContext } from '../../contexts';
 import { StyledTableCell, StyledTableRow } from '../Table/TableStyles';
+// Component Imports
+import DeleteClientModal from './DeleteClientModal';
 
 /**
  * ClientListTableRow Component - Component that generates the individual table
@@ -28,6 +30,7 @@ const ClientListTableRow = ({ labelId, client, state, dispatch }) => {
   const { selectedUser, setSelectedUser } = useContext(SelectedUserContext);
   const { removeUser } = useContext(UserListContext);
   const [pinned, setPinned] = useState(false);
+  const [showDeleteClientModal, setShowClientDeleteModal] = useState(false);
 
   // determine what icon gets rendered in the pinned column
   const pinnedIcon = pinned ? <PushPinIcon color="secondary" /> : <PushPinOutlinedIcon />;
@@ -46,13 +49,7 @@ const ClientListTableRow = ({ labelId, client, state, dispatch }) => {
 
   // Event handler for deleting client from client list
   const handleDeleteClient = async () => {
-    if (
-      !window.confirm(
-        `You're about to delete ${client.person} from your client list, do you wish to continue?`
-      )
-    ) {
-      return;
-    }
+    setShowClientDeleteModal(false);
     runNotification(`Deleting "${client.person}" from client list...`, 3, state, dispatch);
     await removeUser(client);
     runNotification(`"${client.person}" deleted from client list...`, 3, state, dispatch);
@@ -65,45 +62,55 @@ const ClientListTableRow = ({ labelId, client, state, dispatch }) => {
   };
 
   return (
-    <StyledTableRow>
-      <StyledTableCell align="center">
-        <Checkbox
-          id={labelId}
-          color="primary"
-          checked={selectedUser.webId === client.webId}
-          inputProps={{
-            'aria-labelledby': labelId
-          }}
-          onClick={() => {
-            handleSelectClient(client);
-          }}
-        />
-      </StyledTableCell>
-      <StyledTableCell align="center">{client.person}</StyledTableCell>
-      {/* ***** TODO: Switch this webId to being a small Notes section */}
-      {/* seems having a link or even displaying another user's pod is completely useless/irrelevant */}
-      {/* see no reason it would ever need to be used, but notes/comments will be of utmost importance to caseworkers */}
-      <StyledTableCell align="center">
-        <Link
-          to={client.webId}
-          target="_blank"
-          rel="noreferrer"
-          style={{ textDecoration: 'none', color: theme.palette.primary.dark }}
-        >
-          Link to Pod Profile
-        </Link>
-      </StyledTableCell>
-      <StyledTableCell align="center">
-        <IconButton size="large" edge="end" onClick={handlePinClick}>
-          {pinnedIcon}
-        </IconButton>
-      </StyledTableCell>
-      <StyledTableCell align="center">
-        <IconButton size="large" edge="end" onClick={() => handleDeleteClient()}>
-          <DeleteOutlineOutlinedIcon />
-        </IconButton>
-      </StyledTableCell>
-    </StyledTableRow>
+    <>
+      <StyledTableRow>
+        <StyledTableCell align="center">
+          <Checkbox
+            id={labelId}
+            color="primary"
+            checked={selectedUser.webId === client.webId}
+            inputProps={{
+              'aria-labelledby': labelId
+            }}
+            onClick={() => {
+              handleSelectClient(client);
+            }}
+          />
+        </StyledTableCell>
+        <StyledTableCell align="center">{client.person}</StyledTableCell>
+        {/* ***** TODO: Switch this webId to being a small Notes section */}
+        {/* seems having a link or even displaying another user's pod is completely useless/irrelevant */}
+        {/* see no reason it would ever need to be used, but notes/comments will be of utmost importance to caseworkers */}
+        <StyledTableCell align="center">
+          <Link
+            to={client.webId}
+            target="_blank"
+            rel="noreferrer"
+            style={{ textDecoration: 'none', color: theme.palette.primary.dark }}
+          >
+            Link to Pod Profile
+          </Link>
+        </StyledTableCell>
+        <StyledTableCell align="center">
+          <IconButton size="large" edge="end" onClick={handlePinClick}>
+            {pinnedIcon}
+          </IconButton>
+        </StyledTableCell>
+        <StyledTableCell align="center">
+          <IconButton size="large" edge="end" onClick={() => setShowClientDeleteModal(true)}>
+            <DeleteOutlineOutlinedIcon />
+          </IconButton>
+        </StyledTableCell>
+      </StyledTableRow>
+
+      {/* modal/popup renders when showDeleteClientModal state is true */}
+      <DeleteClientModal
+        showDeleteClientModal={showDeleteClientModal}
+        setShowClientDeleteModal={setShowClientDeleteModal}
+        client={client}
+        handleDeleteClient={handleDeleteClient}
+      />
+    </>
   );
 };
 

--- a/src/components/Clients/ClientListTableRow.jsx
+++ b/src/components/Clients/ClientListTableRow.jsx
@@ -11,10 +11,8 @@ import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
 // Utility Imports
 import { runNotification } from '../../utils';
 // Context Imports
-import { SelectedUserContext, UserListContext } from '../../contexts';
+import { SelectedUserContext } from '../../contexts';
 import { StyledTableCell, StyledTableRow } from '../Table/TableStyles';
-// Component Imports
-import DeleteClientModal from './DeleteClientModal';
 
 /**
  * ClientListTableRow Component - Component that generates the individual table
@@ -25,12 +23,17 @@ import DeleteClientModal from './DeleteClientModal';
  */
 
 // determine what gets rendered in the table body
-const ClientListTableRow = ({ labelId, client, state, dispatch }) => {
+const ClientListTableRow = ({
+  labelId,
+  client,
+  state,
+  dispatch,
+  setShowDeleteClientModal,
+  setSelectedClientToDelete
+}) => {
   const theme = useTheme();
   const { selectedUser, setSelectedUser } = useContext(SelectedUserContext);
-  const { removeUser } = useContext(UserListContext);
   const [pinned, setPinned] = useState(false);
-  const [showDeleteClientModal, setShowClientDeleteModal] = useState(false);
 
   // determine what icon gets rendered in the pinned column
   const pinnedIcon = pinned ? <PushPinIcon color="secondary" /> : <PushPinOutlinedIcon />;
@@ -47,70 +50,58 @@ const ClientListTableRow = ({ labelId, client, state, dispatch }) => {
     setSelectedUser(clientToSelect);
   };
 
-  // Event handler for deleting client from client list
-  const handleDeleteClient = async () => {
-    setShowClientDeleteModal(false);
-    runNotification(`Deleting "${client.person}" from client list...`, 3, state, dispatch);
-    await removeUser(client);
-    runNotification(`"${client.person}" deleted from client list...`, 3, state, dispatch);
-  };
-
   // Event handler for pinning client to top of table
   // ***** TODO: Add in moving pinned row to top of table
   const handlePinClick = () => {
     setPinned(!pinned);
   };
 
-  return (
-    <>
-      <StyledTableRow>
-        <StyledTableCell align="center">
-          <Checkbox
-            id={labelId}
-            color="primary"
-            checked={selectedUser.webId === client.webId}
-            inputProps={{
-              'aria-labelledby': labelId
-            }}
-            onClick={() => {
-              handleSelectClient(client);
-            }}
-          />
-        </StyledTableCell>
-        <StyledTableCell align="center">{client.person}</StyledTableCell>
-        {/* ***** TODO: Switch this webId to being a small Notes section */}
-        {/* seems having a link or even displaying another user's pod is completely useless/irrelevant */}
-        {/* see no reason it would ever need to be used, but notes/comments will be of utmost importance to caseworkers */}
-        <StyledTableCell align="center">
-          <Link
-            to={client.webId}
-            target="_blank"
-            rel="noreferrer"
-            style={{ textDecoration: 'none', color: theme.palette.primary.dark }}
-          >
-            Link to Pod Profile
-          </Link>
-        </StyledTableCell>
-        <StyledTableCell align="center">
-          <IconButton size="large" edge="end" onClick={handlePinClick}>
-            {pinnedIcon}
-          </IconButton>
-        </StyledTableCell>
-        <StyledTableCell align="center">
-          <IconButton size="large" edge="end" onClick={() => setShowClientDeleteModal(true)}>
-            <DeleteOutlineOutlinedIcon />
-          </IconButton>
-        </StyledTableCell>
-      </StyledTableRow>
+  // Event handler for deleting a client from client list
+  const handleSelectClientToDelete = () => {
+    setSelectedClientToDelete(client);
+    setShowDeleteClientModal(true);
+  };
 
-      {/* modal/popup renders when showDeleteClientModal state is true */}
-      <DeleteClientModal
-        showDeleteClientModal={showDeleteClientModal}
-        setShowClientDeleteModal={setShowClientDeleteModal}
-        client={client}
-        handleDeleteClient={handleDeleteClient}
-      />
-    </>
+  return (
+    <StyledTableRow>
+      <StyledTableCell align="center">
+        <Checkbox
+          id={labelId}
+          color="primary"
+          checked={selectedUser.webId === client.webId}
+          inputProps={{
+            'aria-labelledby': labelId
+          }}
+          onClick={() => {
+            handleSelectClient(client);
+          }}
+        />
+      </StyledTableCell>
+      <StyledTableCell align="center">{client.person}</StyledTableCell>
+      {/* ***** TODO: Switch this webId to being a small Notes section */}
+      {/* seems having a link or even displaying another user's pod is completely useless/irrelevant */}
+      {/* see no reason it would ever need to be used, but notes/comments will be of utmost importance to caseworkers */}
+      <StyledTableCell align="center">
+        <Link
+          to={client.webId}
+          target="_blank"
+          rel="noreferrer"
+          style={{ textDecoration: 'none', color: theme.palette.primary.dark }}
+        >
+          Link to Pod Profile
+        </Link>
+      </StyledTableCell>
+      <StyledTableCell align="center">
+        <IconButton size="large" edge="end" onClick={handlePinClick}>
+          {pinnedIcon}
+        </IconButton>
+      </StyledTableCell>
+      <StyledTableCell align="center">
+        <IconButton size="large" edge="end" onClick={handleSelectClientToDelete}>
+          <DeleteOutlineOutlinedIcon />
+        </IconButton>
+      </StyledTableCell>
+    </StyledTableRow>
   );
 };
 

--- a/src/components/Clients/DeleteClientModal.jsx
+++ b/src/components/Clients/DeleteClientModal.jsx
@@ -38,7 +38,7 @@ const DeleteClientModal = ({
     event.preventDefault();
     runNotification(
       `Deleting "${selectedClientToDelete?.person}" from client list...`,
-      3,
+      5,
       state,
       dispatch
     );
@@ -47,13 +47,13 @@ const DeleteClientModal = ({
     } finally {
       runNotification(
         `"${selectedClientToDelete?.person}" deleted from client list...`,
-        3,
+        5,
         state,
         dispatch
       );
       setTimeout(() => {
         setShowDeleteClientModal(false);
-      }, 1000);
+      }, 2000);
     }
   };
 

--- a/src/components/Clients/DeleteClientModal.jsx
+++ b/src/components/Clients/DeleteClientModal.jsx
@@ -37,7 +37,7 @@ const DeleteClientModal = ({
   const handleDeleteClient = async (event) => {
     event.preventDefault();
     runNotification(
-      `Deleting "${selectedClientToDelete.person}" from client list...`,
+      `Deleting "${selectedClientToDelete?.person}" from client list...`,
       3,
       state,
       dispatch
@@ -46,7 +46,7 @@ const DeleteClientModal = ({
       await removeUser(selectedClientToDelete);
     } finally {
       runNotification(
-        `"${selectedClientToDelete.person}" deleted from client list...`,
+        `"${selectedClientToDelete?.person}" deleted from client list...`,
         3,
         state,
         dispatch
@@ -91,6 +91,7 @@ const DeleteClientModal = ({
               type="submit"
               variant="contained"
               color="primary"
+              aria-label="Delete Client Button"
               endIcon={<CheckIcon />}
               disabled={state.processing}
               sx={{ marginLeft: '1rem' }}

--- a/src/components/Clients/DeleteClientModal.jsx
+++ b/src/components/Clients/DeleteClientModal.jsx
@@ -81,6 +81,7 @@ const DeleteClientModal = ({
             <Button
               variant="outlined"
               color="error"
+              aria-label="Cancel Button"
               endIcon={<ClearIcon />}
               onClick={() => setShowDeleteClientModal(false)}
             >

--- a/src/components/Clients/DeleteClientModal.jsx
+++ b/src/components/Clients/DeleteClientModal.jsx
@@ -44,7 +44,6 @@ const DeleteClientModal = ({
     );
     try {
       await removeUser(selectedClientToDelete);
-      // get it to show this deleted notification
     } finally {
       runNotification(
         `"${selectedClientToDelete.person}" deleted from client list...`,
@@ -74,7 +73,7 @@ const DeleteClientModal = ({
         <form onSubmit={handleDeleteClient} autoComplete="off">
           <DialogContent>
             <DialogContentText id="dialog-description">
-              {`You're about to delete ${selectedClientToDelete?.person} from your client list, do you wish to continue?`}
+              {`Are you sure you want to delete ${selectedClientToDelete?.person} from your client list?`}
             </DialogContentText>
           </DialogContent>
 

--- a/src/components/Clients/DeleteClientModal.jsx
+++ b/src/components/Clients/DeleteClientModal.jsx
@@ -1,0 +1,64 @@
+// React Imports
+import React from 'react';
+// Material UI Imports
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Button from '@mui/material/Button';
+import ClearIcon from '@mui/icons-material/Clear';
+import CheckIcon from '@mui/icons-material/Check';
+
+/**
+ * DeleteClientModal Component - Component that allows users to delete other user's
+ * Pod URLs from a user's list stored on their own Pod
+ *
+ * @memberof Clients
+ * @name DeleteClientModal
+ */
+
+const DeleteClientModal = ({
+  showDeleteClientModal,
+  setShowClientDeleteModal,
+  client,
+  handleDeleteClient
+}) => (
+  <Dialog
+    open={showDeleteClientModal}
+    aria-labelledby="dialog-title"
+    aria-describedby="dialog-description"
+    onClose={() => setShowClientDeleteModal(false)}
+  >
+    <DialogTitle id="dialog-tile">Delete Client?</DialogTitle>
+
+    <DialogContent>
+      <DialogContentText id="dialog-description">
+        {`You're about to delete ${client.person} from your client list, do you wish to continue?`}
+      </DialogContentText>
+    </DialogContent>
+
+    <DialogActions>
+      <Button
+        variant="outlined"
+        color="error"
+        endIcon={<ClearIcon />}
+        onClick={() => setShowClientDeleteModal(false)}
+      >
+        CANCEL
+      </Button>
+
+      <Button
+        variant="contained"
+        color="primary"
+        endIcon={<CheckIcon />}
+        sx={{ marginLeft: '1rem' }}
+        onClick={handleDeleteClient}
+      >
+        DELETE CLIENT
+      </Button>
+    </DialogActions>
+  </Dialog>
+);
+
+export default DeleteClientModal;

--- a/src/components/Clients/DeleteClientModal.jsx
+++ b/src/components/Clients/DeleteClientModal.jsx
@@ -44,6 +44,8 @@ const DeleteClientModal = ({
     );
     try {
       await removeUser(selectedClientToDelete);
+    } catch (e) {
+      runNotification(`Client deletion failed. Reason: ${e.message}`);
     } finally {
       runNotification(
         `"${selectedClientToDelete?.person}" deleted from client list...`,
@@ -73,7 +75,7 @@ const DeleteClientModal = ({
         <form onSubmit={handleDeleteClient} autoComplete="off">
           <DialogContent>
             <DialogContentText id="dialog-description">
-              {`Are you sure you want to delete ${selectedClientToDelete?.person} from your client list?`}
+              {`Are you sure you want to delete "${selectedClientToDelete?.person}" from your client list?`}
             </DialogContentText>
           </DialogContent>
 

--- a/src/components/Clients/index.js
+++ b/src/components/Clients/index.js
@@ -1,6 +1,7 @@
 import AddClientModal from './AddClientModal';
 import ClientList from './ClientList';
 import ClientListTable from './ClientListTable';
+import DeleteClientModal from './DeleteClientModal';
 
 /**
  * Components and functions related to Clients functionality within project PASS
@@ -8,4 +9,4 @@ import ClientListTable from './ClientListTable';
  * @namespace Clients
  */
 
-export { AddClientModal, ClientList, ClientListTable };
+export { AddClientModal, ClientList, ClientListTable, DeleteClientModal };

--- a/src/components/Clients/index.js
+++ b/src/components/Clients/index.js
@@ -1,6 +1,7 @@
 import AddClientModal from './AddClientModal';
 import ClientList from './ClientList';
 import ClientListTable from './ClientListTable';
+import ClientListTableRow from './ClientListTableRow';
 import DeleteClientModal from './DeleteClientModal';
 
 /**
@@ -9,4 +10,4 @@ import DeleteClientModal from './DeleteClientModal';
  * @namespace Clients
  */
 
-export { AddClientModal, ClientList, ClientListTable, DeleteClientModal };
+export { AddClientModal, ClientList, ClientListTable, ClientListTableRow, DeleteClientModal };

--- a/src/routes/Clients.jsx
+++ b/src/routes/Clients.jsx
@@ -19,7 +19,7 @@ import ClientList from '../components/Clients/ClientList';
 
 const Clients = () => {
   // state for AddClientModal component
-  const [showModal, setShowModal] = useState(false);
+  const [showAddClientModal, setShowAddClientModal] = useState(false);
 
   const location = useLocation();
   localStorage.setItem('restorePath', location.pathname);
@@ -32,14 +32,17 @@ const Clients = () => {
         size="small"
         aria-label="Add Client Button"
         startIcon={<AddIcon />}
-        onClick={() => setShowModal(true)}
+        onClick={() => setShowAddClientModal(true)}
         sx={{ marginTop: '3rem' }}
       >
         Add Client
       </Button>
       <ClientList />
       {/* modal/popup renders when showConfirmationModal state is true */}
-      <AddClientModal showModal={showModal} setShowModal={setShowModal} />
+      <AddClientModal
+        showAddClientModal={showAddClientModal}
+        setShowAddClientModal={setShowAddClientModal}
+      />
     </Container>
   );
 };

--- a/src/routes/Clients.jsx
+++ b/src/routes/Clients.jsx
@@ -7,8 +7,7 @@ import AddIcon from '@mui/icons-material/Add';
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 // Component Imports
-import AddClientModal from '../components/Clients/AddClientModal';
-import ClientList from '../components/Clients/ClientList';
+import { AddClientModal, ClientList } from '../components/Clients';
 
 /**
  * Clients Component - Component that generates Clients Page for PASS
@@ -38,7 +37,8 @@ const Clients = () => {
         Add Client
       </Button>
       <ClientList />
-      {/* modal/popup renders when showConfirmationModal state is true */}
+
+      {/* modal/popup renders when showAddClientModal state is true */}
       <AddClientModal
         showAddClientModal={showAddClientModal}
         setShowAddClientModal={setShowAddClientModal}

--- a/test/components/Clients/DeleteClientModal.test.jsx
+++ b/test/components/Clients/DeleteClientModal.test.jsx
@@ -1,6 +1,6 @@
+import React from 'react';
 import { render, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { expect, it, vi, afterEach } from 'vitest';
 import { DeleteClientModal } from '../../../src/components/Clients';
 import { UserListContext } from '../../../src/contexts';
@@ -9,42 +9,39 @@ afterEach(() => {
   cleanup();
 });
 
-it('shows when showDeleteClientModal is true', () => {
-  const setModal = () => {};
-  const removeUser = vi.fn();
+const client = { person: 'tim' };
+const removeUser = vi.fn();
+const setModal = () => {};
+
+it('renders/mounts when showDeleteClientModal is true', () => {
   const { queryByLabelText } = render(
     <UserListContext.Provider value={{ removeUser }}>
       <DeleteClientModal
         showDeleteClientModal
         setShowDeleteClientModal={setModal}
-        selectedClientToDelete={{ person: 'tim' }}
+        selectedClientToDelete={client}
       />
     </UserListContext.Provider>
   );
   const deleteButton = queryByLabelText('Delete Client Button');
+  const cancelButton = queryByLabelText('Cancel Button');
   expect(deleteButton).not.toBeNull();
+  expect(cancelButton).not.toBeNull();
 });
 
-it('hides when showDeleteClientModal is false', () => {
-  const setModal = () => {};
-  const removeUser = vi.fn();
+it('hides/unmounts when showDeleteClientModal is false', () => {
   const { queryByLabelText } = render(
     <UserListContext.Provider value={{ removeUser }}>
-      <DeleteClientModal
-        setShowDeleteClientModal={setModal}
-        selectedClientToDelete={{ person: 'tim' }}
-      />
+      <DeleteClientModal setShowDeleteClientModal={setModal} selectedClientToDelete={client} />
     </UserListContext.Provider>
   );
   const deleteButton = queryByLabelText('Delete Client Button');
+  const cancelButton = queryByLabelText('Cancel Button');
   expect(deleteButton).toBeNull();
+  expect(cancelButton).toBeNull();
 });
 
-it('triggers delete client when delete button is clicked', async () => {
-  const user = userEvent.setup();
-  const setModal = () => {};
-  const removeUser = vi.fn();
-  const client = { person: 'tim' };
+it('triggers removeUser/deletion of client when delete button is clicked', async () => {
   const { getByLabelText } = render(
     <UserListContext.Provider value={{ removeUser }}>
       <DeleteClientModal
@@ -54,9 +51,25 @@ it('triggers delete client when delete button is clicked', async () => {
       />
     </UserListContext.Provider>
   );
+  const user = userEvent.setup();
   const deleteButton = getByLabelText('Delete Client Button');
   await user.click(deleteButton);
   expect(removeUser).toBeCalledWith(client);
 });
 
-it('closes without an action when cancel button in clicked', () => {});
+it('closes without an action when cancel button is clicked', async () => {
+  const { getByLabelText } = render(
+    <UserListContext.Provider value={{ removeUser }}>
+      <DeleteClientModal
+        showDeleteClientModal
+        setShowDeleteClientModal={setModal}
+        selectedClientToDelete={client}
+      />
+    </UserListContext.Provider>
+  );
+  const user = userEvent.setup();
+  const cancelButton = getByLabelText('Cancel Button');
+  await user.click(cancelButton);
+  const closeModal = vi.fn();
+  expect(closeModal).toHaveBeenCalledOnce();
+});

--- a/test/components/Clients/DeleteClientModal.test.jsx
+++ b/test/components/Clients/DeleteClientModal.test.jsx
@@ -77,6 +77,7 @@ it('closes without an action when cancel button is clicked', async () => {
     const [showModal, setShowModal] = useState(true);
 
     return (
+      // eslint-disable-next-line react/jsx-no-constructed-context-values
       <UserListContext.Provider value={{ removeUser }}>
         <DeleteClientModal
           showDeleteClientModal={showModal}

--- a/test/components/Clients/DeleteClientModal.test.jsx
+++ b/test/components/Clients/DeleteClientModal.test.jsx
@@ -1,0 +1,62 @@
+import { render, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { expect, it, vi, afterEach } from 'vitest';
+import { DeleteClientModal } from '../../../src/components/Clients';
+import { UserListContext } from '../../../src/contexts';
+
+afterEach(() => {
+  cleanup();
+});
+
+it('shows when showDeleteClientModal is true', () => {
+  const setModal = () => {};
+  const removeUser = vi.fn();
+  const { queryByLabelText } = render(
+    <UserListContext.Provider value={{ removeUser }}>
+      <DeleteClientModal
+        showDeleteClientModal
+        setShowDeleteClientModal={setModal}
+        selectedClientToDelete={{ person: 'tim' }}
+      />
+    </UserListContext.Provider>
+  );
+  const deleteButton = queryByLabelText('Delete Client Button');
+  expect(deleteButton).not.toBeNull();
+});
+
+it('hides when showDeleteClientModal is false', () => {
+  const setModal = () => {};
+  const removeUser = vi.fn();
+  const { queryByLabelText } = render(
+    <UserListContext.Provider value={{ removeUser }}>
+      <DeleteClientModal
+        setShowDeleteClientModal={setModal}
+        selectedClientToDelete={{ person: 'tim' }}
+      />
+    </UserListContext.Provider>
+  );
+  const deleteButton = queryByLabelText('Delete Client Button');
+  expect(deleteButton).toBeNull();
+});
+
+it('triggers delete client when delete button is clicked', async () => {
+  const user = userEvent.setup();
+  const setModal = () => {};
+  const removeUser = vi.fn();
+  const client = { person: 'tim' };
+  const { getByLabelText } = render(
+    <UserListContext.Provider value={{ removeUser }}>
+      <DeleteClientModal
+        showDeleteClientModal
+        setShowDeleteClientModal={setModal}
+        selectedClientToDelete={client}
+      />
+    </UserListContext.Provider>
+  );
+  const deleteButton = getByLabelText('Delete Client Button');
+  await user.click(deleteButton);
+  expect(removeUser).toBeCalledWith(client);
+});
+
+it('closes without an action when cancel button in clicked', () => {});

--- a/test/components/Clients/DeleteClientModal.test.jsx
+++ b/test/components/Clients/DeleteClientModal.test.jsx
@@ -1,19 +1,19 @@
-import React from 'react';
-import { render, cleanup } from '@testing-library/react';
+import React, { useState } from 'react';
+import { render, cleanup, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { expect, it, vi, afterEach } from 'vitest';
 import { DeleteClientModal } from '../../../src/components/Clients';
 import { UserListContext } from '../../../src/contexts';
 
+// clear created dom after each test, to start fresh for next
 afterEach(() => {
   cleanup();
 });
 
-const client = { person: 'tim' };
-const removeUser = vi.fn();
-const setModal = () => {};
-
 it('renders/mounts when showDeleteClientModal is true', () => {
+  const removeUser = vi.fn();
+  const setModal = () => {};
+  const client = { person: 'john' };
   const { queryByLabelText } = render(
     <UserListContext.Provider value={{ removeUser }}>
       <DeleteClientModal
@@ -23,25 +23,36 @@ it('renders/mounts when showDeleteClientModal is true', () => {
       />
     </UserListContext.Provider>
   );
+
   const deleteButton = queryByLabelText('Delete Client Button');
   const cancelButton = queryByLabelText('Cancel Button');
+
   expect(deleteButton).not.toBeNull();
   expect(cancelButton).not.toBeNull();
 });
 
 it('hides/unmounts when showDeleteClientModal is false', () => {
+  const removeUser = vi.fn();
+  const setModal = () => {};
+  const client = { person: 'john' };
   const { queryByLabelText } = render(
     <UserListContext.Provider value={{ removeUser }}>
       <DeleteClientModal setShowDeleteClientModal={setModal} selectedClientToDelete={client} />
     </UserListContext.Provider>
   );
+
   const deleteButton = queryByLabelText('Delete Client Button');
   const cancelButton = queryByLabelText('Cancel Button');
+
   expect(deleteButton).toBeNull();
   expect(cancelButton).toBeNull();
 });
 
 it('triggers removeUser/deletion of client when delete button is clicked', async () => {
+  const removeUser = vi.fn();
+  const setModal = () => {};
+  const client = { person: 'john' };
+  const user = userEvent.setup();
   const { getByLabelText } = render(
     <UserListContext.Provider value={{ removeUser }}>
       <DeleteClientModal
@@ -51,25 +62,38 @@ it('triggers removeUser/deletion of client when delete button is clicked', async
       />
     </UserListContext.Provider>
   );
-  const user = userEvent.setup();
+
   const deleteButton = getByLabelText('Delete Client Button');
+
   await user.click(deleteButton);
   expect(removeUser).toBeCalledWith(client);
 });
 
 it('closes without an action when cancel button is clicked', async () => {
-  const { getByLabelText } = render(
-    <UserListContext.Provider value={{ removeUser }}>
-      <DeleteClientModal
-        showDeleteClientModal
-        setShowDeleteClientModal={setModal}
-        selectedClientToDelete={client}
-      />
-    </UserListContext.Provider>
-  );
+  const removeUser = vi.fn();
+  const client = { person: 'john' };
   const user = userEvent.setup();
-  const cancelButton = getByLabelText('Cancel Button');
+  const ModalWrapper = () => {
+    const [showModal, setShowModal] = useState(true);
+
+    return (
+      <UserListContext.Provider value={{ removeUser }}>
+        <DeleteClientModal
+          showDeleteClientModal={showModal}
+          setShowDeleteClientModal={setShowModal}
+          selectedClientToDelete={client}
+        />
+      </UserListContext.Provider>
+    );
+  };
+
+  const { queryByLabelText } = render(<ModalWrapper />);
+
+  const cancelButton = queryByLabelText('Cancel Button');
+
   await user.click(cancelButton);
-  const closeModal = vi.fn();
-  expect(closeModal).toHaveBeenCalledOnce();
+  await waitForElementToBeRemoved(() => queryByLabelText('Cancel Button'));
+  const hiddenCancelButton = queryByLabelText('Cancel Button');
+  expect(hiddenCancelButton).toBeNull();
+  expect(removeUser).not.toBeCalled();
 });


### PR DESCRIPTION
# This PR closes #223 

This PR:
1. Creates `DeleteClientModal` component.
2. Renders this component onClick of trash icon in `ClientListTableRow`.
3. Renames states of `AddClientModal` component to achieve more clarity.
4. Automatically closes the `AddClientModal` component once client has been added to the list.

---


https://github.com/codeforpdx/PASS/assets/71395931/071d91d4-f4a9-4745-82b2-294d106289d2

