### PR TITLE
Removed unused session parameter from createUser

### DIFF
--- a/src/components/Clients/AddClientModal.jsx
+++ b/src/components/Clients/AddClientModal.jsx
@@ -1,7 +1,5 @@
 // React Imports
 import React, { useContext, useState } from 'react';
-// Inrupt Library Imports
-import { useSession } from '@inrupt/solid-ui-react';
 // Material UI Imports
 import Button from '@mui/material/Button';
 import CheckIcon from '@mui/icons-material/Check';
@@ -36,7 +34,6 @@ const renderWebId = (username) => {
 };
 
 const AddClientModal = ({ showModal, setShowModal }) => {
-  const { session } = useSession();
   const { state, dispatch } = useStatusNotification();
   const [userGivenName, setUserGivenName] = useState('');
   const [userFamilyName, setUserFamilyName] = useState('');
@@ -51,7 +48,7 @@ const AddClientModal = ({ showModal, setShowModal }) => {
   };
 
   const submitUser = async (userObject) => {
-    const user = await createUser(session, userObject);
+    const user = await createUser(userObject);
     await addUser(user);
   };
 

--- a/src/model-helpers/User.js
+++ b/src/model-helpers/User.js
@@ -92,11 +92,10 @@ export const updateUserActivity = async (session, podUrl) => {
  *
  * @memberof User
  * @function createUser
- * @param {Session} session - Solid's Session Object {@link Session}
  * @param {object} userSubmission - an object from a form submission containing the user creation data
  * @returns {Promise<object>} Promise - Updates last active time of user to lastActive.ttl
  */
-export const createUser = async (session, userSubmission) => {
+export const createUser = async (userSubmission) => {
   const { familyName, username, givenName, webId } = userSubmission;
 
   let newUserPodUrl = null;

--- a/test/model-helpers/User.test.js
+++ b/test/model-helpers/User.test.js
@@ -26,7 +26,7 @@ describe('createUser', () => {
       familyName: 'Cry',
       webId: `${mockPodUrl}profile/card`
     };
-    const newUser = await createUser(session, mockUserSubmission);
+    const newUser = await createUser(mockUserSubmission);
     expect(newUser).toMatchObject({
       familyName: 'Cry',
       givenName: 'Far',


### PR DESCRIPTION
Not really a bug per-se, but the function `createUser` from `model-helpers/User.js` doesn't seem to use the parameter `session`.

This PR simply removes `session` as a parameter from `createUser`. Other files that utilizes `createUser` has their functions updated to just take in just `userSubmission`, the other parameter in `createUser`.