### PR TITLE
Fixed bug for profile image when profileImage is null

### DIFF
--- a/src/contexts/SignedInUserContext.jsx
+++ b/src/contexts/SignedInUserContext.jsx
@@ -63,7 +63,9 @@ export const SignedInUserContextProvider = ({ children }) => {
           podUrl
         });
         const profileData = await fetchProfileInfo(session);
-        localStorage.setItem('profileImage', profileData.profileInfo.profileImage);
+        if (profileData.profileInfo.profileImage) {
+          localStorage.setItem('profileImage', profileData.profileInfo.profileImage);
+        }
         setUserInfo({
           ...userInfo,
           profileData


### PR DESCRIPTION
This PR fixes a bug related to storing initial profileImage to localStorage. It should really occur if profileImage is not null, but exist within profile card.