### PR TITLE
Issue 296/initialize-document-acl

### DIFF
--- a/src/components/Form/SetAclPermsDocContainerForm.jsx
+++ b/src/components/Form/SetAclPermsDocContainerForm.jsx
@@ -48,17 +48,16 @@ const SetAclPermsDocContainerForm = () => {
     const permissions = event.target.setAclPerms.value
       ? {
           read: event.target.setAclPerms.value === 'Give',
-          write: event.target.setAclPerms.value === 'Give',
           append: event.target.setAclPerms.value === 'Give'
         }
       : undefined;
-    let podUsername = event.target.setAclTo.value;
+    let otherPodUsername = event.target.setAclTo.value;
 
-    if (!podUsername) {
-      podUsername = selectedUser.username;
+    if (!otherPodUsername) {
+      otherPodUsername = selectedUser.username;
     }
 
-    if (!podUsername) {
+    if (!otherPodUsername) {
       runNotification('Set permissions failed. Reason: Username not provided.', 5, state, dispatch);
       setTimeout(() => {
         clearInputFields();
@@ -66,7 +65,7 @@ const SetAclPermsDocContainerForm = () => {
       return;
     }
 
-    if (getPodUrl(podUsername) === podUrl) {
+    if (getPodUrl(otherPodUsername) === podUrl) {
       runNotification(
         'Set permissions failed. Reason: Current user Pod cannot change container permissions to itself.',
         5,
@@ -88,7 +87,7 @@ const SetAclPermsDocContainerForm = () => {
     }
 
     try {
-      await setDocContainerAclPermission(session, permissions, podUsername);
+      await setDocContainerAclPermission(session, permissions, podUrl, otherPodUsername);
 
       runNotification(
         `${permissions.read ? 'Give' : 'Revoke'} permission to ${

--- a/src/contexts/SignedInUserContext.jsx
+++ b/src/contexts/SignedInUserContext.jsx
@@ -4,7 +4,7 @@ import React, { createContext, useState, useMemo, useEffect } from 'react';
 import { useSession } from '@inrupt/solid-ui-react';
 import { getPodUrlAll } from '@inrupt/solid-client';
 // Utility Imports
-import { createPublicContainer } from '../utils';
+import { createDocumentsContainer, createPublicContainer } from '../utils';
 import {
   fetchProfileInfo,
   updateProfileInfo,
@@ -58,21 +58,18 @@ export const SignedInUserContextProvider = ({ children }) => {
         const { webId } = session.info;
         let podUrl = (await getPodUrlAll(webId, { fetch: session.fetch }))[0];
         podUrl = podUrl || webId.split('profile')[0];
-        setUserInfo({
-          ...userInfo,
-          podUrl
-        });
         const profileData = await fetchProfileInfo(session);
         if (profileData.profileInfo.profileImage) {
           localStorage.setItem('profileImage', profileData.profileInfo.profileImage);
         }
         setUserInfo({
-          ...userInfo,
+          podUrl,
           profileData
         });
         await Promise.all([
-          updateUserActivity(session, podUrl),
-          createPublicContainer(session, podUrl)
+          createPublicContainer(session, podUrl),
+          createDocumentsContainer(session, podUrl),
+          updateUserActivity(session, podUrl)
         ]);
       } finally {
         setLoadingUserInfo(false);

--- a/src/contexts/SignedInUserContext.jsx
+++ b/src/contexts/SignedInUserContext.jsx
@@ -4,7 +4,7 @@ import React, { createContext, useState, useMemo, useEffect } from 'react';
 import { useSession } from '@inrupt/solid-ui-react';
 import { getPodUrlAll } from '@inrupt/solid-client';
 // Utility Imports
-import { generateDocumentsAcl, createPublicContainer } from '../utils';
+import { createDocumentsContainer, createPublicContainer } from '../utils';
 import {
   fetchProfileInfo,
   updateProfileInfo,
@@ -54,17 +54,18 @@ export const SignedInUserContextProvider = ({ children }) => {
     const loadUserInfo = async () => {
       try {
         const { webId } = session.info;
-        const fetchedPodUrl = (await getPodUrlAll(webId, { fetch: session.fetch }))[0];
-        setPodUrl(fetchedPodUrl || webId.split('profile')[0]);
+        let fetchedPodUrl = (await getPodUrlAll(webId, { fetch: session.fetch }))[0];
+        fetchedPodUrl = fetchedPodUrl || webId.split('profile')[0];
+        setPodUrl(fetchedPodUrl);
         const fetchedProfileData = await fetchProfileInfo(session);
         if (fetchedProfileData.profileInfo.profileImage) {
           localStorage.setItem('profileImage', fetchedProfileData.profileInfo.profileImage);
         }
         setProfileData(fetchedProfileData);
         await Promise.all([
-          createPublicContainer(session, podUrl),
-          generateDocumentsAcl(session, podUrl),
-          updateUserActivity(session, podUrl)
+          createPublicContainer(session, fetchedPodUrl),
+          createDocumentsContainer(session, fetchedPodUrl),
+          updateUserActivity(session, fetchedPodUrl)
         ]);
       } finally {
         setLoadingUserInfo(false);

--- a/src/contexts/SignedInUserContext.jsx
+++ b/src/contexts/SignedInUserContext.jsx
@@ -76,8 +76,6 @@ export const SignedInUserContextProvider = ({ children }) => {
     }
   }, [session.info.isLoggedIn]);
 
-  console.log(userInfoMemo);
-
   return (
     <SignedInUserContext.Provider value={userInfoMemo}>{children}</SignedInUserContext.Provider>
   );

--- a/src/contexts/SignedInUserContext.jsx
+++ b/src/contexts/SignedInUserContext.jsx
@@ -60,7 +60,7 @@ export const SignedInUserContextProvider = ({ children }) => {
         if (fetchedProfileData.profileInfo.profileImage) {
           localStorage.setItem('profileImage', fetchedProfileData.profileInfo.profileImage);
         }
-        setProfileData(profileData);
+        setProfileData(fetchedProfileData);
         await Promise.all([
           createPublicContainer(session, podUrl),
           generateDocumentsAcl(session, podUrl),
@@ -75,6 +75,8 @@ export const SignedInUserContextProvider = ({ children }) => {
       loadUserInfo();
     }
   }, [session.info.isLoggedIn]);
+
+  console.log(userInfoMemo);
 
   return (
     <SignedInUserContext.Provider value={userInfoMemo}>{children}</SignedInUserContext.Provider>

--- a/src/contexts/SignedInUserContext.jsx
+++ b/src/contexts/SignedInUserContext.jsx
@@ -34,38 +34,33 @@ export const SignedInUserContext = createContext({});
 export const SignedInUserContextProvider = ({ children }) => {
   const { session } = useSession();
   const [loadingUserInfo, setLoadingUserInfo] = useState(true);
-  const [userInfo, setUserInfo] = useState({
-    podUrl: null,
-    profileData: null
-  });
+  const [podUrl, setPodUrl] = useState('');
+  const [profileData, setProfileData] = useState(null);
 
   const userInfoMemo = useMemo(
     () => ({
-      podUrl: userInfo.podUrl,
-      profileData: userInfo.profileData,
-      setProfileData: async (profileData) => setUserInfo({ ...userInfo, profileData }),
+      podUrl,
+      profileData,
+      setProfileData: async (newProfileData) => setProfileData(newProfileData),
       fetchProfileInfo,
       updateProfileInfo,
       uploadProfileImage,
       removeProfileImage
     }),
-    [userInfo, loadingUserInfo]
+    [podUrl, profileData, loadingUserInfo]
   );
 
   useEffect(() => {
     const loadUserInfo = async () => {
       try {
         const { webId } = session.info;
-        let podUrl = (await getPodUrlAll(webId, { fetch: session.fetch }))[0];
-        podUrl = podUrl || webId.split('profile')[0];
-        const profileData = await fetchProfileInfo(session);
-        if (profileData.profileInfo.profileImage) {
-          localStorage.setItem('profileImage', profileData.profileInfo.profileImage);
+        const fetchedPodUrl = (await getPodUrlAll(webId, { fetch: session.fetch }))[0];
+        setPodUrl(fetchedPodUrl || webId.split('profile')[0]);
+        const fetchedProfileData = await fetchProfileInfo(session);
+        if (fetchedProfileData.profileInfo.profileImage) {
+          localStorage.setItem('profileImage', fetchedProfileData.profileInfo.profileImage);
         }
-        setUserInfo({
-          podUrl,
-          profileData
-        });
+        setProfileData(profileData);
         await Promise.all([
           createPublicContainer(session, podUrl),
           generateDocumentsAcl(session, podUrl),

--- a/src/contexts/SignedInUserContext.jsx
+++ b/src/contexts/SignedInUserContext.jsx
@@ -4,7 +4,7 @@ import React, { createContext, useState, useMemo, useEffect } from 'react';
 import { useSession } from '@inrupt/solid-ui-react';
 import { getPodUrlAll } from '@inrupt/solid-client';
 // Utility Imports
-import { createDocumentsContainer, createPublicContainer } from '../utils';
+import { generateDocumentsAcl, createPublicContainer } from '../utils';
 import {
   fetchProfileInfo,
   updateProfileInfo,
@@ -68,7 +68,7 @@ export const SignedInUserContextProvider = ({ children }) => {
         });
         await Promise.all([
           createPublicContainer(session, podUrl),
-          createDocumentsContainer(session, podUrl),
+          generateDocumentsAcl(session, podUrl),
           updateUserActivity(session, podUrl)
         ]);
       } finally {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,8 +1,7 @@
 /**
  * The utils module to help run functions for PASS forms, notifications, and
- * Solid Session. The file session-core contains functions that is exported to
- * PASS, while session-helper contains functions that is only exported to
- * session-core
+ * Solid Session, and Pod management. The file session-core contains functions
+ * that is exported to PASS
  *
  * @module utils
  * @namespace utils
@@ -16,3 +15,4 @@ export { runNotification, getDriversLicenseData, formattedDate };
 export * from './cryptography/credentials-helper';
 export * from './network/session-core';
 export * from './network/session-helper';
+export * from './pod-management/pod-helper';

--- a/src/utils/network/session-core.js
+++ b/src/utils/network/session-core.js
@@ -1,11 +1,4 @@
-import {
-  createContainerAt,
-  getSolidDataset,
-  getThingAll,
-  getFile,
-  hasResourceAcl,
-  getSolidDatasetWithAcl
-} from '@inrupt/solid-client';
+import { getSolidDataset, getThingAll, getFile } from '@inrupt/solid-client';
 import { INTERACTION_TYPES } from '../../constants';
 import {
   getContainerUrl,
@@ -14,7 +7,6 @@ import {
   saveMessageTTL,
   parseMessageTTL,
   buildMessageTTL,
-  setDocAclForPublic,
   getPodUrl
 } from './session-helper';
 
@@ -88,66 +80,6 @@ export const setDocContainerAclPermission = async (
   const webId = `${otherPodUrl}profile/card#me`;
 
   await setDocAclForUser(session, containerUrl, 'update', webId, permissions);
-};
-
-/**
- * Function that creates a public container in the user's Pod when logging in for
- * the first time or if Public is missing and initialize it with an ACL with
- * access to the user
- *
- * @memberof utils
- * @function createPublicContainer
- * @param {Session} session - Solid's Session Object {@link Session}
- * @param {URL} podUrl - The user's Pod URL
- * @returns {Promise} Promise - Generates a public container for Pod upon log in
- * if user's Pod does not have the an outbox to begin with
- */
-
-export const createPublicContainer = async (session, podUrl) => {
-  const publicContainerUrl = `${podUrl}PASS/Public/`;
-
-  try {
-    await getSolidDataset(publicContainerUrl, { fetch: session.fetch });
-  } catch {
-    await createContainerAt(publicContainerUrl, { fetch: session.fetch });
-
-    // Generate ACL file for container
-    await setDocAclForUser(session, publicContainerUrl, 'create', session.info.webId);
-    await setDocAclForPublic(session, publicContainerUrl, { read: true });
-  }
-};
-
-/**
- * Function that creates a Documents container in the user's Pod when logging in
- * for the first time or if Documents is missing and initialize it with an ACL with
- * access to the user
- *
- * @memberof utils
- * @function createDocumentsContainer
- * @param {Session} session - Solid's Session Object {@link Session}
- * @param {URL} podUrl - The user's Pod URL
- * @returns {Promise} Promise - Generates a Documents container for Pod upon log
- * in if user's Pod does not have the an outbox to begin with
- */
-export const createDocumentsContainer = async (session, podUrl) => {
-  const documentsContainerUrl = `${podUrl}PASS/Documents/`;
-
-  try {
-    const solidDataset = await getSolidDatasetWithAcl(documentsContainerUrl, {
-      fetch: session.fetch
-    });
-
-    const resourceAclExists = hasResourceAcl(solidDataset);
-
-    if (!resourceAclExists) {
-      await setDocAclForUser(session, documentsContainerUrl, 'create', session.info.webId);
-    }
-  } catch {
-    await createContainerAt(documentsContainerUrl, { fetch: session.fetch });
-
-    // Generate ACL file for container
-    await setDocAclForUser(session, documentsContainerUrl, 'create', session.info.webId);
-  }
 };
 
 /*
@@ -263,57 +195,6 @@ export const sendMessageTTL = async (session, messageObject, podUrl) => {
     ]);
   } catch (error) {
     throw new Error('Message failed to send. Reason: Inbox does not exist for sender or recipient');
-  }
-};
-
-/**
- * Function that creates an outbox container in the user's Pod when logging in for
- * the first time
- *
- * @memberof utils
- * @function createOutbox
- * @param {Session} session - Solid's Session Object {@link Session}
- * @param {URL} podUrl - The pod URL of user
- * @returns {Promise} Promise - Generates an outbox for Pod upon log in if
- * user's Pod does not have the an outbox to begin with
- */
-
-export const createOutbox = async (session, podUrl) => {
-  const outboxContainerUrl = `${podUrl}PASS/Outbox/`;
-
-  try {
-    await getSolidDataset(outboxContainerUrl, { fetch: session.fetch });
-  } catch {
-    await createContainerAt(outboxContainerUrl, { fetch: session.fetch });
-
-    // Generate ACL file for container
-    await setDocAclForUser(session, outboxContainerUrl, 'create', session.info.webId);
-  }
-};
-
-/**
- * Function that creates an inbox container in the user's Pod when logging in for
- * the first time
- *
- * @memberof utils
- * @function createInbox
- * @param {Session} session - Solid's Session Object {@link Session}
- * @param {URL} podUrl - The pod URL of user
- * @returns {Promise} Promise - Generates an outbox for Pod upon log in if
- * user's Pod does not have the an outbox to begin with
- */
-
-export const createInbox = async (session, podUrl) => {
-  const inboxContainerUrl = `${podUrl}PASS/Inbox/`;
-
-  try {
-    await getSolidDataset(inboxContainerUrl, { fetch: session.fetch });
-  } catch {
-    await createContainerAt(inboxContainerUrl, { fetch: session.fetch });
-
-    // Generate ACL file for container
-    await setDocAclForUser(session, inboxContainerUrl, 'create', session.info.webId);
-    await setDocAclForPublic(session, inboxContainerUrl, { append: true });
   }
 };
 

--- a/src/utils/network/session-core.js
+++ b/src/utils/network/session-core.js
@@ -3,8 +3,8 @@ import {
   getSolidDataset,
   getThingAll,
   getFile,
-  getSolidDatasetWithAcl,
-  hasResourceAcl
+  hasResourceAcl,
+  getSolidDatasetWithAcl
 } from '@inrupt/solid-client';
 import { INTERACTION_TYPES } from '../../constants';
 import {

--- a/src/utils/network/session-core.js
+++ b/src/utils/network/session-core.js
@@ -122,27 +122,20 @@ export const createPublicContainer = async (session, podUrl) => {
  * access to the user
  *
  * @memberof utils
- * @function createDocumentsContainer
+ * @function generateDocumentsAcl
  * @param {Session} session - Solid's Session Object {@link Session}
  * @param {URL} podUrl - The user's Pod URL
  * @returns {Promise} Promise - Generates a Documents container for Pod upon log
  * in if user's Pod does not have the an outbox to begin with
  */
-export const createDocumentsContainer = async (session, podUrl) => {
+export const generateDocumentsAcl = async (session, podUrl) => {
   const documentsContainerUrl = `${podUrl}PASS/Documents/`;
 
-  try {
-    const solidDataset = await getSolidDataset(documentsContainerUrl, {
-      fetch: session.fetch
-    });
+  const solidDataset = await getSolidDataset(documentsContainerUrl, {
+    fetch: session.fetch
+  });
 
-    if (!hasAcl(solidDataset)) {
-      await setDocAclForUser(session, documentsContainerUrl, 'create', session.info.webId);
-    }
-  } catch {
-    await createContainerAt(documentsContainerUrl, { fetch: session.fetch });
-
-    // Generate ACL file for container
+  if (!hasAcl(solidDataset)) {
     await setDocAclForUser(session, documentsContainerUrl, 'create', session.info.webId);
   }
 };

--- a/src/utils/pod-management/pod-helper.js
+++ b/src/utils/pod-management/pod-helper.js
@@ -1,0 +1,119 @@
+import {
+  createContainerAt,
+  getSolidDataset,
+  getSolidDatasetWithAcl,
+  hasResourceAcl
+} from '@inrupt/solid-client';
+import { setDocAclForPublic, setDocAclForUser } from '../network/session-helper';
+
+/**
+ * @typedef {import('@inrupt/solid-ui-react').SessionContext} Session
+ */
+
+/**
+ * Function that creates a public container in the user's Pod when logging in for
+ * the first time or if Public is missing and initialize it with an ACL with
+ * access to the user
+ *
+ * @memberof utils
+ * @function createPublicContainer
+ * @param {Session} session - Solid's Session Object {@link Session}
+ * @param {URL} podUrl - The user's Pod URL
+ * @returns {Promise} Promise - Generates a public container for Pod upon log in
+ * if user's Pod does not have the an outbox to begin with
+ */
+export const createPublicContainer = async (session, podUrl) => {
+  const publicContainerUrl = `${podUrl}PASS/Public/`;
+
+  try {
+    await getSolidDataset(publicContainerUrl, { fetch: session.fetch });
+  } catch {
+    await createContainerAt(publicContainerUrl, { fetch: session.fetch });
+
+    // Generate ACL file for container
+    await setDocAclForUser(session, publicContainerUrl, 'create', session.info.webId);
+    await setDocAclForPublic(session, publicContainerUrl, { read: true });
+  }
+};
+
+/**
+ * Function that creates a Documents container in the user's Pod when logging in
+ * for the first time or if Documents is missing and initialize it with an ACL with
+ * access to the user
+ *
+ * @memberof utils
+ * @function createDocumentsContainer
+ * @param {Session} session - Solid's Session Object {@link Session}
+ * @param {URL} podUrl - The user's Pod URL
+ * @returns {Promise} Promise - Generates a Documents container for Pod upon log
+ * in if user's Pod does not have the an outbox to begin with
+ */
+export const createDocumentsContainer = async (session, podUrl) => {
+  const documentsContainerUrl = `${podUrl}PASS/Documents/`;
+
+  try {
+    const solidDataset = await getSolidDatasetWithAcl(documentsContainerUrl, {
+      fetch: session.fetch
+    });
+
+    const resourceAclExists = hasResourceAcl(solidDataset);
+
+    if (!resourceAclExists) {
+      await setDocAclForUser(session, documentsContainerUrl, 'create', session.info.webId);
+    }
+  } catch {
+    await createContainerAt(documentsContainerUrl, { fetch: session.fetch });
+
+    // Generate ACL file for container
+    await setDocAclForUser(session, documentsContainerUrl, 'create', session.info.webId);
+  }
+};
+
+/**
+ * Function that creates an outbox container in the user's Pod when logging in for
+ * the first time
+ *
+ * @memberof utils
+ * @function createOutbox
+ * @param {Session} session - Solid's Session Object {@link Session}
+ * @param {URL} podUrl - The pod URL of user
+ * @returns {Promise} Promise - Generates an outbox for Pod upon log in if
+ * user's Pod does not have the an outbox to begin with
+ */
+export const createOutbox = async (session, podUrl) => {
+  const outboxContainerUrl = `${podUrl}PASS/Outbox/`;
+
+  try {
+    await getSolidDataset(outboxContainerUrl, { fetch: session.fetch });
+  } catch {
+    await createContainerAt(outboxContainerUrl, { fetch: session.fetch });
+
+    // Generate ACL file for container
+    await setDocAclForUser(session, outboxContainerUrl, 'create', session.info.webId);
+  }
+};
+
+/**
+ * Function that creates an inbox container in the user's Pod when logging in for
+ * the first time
+ *
+ * @memberof utils
+ * @function createInbox
+ * @param {Session} session - Solid's Session Object {@link Session}
+ * @param {URL} podUrl - The pod URL of user
+ * @returns {Promise} Promise - Generates an outbox for Pod upon log in if
+ * user's Pod does not have the an outbox to begin with
+ */
+export const createInbox = async (session, podUrl) => {
+  const inboxContainerUrl = `${podUrl}PASS/Inbox/`;
+
+  try {
+    await getSolidDataset(inboxContainerUrl, { fetch: session.fetch });
+  } catch {
+    await createContainerAt(inboxContainerUrl, { fetch: session.fetch });
+
+    // Generate ACL file for container
+    await setDocAclForUser(session, inboxContainerUrl, 'create', session.info.webId);
+    await setDocAclForPublic(session, inboxContainerUrl, { append: true });
+  }
+};

--- a/test/utils/pod-helper.test.js
+++ b/test/utils/pod-helper.test.js
@@ -1,0 +1,161 @@
+import * as solidClient from '@inrupt/solid-client';
+import { expect, vi, it, describe, afterEach, beforeEach } from 'vitest';
+import {
+  createDocumentsContainer,
+  createInbox,
+  createOutbox,
+  createPublicContainer
+} from '../../src/utils/pod-management/pod-helper';
+import * as sessionHelpers from '../../src/utils/network/session-helper';
+
+const mockPodUrl = 'https://pod.example.com/';
+let session = {};
+
+vi.mock('@inrupt/solid-client');
+
+describe('createInbox', () => {
+  beforeEach(() => {
+    session = {
+      fetch: vi.fn(),
+      info: {
+        webId: `${mockPodUrl}profile/card#me`
+      }
+    };
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const inboxContainerUrl = `${mockPodUrl}PASS/Inbox/`;
+
+  it('just runs getSolidDataset if container exist', async () => {
+    await createInbox(session, inboxContainerUrl);
+    expect(solidClient.getSolidDataset).toBeCalled();
+    expect(solidClient.createContainerAt).not.toBeCalled();
+  });
+
+  it('runs catch block if getSolidDataset rejects', async () => {
+    solidClient.getSolidDataset.mockRejectedValueOnce(Error('No data found'));
+    vi.spyOn(sessionHelpers, 'setDocAclForUser').mockResolvedValue();
+
+    await createInbox(session, inboxContainerUrl);
+    expect(solidClient.getSolidDataset).toBeCalled();
+    expect(solidClient.createContainerAt).toBeCalled();
+    expect(sessionHelpers.setDocAclForUser).toBeCalled();
+  });
+});
+
+describe('createOutbox', () => {
+  beforeEach(() => {
+    session = {
+      fetch: vi.fn(),
+      info: {
+        webId: `${mockPodUrl}profile/card#me`
+      }
+    };
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const outboxContainerUrl = `${mockPodUrl}PASS/Outbox/`;
+
+  it('just runs getSolidDataset if container exist', async () => {
+    await createOutbox(session, outboxContainerUrl);
+    expect(solidClient.getSolidDataset).toBeCalled();
+    expect(solidClient.createContainerAt).not.toBeCalled();
+  });
+
+  it('runs catch block if getSolidDataset rejects', async () => {
+    solidClient.getSolidDataset.mockRejectedValueOnce(Error('No data found'));
+    vi.spyOn(sessionHelpers, 'setDocAclForUser').mockResolvedValue();
+
+    await createOutbox(session, outboxContainerUrl);
+    expect(solidClient.getSolidDataset).toBeCalled();
+    expect(solidClient.createContainerAt).toBeCalled();
+    expect(sessionHelpers.setDocAclForUser).toBeCalled();
+  });
+});
+
+describe('createPublicContainer', () => {
+  beforeEach(() => {
+    session = {
+      fetch: vi.fn(),
+      info: {
+        webId: `${mockPodUrl}profile/card#me`
+      }
+    };
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const publicContainerUrl = `${mockPodUrl}PASS/Public/`;
+
+  it('just runs getSolidDataset if container exist', async () => {
+    await createPublicContainer(session, publicContainerUrl);
+    expect(solidClient.getSolidDataset).toBeCalled();
+    expect(solidClient.createContainerAt).not.toBeCalled();
+  });
+
+  it('runs catch block if getSolidDataset rejects', async () => {
+    solidClient.getSolidDataset.mockRejectedValueOnce(Error('No data found'));
+    vi.spyOn(sessionHelpers, 'setDocAclForUser').mockResolvedValue();
+    vi.spyOn(sessionHelpers, 'setDocAclForPublic').mockResolvedValue();
+
+    await createPublicContainer(session, publicContainerUrl);
+    expect(solidClient.getSolidDataset).toBeCalled();
+    expect(solidClient.createContainerAt).toBeCalled();
+    expect(sessionHelpers.setDocAclForUser).toBeCalled();
+    expect(sessionHelpers.setDocAclForPublic).toBeCalled();
+  });
+});
+
+describe('createDocumentsContainer', () => {
+  beforeEach(() => {
+    session = {
+      fetch: vi.fn(),
+      info: {
+        webId: `${mockPodUrl}profile/card#me`
+      }
+    };
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const publicContainerUrl = `${mockPodUrl}PASS/Documents/`;
+
+  it('runs getSolidDatasetWithAcl if container exist and hasResourceAcl is true', async () => {
+    vi.spyOn(solidClient, 'hasResourceAcl').mockReturnValue(true);
+    vi.spyOn(solidClient, 'getSolidDatasetWithAcl').mockResolvedValue();
+
+    await createDocumentsContainer(session, publicContainerUrl);
+    expect(solidClient.getSolidDatasetWithAcl).toBeCalled();
+    expect(solidClient.hasResourceAcl).toBeCalled();
+    expect(sessionHelpers.setDocAclForUser).not.toBeCalled();
+    expect(solidClient.createContainerAt).not.toBeCalled();
+  });
+
+  it('runs getSolidDatasetWithAcl if container exist and hasResourceAcl is false', async () => {
+    vi.spyOn(solidClient, 'hasResourceAcl').mockReturnValue(false);
+    vi.spyOn(solidClient, 'getSolidDatasetWithAcl').mockResolvedValue();
+
+    await createDocumentsContainer(session, publicContainerUrl);
+    expect(solidClient.getSolidDatasetWithAcl).toBeCalled();
+    expect(solidClient.hasResourceAcl).toBeCalled();
+    expect(sessionHelpers.setDocAclForUser).toBeCalled();
+    expect(solidClient.createContainerAt).not.toBeCalled();
+  });
+
+  it('runs catch block if getSolidDatasetWithAcl rejects', async () => {
+    vi.spyOn(solidClient, 'getSolidDatasetWithAcl').mockRejectedValue();
+    vi.spyOn(sessionHelpers, 'setDocAclForUser').mockResolvedValue();
+
+    await createDocumentsContainer(session, publicContainerUrl);
+    expect(solidClient.getSolidDatasetWithAcl).toBeCalled();
+    expect(solidClient.hasResourceAcl).not.toBeCalled();
+    expect(solidClient.createContainerAt).toBeCalled();
+    expect(sessionHelpers.setDocAclForUser).toBeCalled();
+  });
+});


### PR DESCRIPTION
## PR Details

This PR will re-establish cross-pod functionality for file viewing and permission setting to `/PASS/Documents` by initializing ACL file for `/PASS/Documents` if ACL does not exist in `/PASS/Documents`.

See clip:

https://github.com/codeforpdx/PASS/assets/14917816/68105ebb-ca54-4a39-9309-258dd3ea19b2

`setDocContainerAclPermission` has been updated to only update permissions to `/PASS/Documents` with the Access Object for users who's permissions were given to read and append only, compare to read and write previously. This would allow case workers to able to upload new documents and read existing documents of clients, but not delete existing documents on the clients Pod.

`setDocContainerAclPermission` are also updated to utilize `podUrl` to simplify the generation of the containerUrl to `/PASS/Documents`.

`createPublicContainer` is also re-introduced to PASS, however, this would be a limited version meant to create a skeleton container for generating the `/PASS/Documents` ACL for the user. If the container already exist, but missing an ACL, it'll generate a new ACL. If the container is missing, it'll generate a new `/PASS/Documents` container with the new ACL. No additional containers would be built.

Additional changes has been made for `SignedInUserContext`, with `podUrl` and `profileData` now being stored within their own separate useStates, but keeping the same name for storing their relative states.