### PR TITLE
Issue 298/update profile to spec

### DIFF
--- a/src/constants/rdf_predicates.js
+++ b/src/constants/rdf_predicates.js
@@ -1,4 +1,4 @@
-import { SCHEMA_INRUPT, FOAF } from '@inrupt/vocab-common-rdf';
+import { SCHEMA_INRUPT, FOAF, LDP, RDF } from '@inrupt/vocab-common-rdf';
 
 const RDF_PREDICATES = {
   ...SCHEMA_INRUPT,
@@ -26,7 +26,16 @@ const RDF_PREDICATES = {
   accountablePerson: 'https://schema.org/accountablePerson',
   profileName: FOAF.name,
   profileImg: FOAF.img,
-  nickname: FOAF.nick
+  nickname: FOAF.nick,
+  type: RDF.type,
+  preferenceFile: 'http://www.w3.org/ns/pim/space#preferencesFile',
+  publicTypeIndex: 'http://www.w3.org/ns/solid/terms#publicTypeIndex',
+  privateTypeIndex: 'http://www.w3.org/ns/solid/terms#privateTypeIndex',
+  typeIndex: 'http://www.w3.org/ns/solid/terms#TypeIndex',
+  listedDocument: 'http://www.w3.org/ns/solid/terms#ListedDocument',
+  unlistedDocument: 'http://www.w3.org/ns/solid/terms#UnlistedDocument',
+  storage: 'http://www.w3.org/ns/pim/space#storage',
+  inbox: LDP.inbox
 };
 
 export default RDF_PREDICATES;

--- a/src/model-helpers/Profile.js
+++ b/src/model-helpers/Profile.js
@@ -115,6 +115,7 @@ export const createSettingsContainer = async (session, podUrl) => {
 export const initializeSolidProfile = async (session, podUrl) => {
   let profileDataset = await getWebIdDataset(session.info.webId);
   let profileThing = getThing(profileDataset, session.info.webId);
+  let updated = false;
 
   const preferenceFile = getUrl(profileThing, RDF_PREDICATES.preferenceFile);
   if (!preferenceFile) {
@@ -122,6 +123,7 @@ export const initializeSolidProfile = async (session, podUrl) => {
       .addUrl(RDF_PREDICATES.preferenceFile, `${podUrl}settings/prefs.ttl`)
       .build();
     profileDataset = setThing(profileDataset, profileThing);
+    updated = true;
   }
 
   const publicTypeIndex = getUrl(profileThing, RDF_PREDICATES.publicTypeIndex);
@@ -130,6 +132,7 @@ export const initializeSolidProfile = async (session, podUrl) => {
       .addUrl(RDF_PREDICATES.publicTypeIndex, `${podUrl}settings/publicTypeIndex.ttl`)
       .build();
     profileDataset = setThing(profileDataset, profileThing);
+    updated = true;
   }
 
   const privateTypeIndex = getUrl(profileThing, RDF_PREDICATES.privateTypeIndex);
@@ -138,12 +141,14 @@ export const initializeSolidProfile = async (session, podUrl) => {
       .addUrl(RDF_PREDICATES.privateTypeIndex, `${podUrl}settings/privateTypeIndex.ttl`)
       .build();
     profileDataset = setThing(profileDataset, profileThing);
+    updated = true;
   }
 
   const storage = getUrl(profileThing, RDF_PREDICATES.storage);
   if (!storage) {
     profileThing = buildThing(profileThing).addUrl(RDF_PREDICATES.storage, podUrl).build();
     profileDataset = setThing(profileDataset, profileThing);
+    updated = true;
   }
 
   const inbox = getUrl(profileThing, RDF_PREDICATES.inbox);
@@ -152,9 +157,12 @@ export const initializeSolidProfile = async (session, podUrl) => {
       .addUrl(RDF_PREDICATES.inbox, `${podUrl}PASS/Inbox/`)
       .build();
     profileDataset = setThing(profileDataset, profileThing);
+    updated = true;
   }
 
-  await saveSolidDatasetAt(session.info.webId, profileDataset, { fetch: session.fetch });
+  if (updated) {
+    await saveSolidDatasetAt(session.info.webId, profileDataset, { fetch: session.fetch });
+  }
 };
 
 /**

--- a/src/model-helpers/Profile.js
+++ b/src/model-helpers/Profile.js
@@ -82,12 +82,12 @@ export const createSettingsContainer = async (session, podUrl) => {
     );
 
     // Generate Preference File Document
-    const newPreferenceFileThing = buildThing(createThing({ name: 'Preferences_file' }))
+    const newPreferenceFileThing = buildThing(createThing({ name: 'preferences_file' }))
       .addUrl(RDF_PREDICATES.type, RDF_PREDICATES.preferenceFile)
       .addStringNoLocale(RDF_PREDICATES.title, 'Preferences file')
       .build();
 
-    const newPreferenceFileDocumentsThing = buildThing(createThing({ name: session.info.webid }))
+    const newPreferenceFileDocumentsThing = buildThing(createThing({ name: 'type_index_files' }))
       .addUrl(RDF_PREDICATES.publicTypeIndex, `${settingsContainerUrl}publicTypeIndex.ttl`)
       .addUrl(RDF_PREDICATES.privateTypeIndex, `${settingsContainerUrl}privateTypeIndex.ttl`)
       .build();

--- a/test/model-helpers/Profile.test.js
+++ b/test/model-helpers/Profile.test.js
@@ -62,7 +62,7 @@ describe('initializeSolidProfile', () => {
     vi.clearAllMocks();
   });
 
-  it('run saveSolidDatasetAt only if update is true', async () => {
+  it('does not run saveSolidDatasetAt when update is false', async () => {
     vi.spyOn(solidClient, 'getWebIdDataset').mockResolvedValue();
     vi.spyOn(solidClient, 'getThing').mockReturnValue();
     vi.spyOn(solidClient, 'getUrl').mockReturnValue(true);
@@ -71,6 +71,25 @@ describe('initializeSolidProfile', () => {
     await initializeSolidProfile(session, mockPodUrl);
 
     expect(solidClient.saveSolidDatasetAt).not.toBeCalled();
+  });
+
+  const buildThing = vi.fn().mockReturnValue({
+    addUrl: vi.fn().mockReturnValue(),
+    build: vi.fn().mockReturnValue()
+  });
+
+  it('run saveSolidDatasetAt when update is true', async () => {
+    vi.spyOn(solidClient, 'getWebIdDataset').mockResolvedValue();
+    vi.spyOn(solidClient, 'getThing').mockReturnValue();
+    vi.spyOn(solidClient, 'getUrl').mockReturnValue(false);
+    buildThing.mockReturnValue();
+    vi.spyOn(solidClient, 'setThing').mockReturnValue();
+    vi.spyOn(solidClient, 'saveSolidDatasetAt');
+
+    await initializeSolidProfile(session, mockPodUrl);
+
+    expect(solidClient.setThing).toBeCalledTimes(5);
+    expect(solidClient.saveSolidDatasetAt).toBeCalled();
   });
 });
 


### PR DESCRIPTION
## Update: [Draft]

This PR will update the profile card based on more recent specifications as pointed by Jeff: https://solid.github.io/webid-profile/

On the frontend, the "Profile" page will remain unaffected. The changes are largely under the hood, where it updates a Solid WebId Profile from PASS to fill out certain fields that are consider a must or recommended in the spec for a full Profile. This includes:

- `pim:preferencesFile`
- `solid:publicTypeIndex`
- `solid:privateTypeIndex`
- `prim:storage`
- `ldp:inbox`

and are only triggered if any of the above is missing.

A new `settings` container has been created to store the relevant preference files and type index files.

Extended Profile Documents are excluded for now.