### PR TITLE
Issue 247/update to dayjs

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -1,5 +1,7 @@
 // React Imports
 import React from 'react';
+// Other Library Imports
+import dayjs from 'dayjs';
 // Material UI Imports
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -93,7 +95,7 @@ const legalLinks = [
     target: '_blank',
     rel: 'noopenner',
     ml: 0.5,
-    text: `©${new Date().getFullYear()}`,
+    text: `©${dayjs().year()}`,
     title: 'Code for PDX'
   }
 ];

--- a/src/components/Modals/UploadDocumentModal.jsx
+++ b/src/components/Modals/UploadDocumentModal.jsx
@@ -148,7 +148,7 @@ const UploadDocumentModal = ({ showModal, setShowModal }) => {
             <br />
             {/* File to upload: {file ? file.name : 'No file selected'} */}
             <Button
-              variant={file ? 'contained' : 'outlined'}
+              variant={file ? 'outlined' : 'contained'}
               component="label"
               color="primary"
               id="upload-doctype"

--- a/src/model-helpers/Document.js
+++ b/src/model-helpers/Document.js
@@ -7,6 +7,7 @@ import {
   getDate
 } from '@inrupt/solid-client';
 
+import dayjs from 'dayjs';
 import sha256 from 'crypto-js/sha256';
 
 import { RDF_PREDICATES } from '../constants';
@@ -67,12 +68,12 @@ const addDriversLicenseInfo = async (thing, file) => {
     return thing
       .addStringNoLocale(RDF_PREDICATES.additionalType, dlData.DCA)
       .addStringNoLocale(RDF_PREDICATES.conditionsOfAccess, dlData.DCB)
-      .addDate(RDF_PREDICATES.expires, new Date(`${formattedDate(dlData.DBA)}`))
+      .addDate(RDF_PREDICATES.expires, dayjs(`${formattedDate(dlData.DBA)}`).$d)
       .addStringNoLocale(RDF_PREDICATES.givenName, dlData.DCS)
       .addStringNoLocale(RDF_PREDICATES.alternateName, dlData.DAC)
       .addStringNoLocale(RDF_PREDICATES.familyName, dlData.DAD)
-      .addDate(RDF_PREDICATES.dateIssued, new Date(`${formattedDate(dlData.DBD)}`))
-      .addDate(RDF_PREDICATES.dateOfBirth, new Date(`${formattedDate(dlData.DBB)}`))
+      .addDate(RDF_PREDICATES.dateIssued, dayjs(`${formattedDate(dlData.DBD)}`).$d)
+      .addDate(RDF_PREDICATES.dateOfBirth, dayjs(`${formattedDate(dlData.DBB)}`).$d)
       .addStringNoLocale(RDF_PREDICATES.gender, dlData.DBC)
       .addStringNoLocale(RDF_PREDICATES.Eye, dlData.DAY)
       .addInteger(RDF_PREDICATES.height, Number(dlData.DAU))
@@ -136,14 +137,14 @@ const addAdditionalInfo = async (docDesc, thing, file) => {
 export const makeDocIntoThing = async (docDesc, file) => {
   const checksum = await createFileChecksum(file);
   let thing = buildThing(createThing({ name: docDesc.name }))
-    .addDate(RDF_PREDICATES.uploadDate, new Date())
+    .addDate(RDF_PREDICATES.uploadDate, dayjs().$d)
     .addStringNoLocale(RDF_PREDICATES.name, docDesc.name)
     .addStringNoLocale(RDF_PREDICATES.identifier, docDesc.type)
     .addStringNoLocale(RDF_PREDICATES.additionalType, docDesc.type)
     .addStringNoLocale(RDF_PREDICATES.sha256, checksum)
     .addStringNoLocale(RDF_PREDICATES.description, docDesc.description);
 
-  if (docDesc.date) thing.addDate(RDF_PREDICATES.endDate, new Date(docDesc.date));
+  if (docDesc.date) thing.addDate(RDF_PREDICATES.endDate, dayjs(docDesc.date).$d);
   thing = await addAdditionalInfo(docDesc, thing, file);
   return thing.build();
 };

--- a/src/model-helpers/User.js
+++ b/src/model-helpers/User.js
@@ -10,6 +10,7 @@ import {
   getUrl,
   getThing
 } from '@inrupt/solid-client';
+import dayjs from 'dayjs';
 import { RDF_PREDICATES } from '../constants';
 
 import { setDocAclForUser } from '../utils';
@@ -64,13 +65,13 @@ export const updateUserActivity = async (session, podUrl) => {
     const activeTTLThing = getThing(activityDataset, `${activityDocUrl}#active`);
 
     const activeTTL = buildThing(activeTTLThing)
-      .setDatetime(RDF_PREDICATES.dateModified, new Date())
+      .setDatetime(RDF_PREDICATES.dateModified, dayjs().$d)
       .build();
 
     await saveActivity(activeTTL);
   } catch {
     const newActiveTTL = buildThing(createThing({ name: 'active' }))
-      .addDatetime(RDF_PREDICATES.dateModified, new Date())
+      .addDatetime(RDF_PREDICATES.dateModified, dayjs().$d)
       .build();
 
     activityDataset = createSolidDataset();

--- a/src/utils/barcode/barcode-date-parser.js
+++ b/src/utils/barcode/barcode-date-parser.js
@@ -1,3 +1,5 @@
+import dayjs from 'dayjs';
+
 /**
  * Formats dates returned from barcode scanner
  * into consistent format (i.e. 2023-12-31)
@@ -10,8 +12,7 @@
 
 const formattedDate = (dateStr) => {
   const dateStrWithSpaces = dateStr.replace(/(\d{2})(\d{2})(\d{4})/, '$1 $2 $3');
-  const newDate = new Date(dateStrWithSpaces);
-  return newDate.toISOString();
+  return dayjs(dateStrWithSpaces).toISOString();
 };
 
 export default formattedDate;

--- a/src/utils/network/session-core.js
+++ b/src/utils/network/session-core.js
@@ -1,4 +1,5 @@
 import { getSolidDataset, getThingAll, getFile } from '@inrupt/solid-client';
+import dayjs from 'dayjs';
 import { INTERACTION_TYPES } from '../../constants';
 import {
   getContainerUrl,
@@ -173,9 +174,9 @@ export const sendMessageTTL = async (session, messageObject, podUrl) => {
     throw new Error('Message failed to send. Reason: Recipient username not found');
   }
 
-  const date = new Date();
-  const dateYYYYMMDD = date.toISOString().split('T')[0].replace(/-/g, '');
-  const dateISOTime = date.toISOString().split('T')[1].split('.')[0].replace(/:/g, '');
+  const date = dayjs().$d;
+  const dateYYYYMMDD = dayjs().format('YYYYMMDD');
+  const dateISOTime = dayjs().toISOString().split('T')[1].split('.')[0].replace(/:/g, '');
 
   const newSolidDataset = buildMessageTTL(
     session,

--- a/src/utils/network/session-helper.js
+++ b/src/utils/network/session-helper.js
@@ -20,6 +20,7 @@ import {
   getDatetime,
   createSolidDataset
 } from '@inrupt/solid-client';
+import dayjs from 'dayjs';
 import sha256 from 'crypto-js/sha256';
 import getDriversLicenseData from '../barcode/barcode-scan';
 import formattedDate from '../barcode/barcode-date-parser';
@@ -226,7 +227,7 @@ export const updateTTLFile = async (session, containerUrl, fileObject) => {
   ttlFile = buildThing(ttlFile)
     .setStringNoLocale(RDF_PREDICATES.endDate, fileObject.date)
     .setStringNoLocale(RDF_PREDICATES.description, fileObject.description)
-    .setDatetime(RDF_PREDICATES.dateModified, new Date())
+    .setDatetime(RDF_PREDICATES.dateModified, dayjs().$d)
     .build();
   solidDataset = setThing(solidDataset, ttlFile);
 
@@ -270,15 +271,15 @@ const createFileChecksum = async (fileObject) => {
 const createDriversLicenseTtlFile = async (fileObject, documentUrl, checksum) => {
   const dlData = await getDriversLicenseData(fileObject.file);
   return buildThing(createThing({ name: 'document' }))
-    .addDatetime(RDF_PREDICATES.uploadDate, new Date())
+    .addDatetime(RDF_PREDICATES.uploadDate, dayjs().$d)
     .addStringNoLocale(RDF_PREDICATES.additionalType, dlData.DCA)
     .addStringNoLocale(RDF_PREDICATES.conditionsOfAccess, dlData.DCB)
-    .addDate(RDF_PREDICATES.expires, new Date(`${formattedDate(dlData.DBA)}`))
+    .addDate(RDF_PREDICATES.expires, dayjs(`${formattedDate(dlData.DBA)}`).$d)
     .addStringNoLocale(RDF_PREDICATES.givenName, dlData.DCS)
     .addStringNoLocale(RDF_PREDICATES.alternateName, dlData.DAC)
     .addStringNoLocale(RDF_PREDICATES.familyName, dlData.DAD)
-    .addDate(RDF_PREDICATES.dateIssued, new Date(`${formattedDate(dlData.DBD)}`))
-    .addDate(RDF_PREDICATES.dateOfBirth, new Date(`${formattedDate(dlData.DBB)}`))
+    .addDate(RDF_PREDICATES.dateIssued, dayjs(`${formattedDate(dlData.DBD)}`).$d)
+    .addDate(RDF_PREDICATES.dateOfBirth, dayjs(`${formattedDate(dlData.DBB)}`).$d)
     .addStringNoLocale(RDF_PREDICATES.gender, dlData.DBC)
     .addStringNoLocale(RDF_PREDICATES.Eye, dlData.DAY)
     .addInteger(RDF_PREDICATES.height, Number(dlData.DAU))
@@ -321,7 +322,7 @@ export const createResourceTtlFile = async (fileObject, documentUrl) => {
   }
 
   return buildThing(createThing({ name: 'document' }))
-    .addDatetime(RDF_PREDICATES.uploadDate, new Date())
+    .addDatetime(RDF_PREDICATES.uploadDate, dayjs().$d)
     .addStringNoLocale(RDF_PREDICATES.name, fileObject.file.name)
     .addStringNoLocale(RDF_PREDICATES.identifier, fileObject.type)
     .addStringNoLocale(RDF_PREDICATES.endDate, fileObject.date)

--- a/test/contexts/SignedInUserContext.test.jsx
+++ b/test/contexts/SignedInUserContext.test.jsx
@@ -9,6 +9,7 @@ import {
   createThing
 } from '@inrupt/solid-client';
 import { useSession } from '@inrupt/solid-ui-react';
+import dayjs from 'dayjs';
 import { expect, it, afterEach, describe, vi } from 'vitest';
 import { SignedInUserContext, SignedInUserContextProvider } from '../../src/contexts';
 import { RDF_PREDICATES } from '../../src/constants';
@@ -46,7 +47,7 @@ describe('SignedInUserContext', () => {
 
   it('fetches user data if user is logged in', async () => {
     const newActiveTTL = buildThing(createThing({ name: 'active' }))
-      .addDatetime(RDF_PREDICATES.dateModified, new Date())
+      .addDatetime(RDF_PREDICATES.dateModified, dayjs().$d)
       .build();
 
     const dataset = mockSolidDatasetFrom('https://example.com/pod/PASS/Public/active.ttl');

--- a/test/model-helpers/Document.test.js
+++ b/test/model-helpers/Document.test.js
@@ -1,6 +1,7 @@
 import { expect, vi, it, describe } from 'vitest';
 import { webcrypto } from 'crypto';
 import { buildThing, createThing } from '@inrupt/solid-client';
+import dayjs from 'dayjs';
 import sha256 from 'crypto-js/sha256';
 import { RDF_PREDICATES } from '../../src/constants';
 import { makeDocIntoThing, parseDocFromThing } from '../../src/model-helpers/Document';
@@ -22,7 +23,7 @@ describe('docDescToThing', () => {
     const doc = {
       name: 'name',
       type: 'type',
-      date: new Date('December 17, 1995'),
+      date: dayjs('December 17, 1995').$d,
       description: 'description'
     };
     const thing = await makeDocIntoThing(doc, testFile);
@@ -43,12 +44,12 @@ describe('parseDocument', () => {
     const doc = {
       name: 'name',
       type: 'type',
-      date: new Date('December 17, 1995'),
+      date: dayjs('December 17, 1995').$d,
       description: 'description'
     };
 
     const thing = buildThing(createThing({ name: doc.name }))
-      .addDate(RDF_PREDICATES.uploadDate, new Date())
+      .addDate(RDF_PREDICATES.uploadDate, dayjs().$d)
       .addStringNoLocale(RDF_PREDICATES.name, doc.name)
       .addStringNoLocale(RDF_PREDICATES.identifier, doc.type)
       .addDate(RDF_PREDICATES.endDate, doc.date)


### PR DESCRIPTION
PR's related to issue #247 where we want to replace existing JS Date objects with a library that's ISO-8601 compliant. As such, I've utilized the existing DayJS library in our project to do just that.

All JS Date objects has been converted to their DayJS equivalent in the codebase and some have been simplified for formatting.

One minor detail I've noticed was that the ordering of the `Choose File` variant was reversed. Since it's only one line, I've decided to I've patched it up in this PR as well. 