### PR TITLE
Fix spacing in mock template

### DIFF
--- a/__mocks__/src/constants/index.js
+++ b/__mocks__/src/constants/index.js
@@ -2,5 +2,5 @@ const ENV = {
     VITE_SOLID_IDENTITY_PROVIDER: 'https://solidcommunity.net'
 };
 
-// eslint-disable-next-line
-export { ENV };
+export { ENV }; /* eslint-disable-line */
+


### PR DESCRIPTION
eslint is configured to alert us if a file does not have a new line at the end. Not sure why it isn't doing that here. We can look into that later.