### PR TITLE
Minor patch for DocumentSelection

### DIFF
--- a/src/components/Documents/DocumentTableRow.jsx
+++ b/src/components/Documents/DocumentTableRow.jsx
@@ -11,7 +11,6 @@ import { getBlobFromSolid } from '../../utils';
 // Context Imports
 import { DocumentListContext } from '../../contexts';
 import { StyledTableCell, StyledTableRow } from '../Table/TableStyles';
-import DOC_TYPES from '../../constants/doc_types';
 
 /**
  * DocumentTableRow Component - A row in the Document Table
@@ -48,7 +47,7 @@ const DocumentTableRow = ({ document }) => {
   return (
     <StyledTableRow>
       <StyledTableCell align="center">{name}</StyledTableCell>
-      <StyledTableCell align="center">{DOC_TYPES[type]}</StyledTableCell>
+      <StyledTableCell align="center">{type}</StyledTableCell>
       <StyledTableCell align="center">{description}</StyledTableCell>
       <StyledTableCell align="center">
         {uploadDate ? uploadDate.toDateString() : ''}

--- a/src/components/Form/DocumentSelection.jsx
+++ b/src/components/Form/DocumentSelection.jsx
@@ -30,7 +30,7 @@ const DocumentSelection = ({ htmlForAndIdProp, handleDocType, docType }) => (
         name="document"
       >
         {Object.entries(DOC_TYPES).map(([key, value]) => (
-          <MenuItem key={key} value={key}>
+          <MenuItem key={key} value={value}>
             {value}
           </MenuItem>
         ))}

--- a/src/model-helpers/Document.js
+++ b/src/model-helpers/Document.js
@@ -117,7 +117,7 @@ const createFileChecksum = async (file) => {
  * @returns {Promise<ThingLocal>} a thing
  */
 const addAdditionalInfo = async (docDesc, thing, file) => {
-  if (docDesc.type === 'DriversLicense') {
+  if (docDesc.type === "Driver's License") {
     const retThing = await addDriversLicenseInfo(thing, file);
     return retThing;
   }


### PR DESCRIPTION
Found a small bug where DocumentSelection MenuItem was using `key` instead of `value` for the `value` attribute. So the type value would be correct with "Bank Statement" instead of "BankStatement", "Driver's License" instead of "DriversLicense", etc. These changes should fix things without breaking anything.

https://github.com/codeforpdx/PASS/assets/14917816/de1cd54c-f993-45e8-b5ef-d5f143f9de9e
