### PR TITLE
Issue 308/update status notification

### DIFF
--- a/src/components/Form/FormSection.jsx
+++ b/src/components/Form/FormSection.jsx
@@ -20,7 +20,7 @@ import { StatusNotification } from '../Notification';
  * {@link formSectionProps})
  */
 
-const FormSection = ({ title, state, statusType, defaultMessage, children }) => (
+const FormSection = ({ title, state, statusType, defaultMessage, file = null, children }) => (
   <Box
     sx={{
       marginTop: 1,
@@ -38,7 +38,12 @@ const FormSection = ({ title, state, statusType, defaultMessage, children }) => 
       {title}
     </Typography>
     {children}
-    <StatusNotification state={state} statusType={statusType} defaultMessage={defaultMessage} />
+    <StatusNotification
+      state={state}
+      statusType={statusType}
+      defaultMessage={defaultMessage}
+      file={file}
+    />
   </Box>
 );
 

--- a/src/components/Modals/UploadDocumentModal.jsx
+++ b/src/components/Modals/UploadDocumentModal.jsx
@@ -74,11 +74,11 @@ const UploadDocumentModal = ({ showModal, setShowModal }) => {
       date: expireDate,
       description: docDescription
     };
-    runNotification(`Uploading "${file.name}" to Solid...`, 3, state, dispatch);
+    runNotification(`Uploading file to Solid...`, 3, state, dispatch);
 
     try {
       await addDocument(fileDesc, file);
-      runNotification(`File "${file.name}" uploaded to Solid.`, 5, state, dispatch);
+      runNotification(`File uploaded to Solid.`, 5, state, dispatch);
     } catch (error) {
       const confirmationMessage =
         'A file of this name and type already exists on the pod. Would you like to replace it?';
@@ -87,7 +87,7 @@ const UploadDocumentModal = ({ showModal, setShowModal }) => {
         case 'File already exists':
           if (window.confirm(confirmationMessage)) {
             await replaceDocument(fileDesc, file);
-            runNotification(`File "${file.name}" updated on Solid.`, 5, state, dispatch);
+            runNotification(`File updated on Solid.`, 5, state, dispatch);
           }
           break;
         default:
@@ -105,6 +105,7 @@ const UploadDocumentModal = ({ showModal, setShowModal }) => {
         state={state}
         statusType="Upload status"
         defaultMessage="To be uploaded..."
+        file={file}
       >
         <form onSubmit={handleDocUpload} autoComplete="off">
           <FormControlLabel

--- a/src/components/Notification/StatusNotification.jsx
+++ b/src/components/Notification/StatusNotification.jsx
@@ -21,7 +21,7 @@ import StatusMessage from './StatusMessage';
  * is optional (see {@link statusNotificationProps})
  */
 
-const StatusNotification = ({ state, statusType, defaultMessage }) => (
+const StatusNotification = ({ state, statusType, defaultMessage, file }) => (
   <Box
     sx={{
       marginTop: 1,
@@ -36,7 +36,7 @@ const StatusNotification = ({ state, statusType, defaultMessage }) => (
       <StatusMessage
         notification={state.message}
         locationUrl={state.documentUrl}
-        filename={state.file?.name}
+        filename={file?.name}
       />
     ) : (
       <Typography>{defaultMessage}</Typography>

--- a/src/reducers/statusReducer.js
+++ b/src/reducers/statusReducer.js
@@ -22,7 +22,6 @@ export const initialStatusState = {
   documentUrl: null,
   message: '',
   timeoutID: null,
-  file: null,
   processing: false,
   verifyFile: false
 };
@@ -56,8 +55,6 @@ const statusReducer = (state, action) => {
       return { ...state, message: '' };
     case 'CLEAR_TIMEOUT_ID':
       return { ...state, timeoutID: null };
-    case 'CLEAR_FILE':
-      return { ...state, file: null };
     case 'CLEAR_PROCESSING':
       return { ...state, processing: false };
     case 'CLEAR_VERIFY_FILE':

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -11,7 +11,7 @@ const React = require('react');
  * @typedef {object} statusMessageProps
  * @property {string} notification - File status message
  * @property {URL} [locationUrl] - URL location of file, if exist
- * @property {string} [filename] - Name of the file being processed
+ * @property {string|null} [filename] - Name of the file being processed
  * @memberof typedefs
  */
 
@@ -25,6 +25,8 @@ const React = require('react');
  * fetch, file delete)
  * @property {string} defaultMessage - Default message when status is not
  * triggered
+ * @property {File|null} [file] - File object to be uploaded, if chosen, else
+ * returns null
  * @memberof typedefs
  */
 
@@ -51,7 +53,6 @@ const React = require('react');
  * @property {URL|null} documentUrl - Url link to document container
  * @property {string} message - Status message for file upload, query, or deletion
  * @property {string|null} timeoutID - Timeout ID for status message
- * @property {object|null} file - Object that includes file in question
  * @property {boolean} processing - Boolean on whether application is uploading,
  * fetching, querying data from Solid
  * @property {boolean} verifyFile - Boolean on whether to verify file upon file
@@ -95,6 +96,8 @@ const React = require('react');
  * (see {@link statusNotificationObject})
  * @property {string} statusType - Type of action for PASS
  * @property {string} defaultMessage - Default notification message when inactive
+ * @property {File|null} [file] - File object, if choosen for upload, else return
+ * null
  * @property {React.ReactElement} children - JSX Element of the wrapped form
  * @memberof typedefs
  */


### PR DESCRIPTION
This PR updates `FormSection` and subsequent children components `StatusNotification` and `StatusMessage` to utilize `file` instead of `state.file` since it's no longer in use.

The original intent of having the file name there in the first place was to decouple the file name from the status message in case there's a file with a long name (see Issue #244 and PR #245). This PR should restore this UI feature while removing the deprecated state for file from the reducer and relevant lines.

https://github.com/codeforpdx/PASS/assets/14917816/c056a9b7-20f3-4e94-8df2-f34280820ddf

Truncation like before utilizes CSS properties to truncate rather than explicitly truncating the file name to avoid data manipulation. That remains unchanged.