### PR TITLE
313 updating contributing branching instrutions

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,8 +50,7 @@ By participating in this project, you are expected to uphold our [Code of Conduc
 
 1. Clone repo to local environment in IDE of choice. If you are new to Git/GitHub you can also check out [this article](https://www.digitalocean.com/community/tutorials/how-to-create-a-pull-request-on-github) for a broad overview.
    - Open terminal & change working directory to the location you want the repository cloned to.
-   - `git clone https://github.com/codeforpdx/PASS.git` [learn more about git clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository?platform=linux) 
-   - This will set the git origin to `https://github.com/codeforpdx/PASS.git
+   - `git clone https://github.com/codeforpdx/PASS.git` [learn more about git clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository?platform=linux) This will set the git origin to `https://github.com/codeforpdx/PASS.git
 ` [learn more about git remote](https://docs.github.com/en/get-started/getting-started-with-git/managing-remote-repositories)
    - Change directory to the cloned directory, in this case /PASS: `cd ./PASS`
    - Origin can be verified by running `git remote -v` which should show:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,8 +50,8 @@ By participating in this project, you are expected to uphold our [Code of Conduc
 
 1. Clone repo to local environment in IDE of choice. If you are new to Git/GitHub you can also check out [this article](https://www.digitalocean.com/community/tutorials/how-to-create-a-pull-request-on-github) for a broad overview.
    - Open terminal & change working directory to the location you want the repository cloned to.
-   - `git clone https://github.com/codeforpdx/PASS.git` [learn more about git clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository?platform=linux) This will set the git origin to `https://github.com/codeforpdx/PASS.git
-` [learn more about git remote](https://docs.github.com/en/get-started/getting-started-with-git/managing-remote-repositories)
+   - `git clone https://github.com/codeforpdx/PASS.git` [learn more about git clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository?platform=linux) This will set the git origin to `https://github.com/codeforpdx/PASS.git`. By default the branch is set to Master.
+ [learn more about git remote](https://docs.github.com/en/get-started/getting-started-with-git/managing-remote-repositories)
    - Change directory to the cloned directory, in this case /PASS: `cd ./PASS`
    - Origin can be verified by running `git remote -v` which should show:
       ```
@@ -61,12 +61,10 @@ By participating in this project, you are expected to uphold our [Code of Conduc
 
 1. Create a new branch to work on your feature (We recommend doing this via terminal) Branches should all be based off of `Development`:
     
-    A. `git checkout -b "<your branch name>" Development` [learn more about git branches](https://www.atlassian.com/git/tutorials/using-branches/git-checkout) using the recommended naming convention:`<issue number><branch name>` with a concise title.
+    A. `git switch Development` or `git checkout Development` - to switch to the Development branch.
+
+    B. `git checkout -b "<your branch name>"` [learn more about git branches](https://www.atlassian.com/git/tutorials/using-branches/git-checkout) using the recommended naming convention:`<issue number><branch name>` with a concise title.
       > Example: `112/delete-client-modal`
-
-    B. `git fetch origin Development` - to pull updates PASS Development branch.
-
-    C. `git rebase origin/Development` - to rebase updates from Development with current branch. During the rebase process, if conflicts exist git will pause to allow resolution. the process can be continued with `git rebase --continue` or cancelled with `git rebase --abort`.
   
   > This can also be done directly from an issue in GitHub with the following three steps(Default branch is Master and will need to be changed to Development). If done manually via command line, link branch to corresponding GitHub issue.
   >

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,17 +50,24 @@ By participating in this project, you are expected to uphold our [Code of Conduc
 
 1. Clone repo to local environment in IDE of choice. If you are new to Git/GitHub you can also check out [this article](https://www.digitalocean.com/community/tutorials/how-to-create-a-pull-request-on-github) for a broad overview.
    - Open terminal & change working directory to the location you want the repository cloned to.
-   - `git clone https://github.com/codeforpdx/PASS.git` [learn more about git clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository?platform=linux)
-   - `git remote add origin https://github.com/codeforpdx/PASS.git` [learn more about git remote](https://docs.github.com/en/get-started/getting-started-with-git/managing-remote-repositories)
+   - `git clone https://github.com/codeforpdx/PASS.git` [learn more about git clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository?platform=linux) 
+   - This will set the git origin to `https://github.com/codeforpdx/PASS.git
+` [learn more about git remote](https://docs.github.com/en/get-started/getting-started-with-git/managing-remote-repositories)
+   - Change directory to the cloned directory, in this case /PASS: `cd ./PASS`
+   - Origin can be verified by running `git remote -v` which should show:
+      ```
+     origin https://github.com/codeforpdx/PASS.git (fetch)
+     origin https://github.com/codeforpdx/PASS.git (push)
+      ```
 
-2. Setup instructions to locally run PASS can be found in the [readme](../README.md).
-
-3. Create a new branch to work on your feature (We recommend doing this via terminal) Branches should all be based off of `Development`:
+1. Create a new branch to work on your feature (We recommend doing this via terminal) Branches should all be based off of `Development`:
     
-    A. `git checkout -b <your branch name> Development` [learn more about git branches](https://www.atlassian.com/git/tutorials/using-branches/git-checkout) using the recommended naming convention:`<issue number><branch name>` with a concise title.
+    A. `git checkout -b "<your branch name>" Development` [learn more about git branches](https://www.atlassian.com/git/tutorials/using-branches/git-checkout) using the recommended naming convention:`<issue number><branch name>` with a concise title.
       > Example: `112/delete-client-modal`
 
-    B. `git pull origin Development` - to sync with PASS Development branch
+    B. `git fetch origin Development` - to pull updates PASS Development branch.
+
+    C. `git rebase origin/Development` - to rebase updates from Development with current branch. During the rebase process, if conflicts exist git will pause to allow resolution. the process can be continued with `git rebase --continue` or cancelled with `git rebase --abort`.
   
   > This can also be done directly from an issue in GitHub with the following three steps(Default branch is Master and will need to be changed to Development). If done manually via command line, link branch to corresponding GitHub issue.
   >
@@ -76,10 +83,13 @@ By participating in this project, you are expected to uphold our [Code of Conduc
   >
   >  <img src="https://drive.google.com/uc?id=1rqRkau7lxTVEcwRFc8NcHRf-Z4U_lVxb" width="200">
 
-  - Work on feature in your own branch.
+  - Work on feature in your own branch. Setup instructions to locally run PASS can be found in the [readme](../README.md).
 
-  - When ready, push to GitHub in terminal: `git push origin <your branch name>`
-    
+  - When feature is ready:
+    - run `git add .` to add all changed files in commit. or `git add <fileName>` to include an individual file.
+    - run `git commit -m "some message abut changes in commit"` with a concise message to describe what changes are included in the push.
+    -  push to GitHub in terminal: `git push origin <your branch name>`
+  
 1. Code Styling/Linting
 
    Linting and formatting for this project has also been setup using ESlint and Prettier. They are included as dependencies and will be installed while following the instructions of the readme. To lint your changes with ESLint follow the instructions [here](./README.md#linting)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,12 +55,15 @@ By participating in this project, you are expected to uphold our [Code of Conduc
 
 2. Setup instructions to locally run PASS can be found in the [readme](../README.md).
 
-3. Create a new branch to work on your feature:
-    - `git checkout -b <your branch name> Development` [learn more about git branches](https://www.atlassian.com/git/tutorials/using-branches/git-checkout) using the recommended naming convention `issue-\<number\>/\<branch name\>` 
+3. Create a new branch to work on your feature (We recommend doing this via terminal.) Branches should all be based off of `Development`:
+    
+    A. `git checkout -b <your branch name> Development` [learn more about git branches](https://www.atlassian.com/git/tutorials/using-branches/git-checkout) using the recommended naming convention:`issue-<number><branch-name>` with a concise title.
       > Example: `issue-112/delete-client-modal`
-    - `git pull origin Development` - to sync with PASS Development branch
-    - This can also be done directly from an issue in GitHub with the following three steps(Default branch is Master and will need to be changed to Development).
 
+    B. `git pull origin Development` - to sync with PASS Development branch
+  
+  > This can also be done directly from an issue in GitHub with the following three steps(Default branch is Master and will need to be changed to Development). If done manually via command line, link branch to corresponding GitHub issue.
+  >
   > A. Create a branch by clicking `create a branch` under Development within the issues page.
   >
   >  <img src="https://drive.google.com/uc?id=11zUuOYSkv8K0CJE_snet12YSdyLDKP8q" width="200"/>
@@ -73,15 +76,11 @@ By participating in this project, you are expected to uphold our [Code of Conduc
   >
   >  <img src="https://drive.google.com/uc?id=1rqRkau7lxTVEcwRFc8NcHRf-Z4U_lVxb" width="200">
 
-  - If done manually via command line, link branch to corresponding GitHub issue.
+  - Work on feature in your own branch.
 
-1. Work on feature in your own branch.
-
-2. When ready, push to GitHub
-
- - `git push origin <your branch name>`
+  - When ready, push to GitHub in terminal: `git push origin <your branch name>`
     
-6. Code Styling/Linting
+4. Code Styling/Linting
 
    Linting and formatting for this project has also been setup using ESlint and Prettier. They are included as dependencies and will be installed while following the instructions of the readme. To lint your changes with ESLint follow the instructions [here](./README.md#linting)
 
@@ -89,11 +88,11 @@ By participating in this project, you are expected to uphold our [Code of Conduc
   
    If you are new to GitHub and/or the team, feel free to make your first pull request on the README/Contributing documentation to familiarize yourself with the project and GitHub. Add any comments and/or feedback and request reviews.
 
-1. Make a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to the `Development` branch. Request reviews from members of the team - you’ll need their approval to merge. \*\*Make sure to close your branch once merged.
+-  Make a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to the `Development` branch. Request reviews from members of the team - you’ll need their approval to merge. \*\*Make sure to close your branch once merged.
 
 - Recommended reviewers:
-  - Development -- Jared K, Ka Hung L., Kevin M., Tim S., Scott B.
-  - Documentation -- Danica B, Jared K, Ka Hung L.
+  - Development -- Jared K, Ka Hung L, Kevin M, Tim S, Scott B
+  - Documentation -- Jared K, Ka Hung L
   - Include screenshots whenever you’re building a frontend feature.
 
 - ## Bug Reporting Template

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,10 +55,10 @@ By participating in this project, you are expected to uphold our [Code of Conduc
 
 2. Setup instructions to locally run PASS can be found in the [readme](../README.md).
 
-3. Create a new branch to work on your feature (We recommend doing this via terminal.) Branches should all be based off of `Development`:
+3. Create a new branch to work on your feature (We recommend doing this via terminal) Branches should all be based off of `Development`:
     
-    A. `git checkout -b <your branch name> Development` [learn more about git branches](https://www.atlassian.com/git/tutorials/using-branches/git-checkout) using the recommended naming convention:`issue-<number><branch-name>` with a concise title.
-      > Example: `issue-112/delete-client-modal`
+    A. `git checkout -b <your branch name> Development` [learn more about git branches](https://www.atlassian.com/git/tutorials/using-branches/git-checkout) using the recommended naming convention:`<issue number><branch name>` with a concise title.
+      > Example: `112/delete-client-modal`
 
     B. `git pull origin Development` - to sync with PASS Development branch
   
@@ -80,7 +80,7 @@ By participating in this project, you are expected to uphold our [Code of Conduc
 
   - When ready, push to GitHub in terminal: `git push origin <your branch name>`
     
-4. Code Styling/Linting
+1. Code Styling/Linting
 
    Linting and formatting for this project has also been setup using ESlint and Prettier. They are included as dependencies and will be installed while following the instructions of the readme. To lint your changes with ESLint follow the instructions [here](./README.md#linting)
 

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -21,7 +21,7 @@
 
 ---
 ## Design Board
-  - [Figma Design Board](https://www.figma.com/file/BfsGjGbFUVvtqNq18sykoY/Pass-Project?type=design&node-id=1216-2986&mode=design) contains UX design for the PASS project.
+  - [Figma Design Board](https://www.figma.com/file/BfsGjGbFUVvtqNq18sykoY/Pass-Project?type=design&node-id=1216%3A2986&mode=design&t=6wwtu9VDctN6SvkL-1) contains UX design for the PASS project.
 
 ## Additional Resources
 

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -20,6 +20,8 @@
   ![tech stack](https://drive.google.com/uc?id=1Vkn9hGlSyv6Y9tY_R6SfEGoj5MJTGDDy)
 
 ---
+## Design Board
+  - [Figma Design Board](https://www.figma.com/file/BfsGjGbFUVvtqNq18sykoY/Pass-Project?type=design&node-id=1216-2986&mode=design) contains UX design for the PASS project.
 
 ## Additional Resources
 


### PR DESCRIPTION
Minor refactoring to branching section of contributing.md for clarification of what branch to base from and guidelines for cloning and branching via terminal. Previous instructions were unclear and may have caused users to base from Master as it is the default branch base when creating a new branch via github issues GUI