### PR TITLE
Issue 318/refactor documents to profile

### DIFF
--- a/src/components/Documents/DocumentTable.jsx
+++ b/src/components/Documents/DocumentTable.jsx
@@ -37,7 +37,7 @@ const DocumentTable = () => {
   const determineDocumentsTable = documentListObject?.docList?.length ? (
     // render if documents
     <Container>
-      <TableContainer component={Paper} sx={{ marginTop: '3rem', marginBottom: '3rem' }}>
+      <TableContainer component={Paper} sx={{ margin: '1rem 0' }}>
         <Table aria-label="Documents Table">
           <TableHead>
             <TableRow>

--- a/src/components/Documents/DocumentTable.jsx
+++ b/src/components/Documents/DocumentTable.jsx
@@ -9,7 +9,7 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 // Component Imports
-import { DocumentListContext } from '../../contexts';
+import { DocumentListContext, UserDocumentListContext } from '../../contexts';
 import { StyledTableCell } from '../Table/TableStyles';
 import DocumentTableRow from './DocumentTableRow';
 import { EmptyListNotification, LoadingAnimation } from '../Notification';
@@ -19,11 +19,13 @@ import { EmptyListNotification, LoadingAnimation } from '../Notification';
  *
  * @memberof Documents
  * @name DocumentTable
+ * @param user
  * @returns {React.ReactElement} a table of documents
  */
 
-const DocumentTable = () => {
-  const { documentListObject, loadingDocuments } = useContext(DocumentListContext);
+const DocumentTable = ({ user }) => {
+  const { documentListObject, loadingDocuments } =
+    user === 'personal' ? useContext(UserDocumentListContext) : useContext(DocumentListContext);
   const columnTitlesArray = [
     'Name',
     'Type',
@@ -50,7 +52,7 @@ const DocumentTable = () => {
           </TableHead>
           <TableBody>
             {documentListObject?.docList.map((document) => (
-              <DocumentTableRow key={document.name} document={document} />
+              <DocumentTableRow key={document.name} document={document} user={user} />
             ))}
           </TableBody>
         </Table>

--- a/src/components/Documents/DocumentTableRow.jsx
+++ b/src/components/Documents/DocumentTableRow.jsx
@@ -9,7 +9,7 @@ import IconButton from '@mui/material/IconButton';
 // Utility Imports
 import { getBlobFromSolid } from '../../utils';
 // Context Imports
-import { DocumentListContext } from '../../contexts';
+import { DocumentListContext, UserDocumentListContext } from '../../contexts';
 import { StyledTableCell, StyledTableRow } from '../Table/TableStyles';
 import DOC_TYPES from '../../constants/doc_types';
 
@@ -18,13 +18,15 @@ import DOC_TYPES from '../../constants/doc_types';
  *
  * @memberof Documents
  * @name DocumentTableRow
+ * @param user
  * @param document
  * @returns {React.ReactElement}
  */
 
-const DocumentTableRow = ({ document }) => {
+const DocumentTableRow = ({ user, document }) => {
   const { session } = useSession();
-  const { removeDocument } = useContext(DocumentListContext);
+  const { removeDocument } =
+    user === 'personal' ? useContext(UserDocumentListContext) : useContext(DocumentListContext);
 
   const { name, type, description, fileUrl, uploadDate, endDate } = document;
 

--- a/src/components/Modals/UploadDocumentModal.jsx
+++ b/src/components/Modals/UploadDocumentModal.jsx
@@ -21,7 +21,7 @@ import { runNotification } from '../../utils';
 import { useStatusNotification } from '../../hooks';
 // Component Imports
 import { DocumentSelection, FormSection } from '../Form';
-import { DocumentListContext } from '../../contexts';
+import { DocumentListContext, UserDocumentListContext } from '../../contexts';
 
 /**
  * UploadDocumentModal Component - Component that generates the form for uploading
@@ -31,7 +31,7 @@ import { DocumentListContext } from '../../contexts';
  * @name UploadDocumentModal
  */
 
-const UploadDocumentModal = ({ showModal, setShowModal }) => {
+const UploadDocumentModal = ({ user, showModal, setShowModal }) => {
   const { state, dispatch } = useStatusNotification();
   const [expireDate, setExpireDate] = useState(null);
   const [docDescription, setDocDescription] = useState('');
@@ -39,7 +39,8 @@ const UploadDocumentModal = ({ showModal, setShowModal }) => {
   const [verifyFile, setVerifyFile] = useState(false);
   const [file, setFile] = useState(null);
   const [inputKey, setInputKey] = useState(false);
-  const { addDocument, replaceDocument } = useContext(DocumentListContext);
+  const { addDocument, replaceDocument } =
+    user === 'personal' ? useContext(UserDocumentListContext) : useContext(DocumentListContext);
 
   const handleDocType = (event) => {
     setDocType(event.target.value);

--- a/src/components/Profile/ProfileImageField.jsx
+++ b/src/components/Profile/ProfileImageField.jsx
@@ -66,8 +66,10 @@ const ProfileImageField = ({ loadProfileData }) => {
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        maxWidth: '300px',
-        alignItems: 'flex-start',
+        justifyContent: 'center',
+        alignItems: 'center',
+        boxShadow: '0 0 3px 0 black',
+        padding: '20px',
         gap: '10px'
       }}
     >
@@ -75,7 +77,7 @@ const ProfileImageField = ({ loadProfileData }) => {
       <Avatar
         src={profileImg}
         alt="PASS profile"
-        sx={{ height: '200px', width: '200px', objectFit: 'contain' }}
+        sx={{ height: '100px', width: '100px', objectFit: 'contain' }}
       />
       {profileImg ? (
         <Button

--- a/src/contexts/UserDataContext.jsx
+++ b/src/contexts/UserDataContext.jsx
@@ -6,7 +6,8 @@ import {
   SelectedUserContextProvider,
   UserListContextProvider,
   SignedInUserContextProvider,
-  DocumentListContextProvider
+  DocumentListContextProvider,
+  UserDocumentListContextProvider
 } from '.';
 
 /**
@@ -22,9 +23,11 @@ const UserDataContextProvider = ({ children }) => (
   <SignedInUserContextProvider>
     <SelectedUserContextProvider>
       <UserListContextProvider>
-        <DocumentListContextProvider>
-          <MessageContextProvider>{children}</MessageContextProvider>
-        </DocumentListContextProvider>
+        <UserDocumentListContextProvider>
+          <DocumentListContextProvider>
+            <MessageContextProvider>{children}</MessageContextProvider>
+          </DocumentListContextProvider>
+        </UserDocumentListContextProvider>
       </UserListContextProvider>
     </SelectedUserContextProvider>
   </SignedInUserContextProvider>

--- a/src/contexts/UserDocumentListContext.jsx
+++ b/src/contexts/UserDocumentListContext.jsx
@@ -1,0 +1,69 @@
+// React Imports
+import React, { createContext, useState, useMemo, useEffect, useContext } from 'react';
+// Inrupt Imports
+import { createSolidDataset } from '@inrupt/solid-client';
+import { useSession } from '@inrupt/solid-ui-react';
+// Context Imports
+import { SignedInUserContext } from './SignedInUserContext';
+import { addDocument, removeDocument, replaceDocument, loadDocumentList } from '../model-helpers';
+
+/**
+ * React Context for showing all documents in a user's pod
+ *
+ * @name UserListContext
+ * @memberof contexts
+ */
+export const UserDocumentListContext = createContext([]);
+
+/**
+ * The Provider for DocumentListContext
+ *
+ * @memberof contexts
+ * @function DocumentListContextProvider
+ * @param {React.JSX.Element} children - consumers of documentListContext
+ * @returns {React.JSX.Element}
+ * Context from Provider
+ */
+export const UserDocumentListContextProvider = ({ children }) => {
+  const [documentListObject, setDocumentListObject] = useState({});
+  const [loadingDocuments, setLoadingDocuments] = useState(true);
+  const { podUrl } = useContext(SignedInUserContext);
+  const { session } = useSession();
+
+  const documentListMemo = useMemo(
+    () => ({
+      documentListObject,
+      addDocument: async (docDesc, file) =>
+        setDocumentListObject(await addDocument(docDesc, file, documentListObject, session)),
+      replaceDocument: async (docDesc, file) =>
+        setDocumentListObject(await replaceDocument(docDesc, file, documentListObject, session)),
+      removeDocument: async (docName) =>
+        setDocumentListObject(await removeDocument(docName, documentListObject, session)),
+      loadingDocuments
+    }),
+    [documentListObject, loadingDocuments]
+  );
+
+  useEffect(() => {
+    const loadDocuments = async () => {
+      setDocumentListObject({
+        docList: [],
+        dataset: createSolidDataset(),
+        containerUrl: `${podUrl}PASS/Documents/`
+      });
+      try {
+        setDocumentListObject(await loadDocumentList(session, podUrl));
+      } finally {
+        setLoadingDocuments(false);
+      }
+    };
+
+    if (podUrl) loadDocuments();
+  }, [podUrl]);
+
+  return (
+    <UserDocumentListContext.Provider value={documentListMemo}>
+      {children}
+    </UserDocumentListContext.Provider>
+  );
+};

--- a/src/contexts/index.js
+++ b/src/contexts/index.js
@@ -10,3 +10,4 @@ export * from './SelectedUserContext';
 export * from './UserListContext';
 export * from './MessageContext';
 export * from './DocumentListContext';
+export * from './UserDocumentListContext';

--- a/src/routes/Profile.jsx
+++ b/src/routes/Profile.jsx
@@ -190,8 +190,8 @@ const Profile = () => {
         >
           Add Document
         </Button>
-        <UploadDocumentModal showModal={showModal} setShowModal={setShowModal} />
-        <DocumentTable />
+        <UploadDocumentModal showModal={showModal} setShowModal={setShowModal} user="personal" />
+        <DocumentTable user="personal" />
         <SetAclPermsDocContainerForm />
         <SetAclPermissionForm />
       </Box>

--- a/src/routes/Profile.jsx
+++ b/src/routes/Profile.jsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 // Inrupt Imports
 import { useSession } from '@inrupt/solid-ui-react';
 // Material UI Imports
+import AddIcon from '@mui/icons-material/Add';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CheckIcon from '@mui/icons-material/Check';
@@ -15,6 +16,9 @@ import Typography from '@mui/material/Typography';
 import { SignedInUserContext } from '../contexts';
 // Component Inputs
 import { ProfileInputField, ProfileImageField } from '../components/Profile';
+import { SetAclPermissionForm, SetAclPermsDocContainerForm } from '../components/Form';
+import { UploadDocumentModal } from '../components/Modals';
+import DocumentTable from '../components/Documents/DocumentTable';
 
 /**
  * Profile Page - Page that displays the user's profile card information and
@@ -29,6 +33,7 @@ const Profile = () => {
   const { session } = useSession();
   const { updateProfileInfo, setProfileData, profileData, fetchProfileInfo } =
     useContext(SignedInUserContext);
+  const [showModal, setShowModal] = useState(false);
 
   localStorage.setItem('restorePath', location.pathname);
 
@@ -74,8 +79,16 @@ const Profile = () => {
   }, []);
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: '20px', padding: '30px' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: '20px',
+        padding: '30px'
+      }}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '20px' }}>
         <Typography sx={{ fontWeight: 'bold', fontSize: '18px' }}>Profile Information</Typography>
 
         <Typography>
@@ -87,13 +100,48 @@ const Profile = () => {
 
         {/* TODO: Refactor/optimize the form below once we have more input */}
         {/* fields to update profile for */}
-        <Box style={{ display: 'flex', flexDirection: 'column', gap: '15px' }}>
-          <form onSubmit={handleUpdateProfile}>
+        <Box
+          style={{
+            display: 'flex',
+            gap: '15px',
+            padding: '10px'
+          }}
+        >
+          <ProfileImageField loadProfileData={loadProfileData} />
+          <form
+            onSubmit={handleUpdateProfile}
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              boxShadow: '0 0 3px 0 black',
+              justifyContent: 'space-between',
+              padding: '20px'
+            }}
+          >
             <Box
               sx={{
                 display: 'flex',
-                gap: '10px',
-                marginBottom: 2
+                flexDirection: 'column',
+                gap: '10px'
+              }}
+            >
+              <ProfileInputField
+                inputName="Name"
+                inputValue={profileName}
+                setInputValue={setProfileName}
+                edit={edit}
+              />
+              <ProfileInputField
+                inputName="Nickname"
+                inputValue={nickname}
+                setInputValue={setNickname}
+                edit={edit}
+              />
+            </Box>
+            <Box
+              sx={{
+                display: 'flex',
+                gap: '10px'
               }}
             >
               {edit ? (
@@ -130,29 +178,22 @@ const Profile = () => {
                 </Button>
               )}
             </Box>
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '10px'
-              }}
-            >
-              <ProfileInputField
-                inputName="Name"
-                inputValue={profileName}
-                setInputValue={setProfileName}
-                edit={edit}
-              />
-              <ProfileInputField
-                inputName="Nickname"
-                inputValue={nickname}
-                setInputValue={setNickname}
-                edit={edit}
-              />
-            </Box>
           </form>
-          <ProfileImageField loadProfileData={loadProfileData} />
         </Box>
+        <Button
+          variant="contained"
+          color="secondary"
+          size="small"
+          aria-label="Add Client Button"
+          startIcon={<AddIcon />}
+          onClick={() => setShowModal(true)}
+        >
+          Add Document
+        </Button>
+        <UploadDocumentModal showModal={showModal} setShowModal={setShowModal} />
+        <DocumentTable />
+        <SetAclPermsDocContainerForm />
+        <SetAclPermissionForm />
       </Box>
     </Box>
   );


### PR DESCRIPTION
# PR Details

Included changes to styling for existing profile page components and incorporate parts of `Documents` page into `Profile`. That way we could start phasing out `Documents` in favor of having everything directly in a profile page. The information here should only relates to the user themselves and their own documents in their pod storage.

https://github.com/codeforpdx/PASS/assets/14917816/346a1edf-9bf8-43b4-a895-2377470a41ae

Also created a new `UserDocumentListContext` to separate the document list between user and client. The document list found in profile will only that of the user, not of the client.

https://github.com/codeforpdx/PASS/assets/14917816/b6a8cc2b-0f5a-4ed5-8db5-a7a335446685

The document list in `Documents` will still be using the `DocumentListContext`, thus will still generate the list based on `selectedUser`.

## Future Consideration

Once both profile pages are updated to include elements of the `Documents` page, we could phase out `Documents` completely.

We'll also need to update the UX/UI of the profile page to the existing design on Figma.