### PR TITLE
325 enhancement add heroku config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,22 +36,6 @@ jobs:
         with:
           path: './dist'
 
-  deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/Master'
-    name: Deploy
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
-
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bin/start-nginx-solo

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -1,0 +1,51 @@
+daemon off;
+# Heroku dynos have at least 4 cores.
+worker_processes <%= ENV['NGINX_WORKERS'] || 4 %>;
+
+events {
+	use epoll;
+	accept_mutex on;
+	worker_connections <%= ENV['NGINX_WORKER_CONNECTIONS'] || 1024 %>;
+}
+
+http {
+	gzip on;
+	gzip_comp_level 2;
+	gzip_min_length 512;
+	gzip_proxied any; # Heroku router sends Via header
+
+	server_tokens off;
+
+	log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id';
+	access_log <%= ENV['NGINX_ACCESS_LOG_PATH'] || 'logs/nginx/access.log' %> l2met;
+	error_log <%= ENV['NGINX_ERROR_LOG_PATH'] || 'logs/nginx/error.log' %>;
+
+	include mime.types;
+	default_type application/octet-stream;
+	sendfile on;
+
+	# Must read the body in 5 seconds.
+	client_body_timeout 5;
+
+	upstream app_server {
+		server unix:/tmp/nginx.socket fail_timeout=0;
+	}
+
+	server {
+		listen <%= ENV["PORT"] %>;
+		server_name _;
+		keepalive_timeout 5;
+    root /app/dist;
+
+    location = /index.html {
+        add_header Cache-Control "no-store, no-cache";
+        try_files $uri $uri/ =404;
+    }
+
+    location / {
+        add_header 'Cache-Control' "public, max-age=3600";
+        try_files $uri $uri/ /index.html;
+    }
+	}
+}
+


### PR DESCRIPTION
Add config to run Pass from Heroku. Heroku itself is already set up to watch our repository, and is watching master for pushes. Heroku will see the next push to master, and redeploy our code. As long as these changes are in the push to master, the app should launch fine.

Usually, Heroku will be running master. But right now it is running this PR. It will automatically start running master again after then next push. You can see it here: https://passsmartwallet-967e217a2652.herokuapp.com/

Based these changes off the instructions in this stack overflow post: https://stackoverflow.com/questions/69444225/how-do-i-deploy-to-heroku-using-vite

Basically, Heroku runs the vite build process for us, then we serve the app with NGINX.