### PR TITLE
Free browser memory from blob

### DIFF
--- a/src/components/Documents/DocumentTableRow.jsx
+++ b/src/components/Documents/DocumentTableRow.jsx
@@ -30,7 +30,17 @@ const DocumentTableRow = ({ document }) => {
 
   const handleShowDocumentLocal = async (urlToOpen) => {
     const urlFileBlob = await getBlobFromSolid(session, urlToOpen);
-    window.open(urlFileBlob);
+    const newWindow = window.open(urlFileBlob);
+
+    if (newWindow) {
+      newWindow.addEventListener('beforeunload', () => {
+        // Clear Blob from browser memory when new window is closed
+        URL.revokeObjectURL(urlFileBlob);
+      });
+    } else {
+      // If window cannot be opened, we can immediately clear the Blob from browser memory
+      URL.revokeObjectURL(urlFileBlob);
+    }
   };
 
   // Event handler for deleting client from client list


### PR DESCRIPTION
This PR include additions to the handleShowDocumentLocal handler function in DocumentTableRow to free up browser memory used for the file when closing the new window with the file.