### PR TITLE
Cleanup warnings in tests

### DIFF
--- a/src/components/Modals/DeleteClientModal.jsx
+++ b/src/components/Modals/DeleteClientModal.jsx
@@ -26,7 +26,7 @@ import FormSection from '../Form/FormSection';
  */
 
 const DeleteClientModal = ({
-  showDeleteClientModal,
+  showDeleteClientModal = false,
   setShowDeleteClientModal,
   selectedClientToDelete
 }) => {

--- a/test/contexts/SignedInUserContext.test.jsx
+++ b/test/contexts/SignedInUserContext.test.jsx
@@ -14,7 +14,6 @@ import { expect, it, afterEach, describe, vi } from 'vitest';
 import { fetchProfileInfo } from '../../src/model-helpers';
 import { SignedInUserContext, SignedInUserContextProvider } from '../../src/contexts';
 import { RDF_PREDICATES } from '../../src/constants';
-import flushPromises from '../helpers/testHelpers';
 
 const TestConsumer = () => {
   const { podUrl } = useContext(SignedInUserContext);
@@ -59,12 +58,12 @@ describe('SignedInUserContext', () => {
     });
     fetchProfileInfo.mockResolvedValue({ profileInfo: {} });
     getPodUrlAll.mockResolvedValue(['https://example.com/pod/']);
-    const { container } = render(
+    const { findByText } = render(
       <SignedInUserContextProvider>
         <TestConsumer />
       </SignedInUserContextProvider>
     );
-    await flushPromises();
-    expect(container).toMatchSnapshot();
+    const val = await findByText('https://example.com/pod/');
+    expect(val).not.toBeNull();
   });
 });

--- a/test/contexts/__snapshots__/SignedInUserContext.test.jsx.snap
+++ b/test/contexts/__snapshots__/SignedInUserContext.test.jsx.snap
@@ -1,9 +1,0 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
-
-exports[`SignedInUserContext > fetches user data if user is logged in 1`] = `
-<div>
-  <div>
-    https://example.com/pod/
-  </div>
-</div>
-`;

--- a/test/helpers/testHelpers.js
+++ b/test/helpers/testHelpers.js
@@ -1,4 +1,0 @@
-// eslint-disable-next-line no-promise-executor-return
-const flushPromises = () => new Promise((r) => setTimeout(r));
-
-export default flushPromises;


### PR DESCRIPTION
We've been getting some annoying warning messages from a couple tests on development. This PR cleans them up.

Before:
![image](https://github.com/codeforpdx/PASS/assets/37914436/f9844355-26f0-473f-ab74-b25e751bcf51)

After:
![image](https://github.com/codeforpdx/PASS/assets/37914436/d1d2cfd3-e765-4a69-b186-5c359c74f76b)

See comments for exact changes.