### PR TITLE
Fix oidcIssuer localStorage

### DIFF
--- a/src/components/NavBar/OidcLoginComponent.jsx
+++ b/src/components/NavBar/OidcLoginComponent.jsx
@@ -14,7 +14,6 @@ const OidcLoginComponent = () => {
   const loginHandler = async () => {
     const redirectUrl = window.location.href;
     await login({ oidcIssuer, redirectUrl });
-    localStorage.setItem('oidcIssuer', oidcIssuer);
   };
   return (
     <>
@@ -43,10 +42,12 @@ const OidcLoginComponent = () => {
         aria-label="Login Button"
         onClick={() => {
           loginHandler();
+          localStorage.setItem('oidcIssuer', oidcIssuer);
         }}
         onKeyUp={(event) => {
           if (event.key === 'Enter') {
             loginHandler();
+            localStorage.setItem('oidcIssuer', oidcIssuer);
           }
         }}
       >


### PR DESCRIPTION
Found a bug related to localStorage.setItem for `oidcIssuer` not being triggered upon login. This PR fixes that by moving it outside of the handler function.