### PR TITLE
Update pod server script

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,25 @@ PASS is currently in Development heading towards [Minimum Viable Product](./docs
    ```
 4. PASS should launch at `http://localhost:5173`. You can now visit that url, and sign into a pod hosted at the OIDC provider of your choice.
 
+- ### Setting up a Development Pod Server
+    
+   PASS is able to connect to any solid-spec compliant pod server. However, for testing, it's recommended that you run a server locally. PASS provides tools to make this easy to do.
+
+1. Clone and install dependencies. `npm i`
+
+2. In the project's root directory, copy the `env.template` file into a `.env` file. In bash you can use this command:
+    ```bash
+    cp env.template .env
+    ```
+
+3. Run `npm run pod` to launch the pod server. The server will begin listening on `http://localhost:3000`, and will create a folder in the PASS project folder called `local_temp_server_files`. You can find all server and pod files there.
+
+4. Open a browser and navigate to `http://localhost:3000`. You should encounter a screen asking you to set up the server and create an account. Create your first account, and your server will be ready for development.
+
+5. Launch PASS with `npm run dev`. Click the `Login` button on the home page. If everything has been set up right, you should be redirected to your local pod server to finish login.
+
+Note: The `npm run pod` command will launch a server that stores documents on your local file system. If you don't want to store documents, and want all server data to be deleted on shutdown, you can run `npm run pod:temp`
+
 Further information can be found in [CONTRIBUTING.md](./docs/CONTRIBUTING.md) & [docs/README.md](./docs/README.md)
 
 **[⬆️ Back to Top](#pass---personal-access-system-for-services)**

--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ PASS is currently in Development heading towards [Minimum Viable Product](./docs
     cp env.template .env
     ```
 
-3. Run `npm run pod` to launch the pod server. The server will begin listening on `http://localhost:3000`, and will create a folder in the PASS project folder called `local_temp_server_files`. You can find all server and pod files there.
+3. Run `npm run podserver` to launch the pod server. The server will begin listening on `http://localhost:3000`, and will create a folder in the PASS project folder called `local_temp_server_files`. You can find all server and pod files there.
 
 4. Open a browser and navigate to `http://localhost:3000`. You should encounter a screen asking you to set up the server and create an account. Create your first account, and your server will be ready for development.
 
 5. Launch PASS with `npm run dev`. Click the `Login` button on the home page. If everything has been set up right, you should be redirected to your local pod server to finish login.
 
-Note: The `npm run pod` command will launch a server that stores documents on your local file system. If you don't want to store documents, and want all server data to be deleted on shutdown, you can run `npm run pod:temp`
+Note: The `npm run podserver` command will launch a server that stores documents on your local file system. If you don't want to store documents, and want all server data to be deleted on shutdown, you can run `npm run podserver:temp`
 
 Further information can be found in [CONTRIBUTING.md](./docs/CONTRIBUTING.md) & [docs/README.md](./docs/README.md)
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ PASS is currently in Development heading towards [Minimum Viable Product](./docs
     
    PASS is able to connect to any solid-spec compliant pod server. However, for testing, it's recommended that you run a server locally. PASS provides tools to make this easy to do.
 
-1. Clone and install dependencies. `npm i`
+1. Clone and install dependencies. [See previous section](#clone-and-install-dependencies)
 
 2. In the project's root directory, copy the `env.template` file into a `.env` file. In bash you can use this command:
     ```bash

--- a/env.template
+++ b/env.template
@@ -1,0 +1,1 @@
+VITE_SOLID_IDENTITY_PROVIDER="http://localhost:3000"

--- a/env_templates/README.md
+++ b/env_templates/README.md
@@ -1,1 +1,0 @@
-This is a place to distribute templates of the `.env` file for devs to copy. DO NOT put sensitive environment data (e.g. private keys) in any of these templates. Any fields that take sensitive data should be left blank, and devs should fill the fields in manually with their own information. If you need to distribute private keys to devs, find a different way.

--- a/env_templates/dev.env
+++ b/env_templates/dev.env
@@ -1,1 +1,0 @@
-VITE_SOLID_IDENTITY_PROVIDER="https://solidcommunity.net/"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "lint:fix": "eslint --fix 'src/**/*.js' 'src/**/*.jsx' 'test/**/*.js' 'test/**/*.jsx' '__mocks__/**/*.js'",
     "prettier:check": "prettier --check 'src/**/*.js' 'src/**/*.jsx' 'test/**/*.js' 'test/**/*.jsx'",
     "prettier:run": "prettier --write 'src/**/*.js' 'src/**/*.jsx' 'test/**/*.js' 'test/**/*.jsx'",
-    "dev:pod": "community-solid-server",
-    "dev:pod:stored": "community-solid-server -c @css:config/file.json -f local_temp_server_files/",
+    "pod:temp": "community-solid-server",
     "pod": "community-solid-server -c @css:config/file.json -f local_temp_server_files/"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prettier:check": "prettier --check 'src/**/*.js' 'src/**/*.jsx' 'test/**/*.js' 'test/**/*.jsx'",
     "prettier:run": "prettier --write 'src/**/*.js' 'src/**/*.jsx' 'test/**/*.js' 'test/**/*.jsx'",
     "dev:pod": "community-solid-server",
-    "dev:pod:stored": "community-solid-server -c @css:config/file.json -f local_temp_server_files/"
+    "dev:pod:stored": "community-solid-server -c @css:config/file.json -f local_temp_server_files/",
+    "pod": "community-solid-server -c @css:config/file.json -f local_temp_server_files/"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "lint:fix": "eslint --fix 'src/**/*.js' 'src/**/*.jsx' 'test/**/*.js' 'test/**/*.jsx' '__mocks__/**/*.js'",
     "prettier:check": "prettier --check 'src/**/*.js' 'src/**/*.jsx' 'test/**/*.js' 'test/**/*.jsx'",
     "prettier:run": "prettier --write 'src/**/*.js' 'src/**/*.jsx' 'test/**/*.js' 'test/**/*.jsx'",
-    "pod:temp": "community-solid-server",
-    "pod": "community-solid-server -c @css:config/file.json -f local_temp_server_files/"
+    "podserver:temp": "community-solid-server",
+    "podserver": "community-solid-server -c @css:config/file.json -f local_temp_server_files/"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
We've been getting a lot of questions about running local pod servers, so I want to add better documentation about it. And also make it easier to do, since the scripts right now are confusingly named. Here are the changes:

- Updated README with a section about setting up the pod servers
- Removed `env_templates` folder and replaced it with a single `env.template` file that new devs can copy.
- Updated server scripts to be easier to use and tell apart. Now the command `npm run pod` will launch a server that stores server files to the local file system. `npm run pod:temp` will run a server that only exists in memory. It doesn't store anything, and nothing will persist between startups.