### PR TITLE
Issue 329 update pass color scheme

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -7,7 +7,7 @@ const theme = createTheme({
       light: '#039686',
       main: '#6750a4',
       dark: '#004d3e',
-      slight: '#8fc2bb',
+      slight: '#eaddff',
       contrastText: '#fff'
     },
     secondary: {

--- a/src/theme.js
+++ b/src/theme.js
@@ -5,25 +5,25 @@ const theme = createTheme({
   palette: {
     primary: {
       light: '#039686',
-      main: '#017969',
+      main: '#6750a4',
       dark: '#004d3e',
       slight: '#8fc2bb',
       contrastText: '#fff'
     },
     secondary: {
       light: '#b32126',
-      main: '#961020',
+      main: '#625b71',
       dark: '#790111',
       contrastText: '#fff'
     },
     tertiary: {
       light: '#dbc584',
-      main: '#DEBC59',
+      main: '#7d5260',
       dark: '#dbb032',
       contrastText: '#fff'
     },
     status: {
-      danger: '#e53e3e'
+      danger: '#b3261e'
     },
     neutral: {
       main: '#64748B',


### PR DESCRIPTION
I updated all the main colors in the theme to correspond to the colors found in the Style Guide section of the UX team's Figma document. The instructions indicate to ignore the dark and light colors for now, but it appeared that the Pass uses a color labeled "slight" in the primary category. This color is used in the table rows on the client page and documents list. I replaced that color with the "primary container" color in the primary section of the style guide. 

The colors in the style guid all have a main color, a lighter color marked as "container", a darker color and other variations as well. These aren't keys found in the theme, so if those colors are to be added in the future, please let me know. 

There are elements in the app that are still not within the new color palette, like the pagination buttons, and elements of some of the modals. Also there are some colors in the footer that are not legible and might need to be switched. 