### PR TITLE
Issue 307/use webID to set permissions

### DIFF
--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -52,7 +52,7 @@ const SetAclPermissionForm = () => {
     const permissions = event.target.setAclPerms.value
       ? { read: event.target.setAclPerms.value === 'Give' }
       : undefined;
-    const webIdToSetPermsTo = `${permissionState.podUrlToSetPermissionsTo}/profile/card#me`;
+    const webIdToSetPermsTo = `${permissionState.podUrlToSetPermissionsTo}profile/card#me`;
 
     try {
       await setDocAclPermission(session, docType, permissions, podUrl, webIdToSetPermsTo);

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -149,7 +149,7 @@ const SetAclPermissionForm = () => {
             >
               {permissionState.permissionType
                 ? `${permissionState.permissionType} Permission`
-                : 'Give or Revoke Permission'}
+                : 'Set Permission'}
             </Button>
           </FormControl>
         </form>

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -11,7 +11,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
 // Utility Imports
-import { getPodUrl, runNotification, setDocAclPermission } from '@utils';
+import { runNotification, setDocAclPermission } from '@utils';
 // Context Imports
 import { SignedInUserContext } from '@contexts';
 // Component Imports
@@ -32,7 +32,7 @@ const SetAclPermissionForm = () => {
   const { podUrl } = useContext(SignedInUserContext);
   const [docType, setDocType] = useState('');
   const [permissionState, setPermissionState] = useState({
-    username: '',
+    podToSetPermissionsTo: '',
     permissionType: ''
   });
 
@@ -51,9 +51,9 @@ const SetAclPermissionForm = () => {
     const permissions = event.target.setAclPerms.value
       ? { read: event.target.setAclPerms.value === 'Give' }
       : undefined;
-    const podUsername = event.target.setAclTo.value;
+    const podToSetPermissionsToURL = event.target.setAclTo.value;
 
-    if (!podUsername) {
+    if (!podToSetPermissionsToURL) {
       runNotification('Set permissions failed. Reason: PodURL not provided.', 5, state, dispatch);
       setTimeout(() => {
         clearInputFields();
@@ -61,7 +61,7 @@ const SetAclPermissionForm = () => {
       return;
     }
 
-    if (getPodUrl(podUsername) === podUrl) {
+    if (podToSetPermissionsToURL === podUrl) {
       runNotification(
         'Set permissions failed. Reason: Current user Pod cannot change container permissions to itself.',
         5,
@@ -91,11 +91,11 @@ const SetAclPermissionForm = () => {
     }
 
     try {
-      await setDocAclPermission(session, docType, permissions, podUsername);
+      await setDocAclPermission(session, docType, permissions, podToSetPermissionsToURL);
 
       runNotification(
         `${permissions.read ? 'Give' : 'Revoke'} permission to ${
-          permissionState.username
+          permissionState.podToSetPermissionsTo
         } for ${docType}.`,
         5,
         state,
@@ -140,9 +140,11 @@ const SetAclPermissionForm = () => {
             <TextField
               id="set-acl-to"
               name="setAclTo"
-              value={permissionState.username}
-              onChange={(e) => setPermissionState({ ...permissionState, username: e.target.value })}
-              placeholder={permissionState.username}
+              value={permissionState.podToSetPermissionsTo}
+              onChange={(e) =>
+                setPermissionState({ ...permissionState, podToSetPermissionsTo: e.target.value })
+              }
+              placeholder={permissionState.podToSetPermissionsTo}
               label="Enter PodURL"
               required
             />

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -51,19 +51,11 @@ const SetAclPermissionForm = () => {
     const permissions = event.target.setAclPerms.value
       ? { read: event.target.setAclPerms.value === 'Give' }
       : undefined;
-    const podToSetPermissionsToURL = event.target.setAclTo.value;
+    const podUrlToSetPermissionsTo = event.target.setAclTo.value;
 
-    if (!podToSetPermissionsToURL) {
-      runNotification('Set permissions failed. Reason: PodURL not provided.', 5, state, dispatch);
-      setTimeout(() => {
-        clearInputFields();
-      }, 3000);
-      return;
-    }
-
-    if (podToSetPermissionsToURL === podUrl) {
+    if (podUrlToSetPermissionsTo === podUrl) {
       runNotification(
-        'Set permissions failed. Reason: Current user Pod cannot change container permissions to itself.',
+        'FAILED TO SET PERMISSIONS. REASON: Current user Pod cannot change container permissions to itself.',
         5,
         state,
         dispatch
@@ -74,24 +66,8 @@ const SetAclPermissionForm = () => {
       return;
     }
 
-    if (permissions === undefined) {
-      runNotification('Set permissions failed. Reason: Permissions not set.', 5, state, dispatch);
-      setTimeout(() => {
-        clearInputFields();
-      }, 3000);
-      return;
-    }
-
-    if (!docType) {
-      runNotification('Search failed. Reason: No document type selected.', 5, state, dispatch);
-      setTimeout(() => {
-        dispatch({ type: 'CLEAR_PROCESSING' });
-      }, 3000);
-      return;
-    }
-
     try {
-      await setDocAclPermission(session, docType, permissions, podToSetPermissionsToURL);
+      await setDocAclPermission(session, docType, permissions, podUrl, podUrlToSetPermissionsTo);
 
       runNotification(
         `${permissions.read ? 'Give' : 'Revoke'} permission to ${
@@ -102,7 +78,7 @@ const SetAclPermissionForm = () => {
         dispatch
       );
     } catch (error) {
-      runNotification('Set permissions failed. Reason: File not found.', 5, state, dispatch);
+      runNotification('FAILED TO SET PERMISSIONS. REASON: File not found.', 5, state, dispatch);
     } finally {
       setTimeout(() => {
         clearInputFields();

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -10,6 +10,7 @@ import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 // Utility Imports
 import { runNotification, setDocAclPermission } from '@utils';
 // Context Imports
@@ -53,19 +54,6 @@ const SetAclPermissionForm = () => {
       : undefined;
     const podUrlToSetPermissionsTo = event.target.setAclTo.value;
 
-    if (podUrlToSetPermissionsTo === podUrl) {
-      runNotification(
-        'FAILED TO SET PERMISSIONS. REASON: Current user Pod cannot change container permissions to itself.',
-        5,
-        state,
-        dispatch
-      );
-      setTimeout(() => {
-        clearInputFields();
-      }, 3000);
-      return;
-    }
-
     try {
       await setDocAclPermission(session, docType, permissions, podUrl, podUrlToSetPermissionsTo);
 
@@ -95,6 +83,18 @@ const SetAclPermissionForm = () => {
     >
       <Box display="flex" justifyContent="center">
         <form onSubmit={handleAclPermission} autoComplete="off">
+          <Typography
+            variant="subtitle2"
+            mb={2}
+            sx={{
+              width: '250px',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis'
+            }}
+          >
+            File Name: LongAssFileNameToTestIfThisIsWorkingCorrectly
+          </Typography>
           <FormControl required fullWidth sx={{ marginBottom: '1rem' }}>
             <InputLabel id="permissionType-label">Select One</InputLabel>
             <Select
@@ -123,6 +123,12 @@ const SetAclPermissionForm = () => {
               placeholder={permissionState.podToSetPermissionsTo}
               label="Enter PodURL"
               required
+              error={permissionState.podToSetPermissionsTo === podUrl}
+              helperText={
+                permissionState.podToSetPermissionsTo === podUrl
+                  ? 'Cannot modify your permissions to your own pod.'.toUpperCase()
+                  : ''
+              }
             />
           </FormControl>
 
@@ -133,7 +139,12 @@ const SetAclPermissionForm = () => {
           />
 
           <FormControl fullWidth sx={{ marginTop: '2rem' }}>
-            <Button variant="contained" disabled={state.processing} type="submit" color="primary">
+            <Button
+              variant="contained"
+              disabled={permissionState.podToSetPermissionsTo === podUrl || state.processing}
+              type="submit"
+              color="primary"
+            >
               {permissionState.permissionType
                 ? `${permissionState.permissionType} Permission`
                 : 'Give or Revoke Permission'}

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -66,7 +66,7 @@ const SetAclPermissionForm = () => {
         dispatch
       );
     } catch (error) {
-      runNotification('FAILED TO SET PERMISSIONS. REASON: File not found.', 5, state, dispatch);
+      runNotification('Failed to set permissions. Reason: File not found.', 5, state, dispatch);
     } finally {
       setTimeout(() => {
         clearInputFields();
@@ -94,7 +94,8 @@ const SetAclPermissionForm = () => {
             }}
           >
             <span style={{ color: 'grey' }}>File Name: </span>
-            LongAssFileNameToTestIfThisIsWorkingCorrectly
+            {/* TODO: adjust here to show filename of the one that triggered this form */}
+            filename.jpeg
           </Typography>
 
           <FormControl required fullWidth sx={{ marginBottom: '1rem' }}>

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -33,7 +33,7 @@ const SetAclPermissionForm = () => {
   const { podUrl } = useContext(SignedInUserContext);
   const [docType, setDocType] = useState('');
   const [permissionState, setPermissionState] = useState({
-    webIdToSetPermissionsTo: '',
+    podUrlToSetPermissionsTo: '',
     permissionType: ''
   });
 
@@ -52,14 +52,14 @@ const SetAclPermissionForm = () => {
     const permissions = event.target.setAclPerms.value
       ? { read: event.target.setAclPerms.value === 'Give' }
       : undefined;
-    const webIdToAssignPermissionsTo = event.target.setAclTo.value;
+    const webIdToSetPermsTo = `${permissionState.podUrlToSetPermissionsTo}/profile/card#me`;
 
     try {
-      await setDocAclPermission(session, docType, permissions, podUrl, webIdToAssignPermissionsTo);
+      await setDocAclPermission(session, docType, permissions, podUrl, webIdToSetPermsTo);
 
       runNotification(
         `${permissions.read ? 'Give' : 'Revoke'} permission to ${
-          permissionState.webIdToSetPermissionsTo
+          permissionState.podUrlToSetPermissionsTo
         } for ${docType}.`,
         5,
         state,
@@ -116,16 +116,16 @@ const SetAclPermissionForm = () => {
             <TextField
               id="set-acl-to"
               name="setAclTo"
-              value={permissionState.webIdToSetPermissionsTo}
+              value={permissionState.podUrlToSetPermissionsTo}
               onChange={(e) =>
-                setPermissionState({ ...permissionState, webIdToSetPermissionsTo: e.target.value })
+                setPermissionState({ ...permissionState, podUrlToSetPermissionsTo: e.target.value })
               }
-              placeholder={permissionState.webIdToSetPermissionsTo}
-              label="Enter webID"
+              placeholder={permissionState.podUrlToSetPermissionsTo}
+              label="Enter podURL"
               required
-              error={permissionState.webIdToSetPermissionsTo === podUrl}
+              error={permissionState.podUrlToSetPermissionsTo === podUrl}
               helperText={
-                permissionState.webIdToSetPermissionsTo === podUrl
+                permissionState.podUrlToSetPermissionsTo === podUrl
                   ? 'Cannot modify your permissions to your own pod.'.toUpperCase()
                   : ''
               }
@@ -141,7 +141,7 @@ const SetAclPermissionForm = () => {
           <FormControl fullWidth sx={{ marginTop: '2rem' }}>
             <Button
               variant="contained"
-              disabled={permissionState.webIdToSetPermissionsTo === podUrl || state.processing}
+              disabled={permissionState.podUrlToSetPermissionsTo === podUrl || state.processing}
               type="submit"
               color="primary"
             >

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -6,11 +6,9 @@ import { useSession, useStatusNotification } from '@hooks';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import FormControl from '@mui/material/FormControl';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import FormLabel from '@mui/material/FormLabel';
 import InputLabel from '@mui/material/InputLabel';
-import Radio from '@mui/material/Radio';
-import RadioGroup from '@mui/material/RadioGroup';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
 // Utility Imports
 import { getPodUrl, runNotification, setDocAclPermission } from '@utils';
@@ -31,9 +29,12 @@ import FormSection from './FormSection';
 const SetAclPermissionForm = () => {
   const { session } = useSession();
   const { state, dispatch } = useStatusNotification();
-  const [username, setUsername] = useState('');
   const { podUrl } = useContext(SignedInUserContext);
   const [docType, setDocType] = useState('');
+  const [permissionState, setPermissionState] = useState({
+    username: '',
+    permissionType: ''
+  });
 
   const handleDocType = (event) => {
     setDocType(event.target.value);
@@ -53,7 +54,7 @@ const SetAclPermissionForm = () => {
     const podUsername = event.target.setAclTo.value;
 
     if (!podUsername) {
-      runNotification('Set permissions failed. Reason: Username not provided.', 5, state, dispatch);
+      runNotification('Set permissions failed. Reason: PodURL not provided.', 5, state, dispatch);
       setTimeout(() => {
         clearInputFields();
       }, 3000);
@@ -93,7 +94,9 @@ const SetAclPermissionForm = () => {
       await setDocAclPermission(session, docType, permissions, podUsername);
 
       runNotification(
-        `${permissions.read ? 'Give' : 'Revoke'} permission to ${username} for ${docType}.`,
+        `${permissions.read ? 'Give' : 'Revoke'} permission to ${
+          permissionState.username
+        } for ${docType}.`,
         5,
         state,
         dispatch
@@ -109,51 +112,53 @@ const SetAclPermissionForm = () => {
 
   return (
     <FormSection
-      title="Set Permission to File"
+      title="Permission for [FileName]"
       state={state}
-      statusType="Permission status"
-      defaultMessage="To be set..."
+      statusType="Status"
+      defaultMessage="No action yet..."
     >
       <Box display="flex" justifyContent="center">
         <form onSubmit={handleAclPermission} autoComplete="off">
-          <FormControl fullWidth>
-            <InputLabel htmlFor="set-acl-to" label="Set permissions to:" />
+          <FormControl required fullWidth sx={{ marginBottom: '1rem' }}>
+            <InputLabel id="permissionType-label">Select One</InputLabel>
+            <Select
+              labelId="permissionType-label"
+              id="permissionType"
+              label="Select One"
+              value={permissionState.permissionType}
+              onChange={(e) =>
+                setPermissionState({ ...permissionState, permissionType: e.target.value })
+              }
+              name="setAclPerms"
+            >
+              <MenuItem value="Give">Give Permission</MenuItem>
+              <MenuItem value="Revoke">Revoke Permission</MenuItem>
+            </Select>
+          </FormControl>
+
+          <FormControl fullWidth sx={{ marginBottom: '1rem' }}>
             <TextField
               id="set-acl-to"
               name="setAclTo"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              placeholder={username}
-              label="Search Username"
+              value={permissionState.username}
+              onChange={(e) => setPermissionState({ ...permissionState, username: e.target.value })}
+              placeholder={permissionState.username}
+              label="Enter PodURL"
               required
             />
           </FormControl>
+
           <DocumentSelection
             htmlForAndIdProp="set-acl-doctype"
             handleDocType={handleDocType}
             docType={docType}
           />
-          <br />
-          <FormControl fullWidth>
-            <FormLabel htmlFor="set-acl-perm-label">Select permission setting:</FormLabel>
-            <RadioGroup row aria-labelledby="set-acl-perm-label" name="set-acl-perm">
-              <FormControlLabel
-                value="Give"
-                control={<Radio />}
-                label="Give"
-                id="set-acl-perm-give"
-                name="setAclPerms"
-              />
-              <FormControlLabel
-                value="Revoke"
-                control={<Radio />}
-                label="Revoke"
-                id="set-acl-perm-revoke"
-                name="setAclPerms"
-              />
-            </RadioGroup>
+
+          <FormControl fullWidth sx={{ marginTop: '2rem' }}>
             <Button variant="contained" disabled={state.processing} type="submit" color="primary">
-              Set Permission
+              {permissionState.permissionType
+                ? `${permissionState.permissionType} Permission`
+                : 'Give or Revoke Permission'}
             </Button>
           </FormControl>
         </form>

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -76,7 +76,7 @@ const SetAclPermissionForm = () => {
 
   return (
     <FormSection
-      title="Permission for [FileName]"
+      title="Permission for Document"
       state={state}
       statusType="Status"
       defaultMessage="No action yet..."
@@ -93,8 +93,10 @@ const SetAclPermissionForm = () => {
               textOverflow: 'ellipsis'
             }}
           >
-            File Name: LongAssFileNameToTestIfThisIsWorkingCorrectly
+            <span style={{ color: 'grey' }}>File Name: </span>
+            LongAssFileNameToTestIfThisIsWorkingCorrectly
           </Typography>
+
           <FormControl required fullWidth sx={{ marginBottom: '1rem' }}>
             <InputLabel id="permissionType-label">Select One</InputLabel>
             <Select
@@ -111,7 +113,7 @@ const SetAclPermissionForm = () => {
               <MenuItem value="Revoke">Revoke Permission</MenuItem>
             </Select>
           </FormControl>
-
+          <br />
           <FormControl fullWidth sx={{ marginBottom: '1rem' }}>
             <TextField
               id="set-acl-to"

--- a/src/components/Form/SetAclPermissionForm.jsx
+++ b/src/components/Form/SetAclPermissionForm.jsx
@@ -33,7 +33,7 @@ const SetAclPermissionForm = () => {
   const { podUrl } = useContext(SignedInUserContext);
   const [docType, setDocType] = useState('');
   const [permissionState, setPermissionState] = useState({
-    podToSetPermissionsTo: '',
+    webIdToSetPermissionsTo: '',
     permissionType: ''
   });
 
@@ -52,14 +52,14 @@ const SetAclPermissionForm = () => {
     const permissions = event.target.setAclPerms.value
       ? { read: event.target.setAclPerms.value === 'Give' }
       : undefined;
-    const podUrlToSetPermissionsTo = event.target.setAclTo.value;
+    const webIdToAssignPermissionsTo = event.target.setAclTo.value;
 
     try {
-      await setDocAclPermission(session, docType, permissions, podUrl, podUrlToSetPermissionsTo);
+      await setDocAclPermission(session, docType, permissions, podUrl, webIdToAssignPermissionsTo);
 
       runNotification(
         `${permissions.read ? 'Give' : 'Revoke'} permission to ${
-          permissionState.podToSetPermissionsTo
+          permissionState.webIdToSetPermissionsTo
         } for ${docType}.`,
         5,
         state,
@@ -116,16 +116,16 @@ const SetAclPermissionForm = () => {
             <TextField
               id="set-acl-to"
               name="setAclTo"
-              value={permissionState.podToSetPermissionsTo}
+              value={permissionState.webIdToSetPermissionsTo}
               onChange={(e) =>
-                setPermissionState({ ...permissionState, podToSetPermissionsTo: e.target.value })
+                setPermissionState({ ...permissionState, webIdToSetPermissionsTo: e.target.value })
               }
-              placeholder={permissionState.podToSetPermissionsTo}
-              label="Enter PodURL"
+              placeholder={permissionState.webIdToSetPermissionsTo}
+              label="Enter webID"
               required
-              error={permissionState.podToSetPermissionsTo === podUrl}
+              error={permissionState.webIdToSetPermissionsTo === podUrl}
               helperText={
-                permissionState.podToSetPermissionsTo === podUrl
+                permissionState.webIdToSetPermissionsTo === podUrl
                   ? 'Cannot modify your permissions to your own pod.'.toUpperCase()
                   : ''
               }
@@ -141,7 +141,7 @@ const SetAclPermissionForm = () => {
           <FormControl fullWidth sx={{ marginTop: '2rem' }}>
             <Button
               variant="contained"
-              disabled={permissionState.podToSetPermissionsTo === podUrl || state.processing}
+              disabled={permissionState.webIdToSetPermissionsTo === podUrl || state.processing}
               type="submit"
               color="primary"
             >

--- a/src/components/Form/SetAclPermsDocContainerForm.jsx
+++ b/src/components/Form/SetAclPermsDocContainerForm.jsx
@@ -49,7 +49,7 @@ const SetAclPermsDocContainerForm = () => {
           append: event.target.setAclPerms.value === 'Give'
         }
       : undefined;
-    const webIdToSetPermsTo = `${permissionState.podUrlToSetPermissionsTo}/profile/card#me`;
+    const webIdToSetPermsTo = `${permissionState.podUrlToSetPermissionsTo}profile/card#me`;
 
     try {
       await setDocContainerAclPermission(session, permissions, podUrl, webIdToSetPermsTo);

--- a/src/components/Form/SetAclPermsDocContainerForm.jsx
+++ b/src/components/Form/SetAclPermsDocContainerForm.jsx
@@ -73,7 +73,7 @@ const SetAclPermsDocContainerForm = () => {
 
   return (
     <FormSection
-      title="Permission for all Documents"
+      title="Permission for Container"
       state={state}
       statusType="Status"
       defaultMessage="No action yet..."
@@ -96,7 +96,7 @@ const SetAclPermsDocContainerForm = () => {
               <MenuItem value="Revoke">Revoke Permission</MenuItem>
             </Select>
           </FormControl>
-
+          <br />
           <FormControl fullWidth sx={{ marginBottom: '2rem' }}>
             <TextField
               id="set-acl-to"
@@ -116,15 +116,15 @@ const SetAclPermsDocContainerForm = () => {
               }
             />
           </FormControl>
-
+          <br />
           <FormControl fullWidth>
             <Button
               variant="contained"
               disabled={
-                state.processing ||
-                permissionState.podUrlToSetPermissionsTo === '' ||
-                permissionState.permissionType === '' ||
-                permissionState.podUrlToSetPermissionsTo === podUrl
+                state.processing
+                // permissionState.podUrlToSetPermissionsTo === '' ||
+                // permissionState.permissionType === '' ||
+                // permissionState.podUrlToSetPermissionsTo === podUrl
               }
               type="submit"
               color="primary"

--- a/src/components/Form/SetAclPermsDocContainerForm.jsx
+++ b/src/components/Form/SetAclPermsDocContainerForm.jsx
@@ -51,19 +51,6 @@ const SetAclPermsDocContainerForm = () => {
       : undefined;
     const podUrlToSetPermissionsTo = event.target.setAclTo.value;
 
-    if (podUrlToSetPermissionsTo === podUrl) {
-      runNotification(
-        'FAILED TO SET PERMISSIONS. REASON: Current user Pod cannot change container permissions to itself.',
-        5,
-        state,
-        dispatch
-      );
-      setTimeout(() => {
-        clearInputFields();
-      }, 3000);
-      return;
-    }
-
     try {
       await setDocContainerAclPermission(session, permissions, podUrl, podUrlToSetPermissionsTo);
 
@@ -121,6 +108,12 @@ const SetAclPermsDocContainerForm = () => {
               placeholder={permissionState.podToSetPermissionsTo}
               label="Enter PodURL"
               required
+              error={permissionState.podToSetPermissionsTo === podUrl}
+              helperText={
+                permissionState.podToSetPermissionsTo === podUrl
+                  ? 'Cannot modify your permissions to your own pod.'.toUpperCase()
+                  : ''
+              }
             />
           </FormControl>
 
@@ -130,7 +123,8 @@ const SetAclPermsDocContainerForm = () => {
               disabled={
                 state.processing ||
                 permissionState.podToSetPermissionsTo === '' ||
-                permissionState.permissionType === ''
+                permissionState.permissionType === '' ||
+                permissionState.podToSetPermissionsTo === podUrl
               }
               type="submit"
               color="primary"

--- a/src/components/Form/SetAclPermsDocContainerForm.jsx
+++ b/src/components/Form/SetAclPermsDocContainerForm.jsx
@@ -31,7 +31,7 @@ const SetAclPermsDocContainerForm = () => {
   const { state, dispatch } = useStatusNotification();
   const { podUrl } = useContext(SignedInUserContext);
   const [permissionState, setPermissionState] = useState({
-    podToSetPermissionsTo: '',
+    webIdToSetPermissionsTo: '',
     permissionType: ''
   });
 
@@ -49,14 +49,14 @@ const SetAclPermsDocContainerForm = () => {
           append: event.target.setAclPerms.value === 'Give'
         }
       : undefined;
-    const podUrlToSetPermissionsTo = event.target.setAclTo.value;
+    const webIdToSetPermissionsTo = event.target.setAclTo.value;
 
     try {
-      await setDocContainerAclPermission(session, permissions, podUrl, podUrlToSetPermissionsTo);
+      await setDocContainerAclPermission(session, permissions, podUrl, webIdToSetPermissionsTo);
 
       runNotification(
         `${permissions.read ? 'Give' : 'Revoke'} permission to ${
-          permissionState.podToSetPermissionsTo
+          permissionState.webIdToSetPermissionsTo
         } for Documents Container.`,
         5,
         state,
@@ -101,16 +101,16 @@ const SetAclPermsDocContainerForm = () => {
             <TextField
               id="set-acl-to"
               name="setAclTo"
-              value={permissionState.podToSetPermissionsTo}
+              value={permissionState.webIdToSetPermissionsTo}
               onChange={(e) =>
-                setPermissionState({ ...permissionState, podToSetPermissionsTo: e.target.value })
+                setPermissionState({ ...permissionState, webIdToSetPermissionsTo: e.target.value })
               }
-              placeholder={permissionState.podToSetPermissionsTo}
-              label="Enter PodURL"
+              placeholder={permissionState.webIdToSetPermissionsTo}
+              label="Enter webID"
               required
-              error={permissionState.podToSetPermissionsTo === podUrl}
+              error={permissionState.webIdToSetPermissionsTo === podUrl}
               helperText={
-                permissionState.podToSetPermissionsTo === podUrl
+                permissionState.webIdToSetPermissionsTo === podUrl
                   ? 'Cannot modify your permissions to your own pod.'.toUpperCase()
                   : ''
               }
@@ -122,9 +122,9 @@ const SetAclPermsDocContainerForm = () => {
               variant="contained"
               disabled={
                 state.processing ||
-                permissionState.podToSetPermissionsTo === '' ||
+                permissionState.webIdToSetPermissionsTo === '' ||
                 permissionState.permissionType === '' ||
-                permissionState.podToSetPermissionsTo === podUrl
+                permissionState.webIdToSetPermissionsTo === podUrl
               }
               type="submit"
               color="primary"

--- a/src/components/Form/SetAclPermsDocContainerForm.jsx
+++ b/src/components/Form/SetAclPermsDocContainerForm.jsx
@@ -6,12 +6,10 @@ import { useSession, useStatusNotification } from '@hooks';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import FormControl from '@mui/material/FormControl';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import FormLabel from '@mui/material/FormLabel';
-import Radio from '@mui/material/Radio';
-import RadioGroup from '@mui/material/RadioGroup';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
 // Utility Imports
 import { getPodUrl, runNotification, setDocContainerAclPermission } from '@utils';
 // Context Imports
@@ -31,8 +29,11 @@ import FormSection from './FormSection';
 const SetAclPermsDocContainerForm = () => {
   const { session } = useSession();
   const { state, dispatch } = useStatusNotification();
-  const [username, setUsername] = useState('');
   const { podUrl } = useContext(SignedInUserContext);
+  const [permissionState, setPermissionState] = useState({
+    username: '',
+    permissionType: ''
+  });
 
   const clearInputFields = () => {
     dispatch({ type: 'CLEAR_PROCESSING' });
@@ -51,7 +52,12 @@ const SetAclPermsDocContainerForm = () => {
     const otherPodUsername = event.target.setAclTo.value;
 
     if (!otherPodUsername) {
-      runNotification('Set permissions failed. Reason: Username not provided.', 5, state, dispatch);
+      runNotification(
+        'FAILED TO SET PERMISSIONS. REASON: PodURL not provided.',
+        5,
+        state,
+        dispatch
+      );
       setTimeout(() => {
         clearInputFields();
       }, 3000);
@@ -60,7 +66,7 @@ const SetAclPermsDocContainerForm = () => {
 
     if (getPodUrl(otherPodUsername) === podUrl) {
       runNotification(
-        'Set permissions failed. Reason: Current user Pod cannot change container permissions to itself.',
+        'FAILED TO SET PERMISSIONS. REASON: Current user Pod cannot change container permissions to itself.',
         5,
         state,
         dispatch
@@ -71,27 +77,27 @@ const SetAclPermsDocContainerForm = () => {
       return;
     }
 
-    if (permissions === undefined) {
-      runNotification('Set permissions failed. Reason: Permissions not set.', 5, state, dispatch);
-      setTimeout(() => {
-        clearInputFields();
-      }, 3000);
-      return;
-    }
+    // if (permissions === undefined) {
+    //   runNotification('FAILED TO SET PERMISSIONS. REASON: Permissions not set.', 5, state, dispatch);
+    //   setTimeout(() => {
+    //     clearInputFields();
+    //   }, 3000);
+    //   return;
+    // }
 
     try {
       await setDocContainerAclPermission(session, permissions, podUrl, otherPodUsername);
 
       runNotification(
-        `${
-          permissions.read ? 'Give' : 'Revoke'
-        } permission to ${username} for Documents Container.`,
+        `${permissions.read ? 'Give' : 'Revoke'} permission to ${
+          permissionState.username
+        } for Documents Container.`,
         5,
         state,
         dispatch
       );
     } catch (error) {
-      runNotification('Set permissions failed. Reason: File not found.', 5, state, dispatch);
+      runNotification('FAILED TO SET PERMISSIONS. REASON: File not found.', 5, state, dispatch);
     } finally {
       setTimeout(() => {
         clearInputFields();
@@ -101,51 +107,56 @@ const SetAclPermsDocContainerForm = () => {
 
   return (
     <FormSection
-      title="Set Permission to Documents"
+      title="Permission for all Documents"
       state={state}
-      statusType="Permission status"
-      defaultMessage="To be set..."
+      statusType="Status"
+      defaultMessage="No action yet..."
     >
       <Box display="flex" justifyContent="center">
         <form onSubmit={handleAclPermission} autoComplete="off">
-          <FormControl>
-            <Typography htmlFor="set-acl-to">Set permissions to username:</Typography>
+          <FormControl required fullWidth sx={{ marginBottom: '1rem' }}>
+            <InputLabel id="permissionType-label">Select One</InputLabel>
+            <Select
+              labelId="permissionType-label"
+              id="permissionType"
+              label="Select One"
+              value={permissionState.permissionType}
+              onChange={(e) =>
+                setPermissionState({ ...permissionState, permissionType: e.target.value })
+              }
+              name="setAclPerms"
+            >
+              <MenuItem value="Give">Give Permission</MenuItem>
+              <MenuItem value="Revoke">Revoke Permission</MenuItem>
+            </Select>
+          </FormControl>
+
+          <FormControl fullWidth sx={{ marginBottom: '2rem' }}>
             <TextField
               id="set-acl-to"
               name="setAclTo"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              placeholder={username}
-              label="Search Username"
+              value={permissionState.username}
+              onChange={(e) => setPermissionState({ ...permissionState, username: e.target.value })}
+              placeholder={permissionState.username}
+              label="Enter PodURL"
               required
             />
           </FormControl>
-          <br />
+
           <FormControl fullWidth>
-            <FormLabel htmlFor="set-acl-perm-label">Select permission setting:</FormLabel>
-            <RadioGroup
-              row
-              aria-labelledby="set-acl-perm-label"
-              name="set-acl-perm"
-              sx={{ display: 'flex', justifyContent: 'center' }}
+            <Button
+              variant="contained"
+              disabled={
+                state.processing ||
+                permissionState.username === '' ||
+                permissionState.permissionType === ''
+              }
+              type="submit"
+              color="primary"
             >
-              <FormControlLabel
-                value="Give"
-                control={<Radio />}
-                label="Give"
-                id="set-acl-perm-give"
-                name="setAclPerms"
-              />
-              <FormControlLabel
-                value="Revoke"
-                control={<Radio />}
-                label="Revoke"
-                id="set-acl-perm-revoke"
-                name="setAclPerms"
-              />
-            </RadioGroup>
-            <Button variant="contained" disabled={state.processing} type="submit" color="primary">
-              Set Permission
+              {permissionState.permissionType
+                ? `${permissionState.permissionType} Permission`
+                : 'Give or Revoke Permission'}
             </Button>
           </FormControl>
         </form>

--- a/src/components/Form/SetAclPermsDocContainerForm.jsx
+++ b/src/components/Form/SetAclPermsDocContainerForm.jsx
@@ -11,7 +11,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
 // Utility Imports
-import { getPodUrl, runNotification, setDocContainerAclPermission } from '@utils';
+import { runNotification, setDocContainerAclPermission } from '@utils';
 // Context Imports
 import { SignedInUserContext } from '@contexts';
 // Component Imports
@@ -31,7 +31,7 @@ const SetAclPermsDocContainerForm = () => {
   const { state, dispatch } = useStatusNotification();
   const { podUrl } = useContext(SignedInUserContext);
   const [permissionState, setPermissionState] = useState({
-    username: '',
+    podToSetPermissionsTo: '',
     permissionType: ''
   });
 
@@ -49,22 +49,22 @@ const SetAclPermsDocContainerForm = () => {
           append: event.target.setAclPerms.value === 'Give'
         }
       : undefined;
-    const otherPodUsername = event.target.setAclTo.value;
+    const podToSetPermissionsToURL = event.target.setAclTo.value;
 
-    if (!otherPodUsername) {
-      runNotification(
-        'FAILED TO SET PERMISSIONS. REASON: PodURL not provided.',
-        5,
-        state,
-        dispatch
-      );
-      setTimeout(() => {
-        clearInputFields();
-      }, 3000);
-      return;
-    }
+    // if (!podToSetPermissionsToURL) {
+    //   runNotification(
+    //     'FAILED TO SET PERMISSIONS. REASON: PodURL not provided.',
+    //     5,
+    //     state,
+    //     dispatch
+    //   );
+    //   setTimeout(() => {
+    //     clearInputFields();
+    //   }, 3000);
+    //   return;
+    // }
 
-    if (getPodUrl(otherPodUsername) === podUrl) {
+    if (podToSetPermissionsToURL === podUrl) {
       runNotification(
         'FAILED TO SET PERMISSIONS. REASON: Current user Pod cannot change container permissions to itself.',
         5,
@@ -86,11 +86,11 @@ const SetAclPermsDocContainerForm = () => {
     // }
 
     try {
-      await setDocContainerAclPermission(session, permissions, podUrl, otherPodUsername);
+      await setDocContainerAclPermission(session, permissions, podUrl, podToSetPermissionsToURL);
 
       runNotification(
         `${permissions.read ? 'Give' : 'Revoke'} permission to ${
-          permissionState.username
+          permissionState.podToSetPermissionsTo
         } for Documents Container.`,
         5,
         state,
@@ -135,9 +135,11 @@ const SetAclPermsDocContainerForm = () => {
             <TextField
               id="set-acl-to"
               name="setAclTo"
-              value={permissionState.username}
-              onChange={(e) => setPermissionState({ ...permissionState, username: e.target.value })}
-              placeholder={permissionState.username}
+              value={permissionState.podToSetPermissionsTo}
+              onChange={(e) =>
+                setPermissionState({ ...permissionState, podToSetPermissionsTo: e.target.value })
+              }
+              placeholder={permissionState.podToSetPermissionsTo}
               label="Enter PodURL"
               required
             />
@@ -148,7 +150,7 @@ const SetAclPermsDocContainerForm = () => {
               variant="contained"
               disabled={
                 state.processing ||
-                permissionState.username === '' ||
+                permissionState.podToSetPermissionsTo === '' ||
                 permissionState.permissionType === ''
               }
               type="submit"

--- a/src/components/Form/SetAclPermsDocContainerForm.jsx
+++ b/src/components/Form/SetAclPermsDocContainerForm.jsx
@@ -49,22 +49,9 @@ const SetAclPermsDocContainerForm = () => {
           append: event.target.setAclPerms.value === 'Give'
         }
       : undefined;
-    const podToSetPermissionsToURL = event.target.setAclTo.value;
+    const podUrlToSetPermissionsTo = event.target.setAclTo.value;
 
-    // if (!podToSetPermissionsToURL) {
-    //   runNotification(
-    //     'FAILED TO SET PERMISSIONS. REASON: PodURL not provided.',
-    //     5,
-    //     state,
-    //     dispatch
-    //   );
-    //   setTimeout(() => {
-    //     clearInputFields();
-    //   }, 3000);
-    //   return;
-    // }
-
-    if (podToSetPermissionsToURL === podUrl) {
+    if (podUrlToSetPermissionsTo === podUrl) {
       runNotification(
         'FAILED TO SET PERMISSIONS. REASON: Current user Pod cannot change container permissions to itself.',
         5,
@@ -77,16 +64,8 @@ const SetAclPermsDocContainerForm = () => {
       return;
     }
 
-    // if (permissions === undefined) {
-    //   runNotification('FAILED TO SET PERMISSIONS. REASON: Permissions not set.', 5, state, dispatch);
-    //   setTimeout(() => {
-    //     clearInputFields();
-    //   }, 3000);
-    //   return;
-    // }
-
     try {
-      await setDocContainerAclPermission(session, permissions, podUrl, podToSetPermissionsToURL);
+      await setDocContainerAclPermission(session, permissions, podUrl, podUrlToSetPermissionsTo);
 
       runNotification(
         `${permissions.read ? 'Give' : 'Revoke'} permission to ${

--- a/src/components/Form/SetAclPermsDocContainerForm.jsx
+++ b/src/components/Form/SetAclPermsDocContainerForm.jsx
@@ -63,7 +63,7 @@ const SetAclPermsDocContainerForm = () => {
         dispatch
       );
     } catch (error) {
-      runNotification('FAILED TO SET PERMISSIONS. REASON: File not found.', 5, state, dispatch);
+      runNotification('Failed to set permissions. Reason: File not found.', 5, state, dispatch);
     } finally {
       setTimeout(() => {
         clearInputFields();

--- a/src/components/Form/SetAclPermsDocContainerForm.jsx
+++ b/src/components/Form/SetAclPermsDocContainerForm.jsx
@@ -31,7 +31,7 @@ const SetAclPermsDocContainerForm = () => {
   const { state, dispatch } = useStatusNotification();
   const { podUrl } = useContext(SignedInUserContext);
   const [permissionState, setPermissionState] = useState({
-    webIdToSetPermissionsTo: '',
+    podUrlToSetPermissionsTo: '',
     permissionType: ''
   });
 
@@ -49,14 +49,14 @@ const SetAclPermsDocContainerForm = () => {
           append: event.target.setAclPerms.value === 'Give'
         }
       : undefined;
-    const webIdToAssignPermissionsTo = event.target.setAclTo.value;
+    const webIdToSetPermsTo = `${permissionState.podUrlToSetPermissionsTo}/profile/card#me`;
 
     try {
-      await setDocContainerAclPermission(session, permissions, podUrl, webIdToAssignPermissionsTo);
+      await setDocContainerAclPermission(session, permissions, podUrl, webIdToSetPermsTo);
 
       runNotification(
         `${permissions.read ? 'Give' : 'Revoke'} permission to ${
-          permissionState.webIdToSetPermissionsTo
+          permissionState.podUrlToSetPermissionsTo
         } for Documents Container.`,
         5,
         state,
@@ -101,16 +101,16 @@ const SetAclPermsDocContainerForm = () => {
             <TextField
               id="set-acl-to"
               name="setAclTo"
-              value={permissionState.webIdToSetPermissionsTo}
+              value={permissionState.podUrlToSetPermissionsTo}
               onChange={(e) =>
-                setPermissionState({ ...permissionState, webIdToSetPermissionsTo: e.target.value })
+                setPermissionState({ ...permissionState, podUrlToSetPermissionsTo: e.target.value })
               }
-              placeholder={permissionState.webIdToSetPermissionsTo}
-              label="Enter webID"
+              placeholder={permissionState.podUrlToSetPermissionsTo}
+              label="Enter podURL"
               required
-              error={permissionState.webIdToSetPermissionsTo === podUrl}
+              error={permissionState.podUrlToSetPermissionsTo === podUrl}
               helperText={
-                permissionState.webIdToSetPermissionsTo === podUrl
+                permissionState.podUrlToSetPermissionsTo === podUrl
                   ? 'Cannot modify your permissions to your own pod.'.toUpperCase()
                   : ''
               }
@@ -122,9 +122,9 @@ const SetAclPermsDocContainerForm = () => {
               variant="contained"
               disabled={
                 state.processing ||
-                permissionState.webIdToSetPermissionsTo === '' ||
+                permissionState.podUrlToSetPermissionsTo === '' ||
                 permissionState.permissionType === '' ||
-                permissionState.webIdToSetPermissionsTo === podUrl
+                permissionState.podUrlToSetPermissionsTo === podUrl
               }
               type="submit"
               color="primary"

--- a/src/components/Form/SetAclPermsDocContainerForm.jsx
+++ b/src/components/Form/SetAclPermsDocContainerForm.jsx
@@ -118,17 +118,7 @@ const SetAclPermsDocContainerForm = () => {
           </FormControl>
           <br />
           <FormControl fullWidth>
-            <Button
-              variant="contained"
-              disabled={
-                state.processing
-                // permissionState.podUrlToSetPermissionsTo === '' ||
-                // permissionState.permissionType === '' ||
-                // permissionState.podUrlToSetPermissionsTo === podUrl
-              }
-              type="submit"
-              color="primary"
-            >
+            <Button variant="contained" disabled={state.processing} type="submit" color="primary">
               {permissionState.permissionType
                 ? `${permissionState.permissionType} Permission`
                 : 'Give or Revoke Permission'}

--- a/src/components/Form/SetAclPermsDocContainerForm.jsx
+++ b/src/components/Form/SetAclPermsDocContainerForm.jsx
@@ -49,10 +49,10 @@ const SetAclPermsDocContainerForm = () => {
           append: event.target.setAclPerms.value === 'Give'
         }
       : undefined;
-    const webIdToSetPermissionsTo = event.target.setAclTo.value;
+    const webIdToAssignPermissionsTo = event.target.setAclTo.value;
 
     try {
-      await setDocContainerAclPermission(session, permissions, podUrl, webIdToSetPermissionsTo);
+      await setDocContainerAclPermission(session, permissions, podUrl, webIdToAssignPermissionsTo);
 
       runNotification(
         `${permissions.read ? 'Give' : 'Revoke'} permission to ${

--- a/src/components/Form/SetAclPermsDocContainerForm.jsx
+++ b/src/components/Form/SetAclPermsDocContainerForm.jsx
@@ -121,7 +121,7 @@ const SetAclPermsDocContainerForm = () => {
             <Button variant="contained" disabled={state.processing} type="submit" color="primary">
               {permissionState.permissionType
                 ? `${permissionState.permissionType} Permission`
-                : 'Give or Revoke Permission'}
+                : 'Set Permission'}
             </Button>
           </FormControl>
         </form>

--- a/src/components/Form/SetAclPermsDocContainerForm.jsx
+++ b/src/components/Form/SetAclPermsDocContainerForm.jsx
@@ -118,7 +118,12 @@ const SetAclPermsDocContainerForm = () => {
           </FormControl>
           <br />
           <FormControl fullWidth>
-            <Button variant="contained" disabled={state.processing} type="submit" color="primary">
+            <Button
+              variant="contained"
+              disabled={permissionState.podUrlToSetPermissionsTo === podUrl || state.processing}
+              type="submit"
+              color="primary"
+            >
               {permissionState.permissionType
                 ? `${permissionState.permissionType} Permission`
                 : 'Set Permission'}

--- a/src/utils/network/session-core.js
+++ b/src/utils/network/session-core.js
@@ -53,11 +53,11 @@ export const setDocAclPermission = async (
   docType,
   permissions,
   podUrl,
-  podUrlToSetPermissionsTo
+  webIdToAssignPermissionsTo
 ) => {
   const containerUrl = `${podUrl}PASS/Documents/`;
   const documentUrl = `${containerUrl}${docType.replace("'", '').replace(' ', '_')}/`;
-  const webId = `${podUrlToSetPermissionsTo}profile/card#me`;
+  const webId = webIdToAssignPermissionsTo;
 
   await setDocAclForUser(session, documentUrl, 'update', webId, permissions);
 };
@@ -78,10 +78,10 @@ export const setDocContainerAclPermission = async (
   session,
   permissions,
   podUrl,
-  podUrlToSetPermissionsTo
+  webIdToSetPermissionsTo
 ) => {
   const containerUrl = `${podUrl}PASS/Documents/`;
-  const webId = `${podUrlToSetPermissionsTo}profile/card#me`;
+  const webId = webIdToSetPermissionsTo;
 
   await setDocAclForUser(session, containerUrl, 'update', webId, permissions);
 };

--- a/src/utils/network/session-core.js
+++ b/src/utils/network/session-core.js
@@ -44,7 +44,7 @@ import {
  * @param {string} docType - Type of document
  * @param {Access} permissions - The Access object for setting ACL in Solid
  * @param {URL} podUrl - URL of the user's Pod
- * @param {string} podUrlToSetPermissionsTo - URL of the other user's Pod to give/revoke permissions OR empty string
+ * @param {string} webIdToAssignPermissionsTo - URL of the other user's Pod to give/revoke permissions OR empty string
  * @returns {Promise} Promise - Sets permission for otherPodUsername for given
  * document type, if exists, or null
  */
@@ -70,7 +70,7 @@ export const setDocAclPermission = async (
  * @param {Session} session - Solid's Session Object {@link Session}
  * @param {Access} permissions - The Access object for setting ACL in Solid
  * @param {URL} podUrl - URL of the user's Pod
- * @param {string} podUrlToSetPermissionsTo - URL of the other user's Pod to give/revoke permissions OR empty string
+ * @param {string} webIdToAssignPermissionsTo - URL of the other user's Pod to give/revoke permissions OR empty string
  * @returns {Promise} Promise - Sets permission for otherPodUsername for the user's
  * Documents container
  */
@@ -78,10 +78,10 @@ export const setDocContainerAclPermission = async (
   session,
   permissions,
   podUrl,
-  webIdToSetPermissionsTo
+  webIdToAssignPermissionsTo
 ) => {
   const containerUrl = `${podUrl}PASS/Documents/`;
-  const webId = webIdToSetPermissionsTo;
+  const webId = webIdToAssignPermissionsTo;
 
   await setDocAclForUser(session, containerUrl, 'update', webId, permissions);
 };

--- a/src/utils/network/session-core.js
+++ b/src/utils/network/session-core.js
@@ -1,9 +1,7 @@
 import { getSolidDataset, getThingAll, getFile } from '@inrupt/solid-client';
 import dayjs from 'dayjs';
 import { v4 as uuidv4 } from 'uuid';
-import { INTERACTION_TYPES } from '../../constants';
 import {
-  getContainerUrl,
   setDocAclForUser,
   getUserProfileName,
   saveMessageTTL,
@@ -43,21 +41,23 @@ import {
  * @memberof utils
  * @function setDocAclPermission
  * @param {Session} session - Solid's Session Object {@link Session}
- * @param {string} fileType - Type of document
+ * @param {string} docType - Type of document
  * @param {Access} permissions - The Access object for setting ACL in Solid
- * @param {string} podToSetPermissionsToURL - URL of the other user's Pod to give/revoke permissions OR empty string
+ * @param {URL} podUrl - URL of the user's Pod
+ * @param {string} podUrlToSetPermissionsTo - URL of the other user's Pod to give/revoke permissions OR empty string
  * @returns {Promise} Promise - Sets permission for otherPodUsername for given
  * document type, if exists, or null
  */
 export const setDocAclPermission = async (
   session,
-  fileType,
+  docType,
   permissions,
-  podToSetPermissionsToURL
+  podUrl,
+  podUrlToSetPermissionsTo
 ) => {
-  const containerUrl = getContainerUrl(session, 'Documents', INTERACTION_TYPES.SELF);
-  const documentUrl = `${containerUrl}${fileType.replace("'", '').replace(' ', '_')}/`;
-  const webId = `${podToSetPermissionsToURL}profile/card#me`;
+  const containerUrl = `${podUrl}PASS/Documents/`;
+  const documentUrl = `${containerUrl}${docType.replace("'", '').replace(' ', '_')}/`;
+  const webId = `${podUrlToSetPermissionsTo}profile/card#me`;
 
   await setDocAclForUser(session, documentUrl, 'update', webId, permissions);
 };
@@ -70,7 +70,7 @@ export const setDocAclPermission = async (
  * @param {Session} session - Solid's Session Object {@link Session}
  * @param {Access} permissions - The Access object for setting ACL in Solid
  * @param {URL} podUrl - URL of the user's Pod
- * @param {string} podToSetPermissionsToURL - URL of the other user's Pod to give/revoke permissions OR empty string
+ * @param {string} podUrlToSetPermissionsTo - URL of the other user's Pod to give/revoke permissions OR empty string
  * @returns {Promise} Promise - Sets permission for otherPodUsername for the user's
  * Documents container
  */
@@ -78,10 +78,10 @@ export const setDocContainerAclPermission = async (
   session,
   permissions,
   podUrl,
-  podToSetPermissionsToURL
+  podUrlToSetPermissionsTo
 ) => {
   const containerUrl = `${podUrl}PASS/Documents/`;
-  const webId = `${podToSetPermissionsToURL}profile/card#me`;
+  const webId = `${podUrlToSetPermissionsTo}profile/card#me`;
 
   await setDocAclForUser(session, containerUrl, 'update', webId, permissions);
 };

--- a/src/utils/network/session-core.js
+++ b/src/utils/network/session-core.js
@@ -44,7 +44,7 @@ import {
  * @param {string} docType - Type of document
  * @param {Access} permissions - The Access object for setting ACL in Solid
  * @param {URL} podUrl - URL of the user's Pod
- * @param {string} webIdToAssignPermissionsTo - URL of the other user's Pod to give/revoke permissions OR empty string
+ * @param {string} webIdToSetPermsTo - URL of the other user's Pod to give/revoke permissions OR empty string
  * @returns {Promise} Promise - Sets permission for otherPodUsername for given
  * document type, if exists, or null
  */
@@ -53,13 +53,12 @@ export const setDocAclPermission = async (
   docType,
   permissions,
   podUrl,
-  webIdToAssignPermissionsTo
+  webIdToSetPermsTo
 ) => {
   const containerUrl = `${podUrl}PASS/Documents/`;
   const documentUrl = `${containerUrl}${docType.replace("'", '').replace(' ', '_')}/`;
-  const webId = webIdToAssignPermissionsTo;
 
-  await setDocAclForUser(session, documentUrl, 'update', webId, permissions);
+  await setDocAclForUser(session, documentUrl, 'update', webIdToSetPermsTo, permissions);
 };
 
 /**
@@ -70,7 +69,7 @@ export const setDocAclPermission = async (
  * @param {Session} session - Solid's Session Object {@link Session}
  * @param {Access} permissions - The Access object for setting ACL in Solid
  * @param {URL} podUrl - URL of the user's Pod
- * @param {string} webIdToAssignPermissionsTo - URL of the other user's Pod to give/revoke permissions OR empty string
+ * @param {string} webIdToSetPermsTo - URL of the other user's Pod to give/revoke permissions OR empty string
  * @returns {Promise} Promise - Sets permission for otherPodUsername for the user's
  * Documents container
  */
@@ -78,12 +77,11 @@ export const setDocContainerAclPermission = async (
   session,
   permissions,
   podUrl,
-  webIdToAssignPermissionsTo
+  webIdToSetPermsTo
 ) => {
   const containerUrl = `${podUrl}PASS/Documents/`;
-  const webId = webIdToAssignPermissionsTo;
 
-  await setDocAclForUser(session, containerUrl, 'update', webId, permissions);
+  await setDocAclForUser(session, containerUrl, 'update', webIdToSetPermsTo, permissions);
 };
 
 /*

--- a/src/utils/network/session-core.js
+++ b/src/utils/network/session-core.js
@@ -8,8 +8,7 @@ import {
   getUserProfileName,
   saveMessageTTL,
   parseMessageTTL,
-  buildMessageTTL,
-  getPodUrl
+  buildMessageTTL
 } from './session-helper';
 
 /**
@@ -46,15 +45,19 @@ import {
  * @param {Session} session - Solid's Session Object {@link Session}
  * @param {string} fileType - Type of document
  * @param {Access} permissions - The Access object for setting ACL in Solid
- * @param {string} otherPodUsername - Username to other user's Pod or empty string
+ * @param {string} podToSetPermissionsToURL - URL of the other user's Pod to give/revoke permissions OR empty string
  * @returns {Promise} Promise - Sets permission for otherPodUsername for given
  * document type, if exists, or null
  */
-export const setDocAclPermission = async (session, fileType, permissions, otherPodUsername) => {
+export const setDocAclPermission = async (
+  session,
+  fileType,
+  permissions,
+  podToSetPermissionsToURL
+) => {
   const containerUrl = getContainerUrl(session, 'Documents', INTERACTION_TYPES.SELF);
   const documentUrl = `${containerUrl}${fileType.replace("'", '').replace(' ', '_')}/`;
-  const otherPodUrl = getPodUrl(otherPodUsername);
-  const webId = `${otherPodUrl}profile/card#me`;
+  const webId = `${podToSetPermissionsToURL}profile/card#me`;
 
   await setDocAclForUser(session, documentUrl, 'update', webId, permissions);
 };
@@ -67,7 +70,7 @@ export const setDocAclPermission = async (session, fileType, permissions, otherP
  * @param {Session} session - Solid's Session Object {@link Session}
  * @param {Access} permissions - The Access object for setting ACL in Solid
  * @param {URL} podUrl - URL of the user's Pod
- * @param {string} otherPodUsername - Username to other user's Pod or empty string
+ * @param {string} podToSetPermissionsToURL - URL of the other user's Pod to give/revoke permissions OR empty string
  * @returns {Promise} Promise - Sets permission for otherPodUsername for the user's
  * Documents container
  */
@@ -75,11 +78,10 @@ export const setDocContainerAclPermission = async (
   session,
   permissions,
   podUrl,
-  otherPodUsername
+  podToSetPermissionsToURL
 ) => {
   const containerUrl = `${podUrl}PASS/Documents/`;
-  const otherPodUrl = getPodUrl(otherPodUsername);
-  const webId = `${otherPodUrl}profile/card#me`;
+  const webId = `${podToSetPermissionsToURL}profile/card#me`;
 
   await setDocAclForUser(session, containerUrl, 'update', webId, permissions);
 };

--- a/test/utils/session-core.test.js
+++ b/test/utils/session-core.test.js
@@ -26,26 +26,6 @@ describe('setDocContainerAclPermission', () => {
     vi.clearAllMocks();
   });
 
-  // it('runs setDocAclForUser with the correct inputs', async () => {
-  //   const permissions = { read: true, append: true };
-  //   const otherPodUsername = 'pod2';
-
-  //   const expectedContainerUrl = 'https://pod.example.com/PASS/Documents/';
-  //   const expectedWebId = 'https://pod2.example.com/profile/card#me';
-
-  //   vi.spyOn(sessionHelpers, 'setDocAclForUser');
-
-  //   await setDocContainerAclPermission(session, permissions, mockPodUrl, otherPodUsername);
-
-  //   expect(sessionHelpers.setDocAclForUser).toBeCalledWith(
-  //     session,
-  //     expectedContainerUrl,
-  //     'update',
-  //     expectedWebId,
-  //     permissions
-  //   );
-  // });
-
   it('runs setDocAclForUser with the correct inputs', async () => {
     const permissions = { read: true, append: true };
     const expectedWebId = 'https://pod2.example.com/profile/card#me';

--- a/test/utils/session-core.test.js
+++ b/test/utils/session-core.test.js
@@ -26,16 +26,35 @@ describe('setDocContainerAclPermission', () => {
     vi.clearAllMocks();
   });
 
+  // it('runs setDocAclForUser with the correct inputs', async () => {
+  //   const permissions = { read: true, append: true };
+  //   const otherPodUsername = 'pod2';
+
+  //   const expectedContainerUrl = 'https://pod.example.com/PASS/Documents/';
+  //   const expectedWebId = 'https://pod2.example.com/profile/card#me';
+
+  //   vi.spyOn(sessionHelpers, 'setDocAclForUser');
+
+  //   await setDocContainerAclPermission(session, permissions, mockPodUrl, otherPodUsername);
+
+  //   expect(sessionHelpers.setDocAclForUser).toBeCalledWith(
+  //     session,
+  //     expectedContainerUrl,
+  //     'update',
+  //     expectedWebId,
+  //     permissions
+  //   );
+  // });
+
   it('runs setDocAclForUser with the correct inputs', async () => {
     const permissions = { read: true, append: true };
-    const otherPodUsername = 'pod2';
+    const expectedWebId = 'https://pod2.example.com/profile/card#me';
 
     const expectedContainerUrl = 'https://pod.example.com/PASS/Documents/';
-    const expectedWebId = 'https://pod2.example.com/profile/card#me';
 
     vi.spyOn(sessionHelpers, 'setDocAclForUser');
 
-    await setDocContainerAclPermission(session, permissions, mockPodUrl, otherPodUsername);
+    await setDocContainerAclPermission(session, permissions, mockPodUrl, expectedWebId);
 
     expect(sessionHelpers.setDocAclForUser).toBeCalledWith(
       session,


### PR DESCRIPTION
## This PR is the first step of what is needed for the "set permissions" forms ( Closes #307 )

---
## This PR:
1.  Changes from having a user type in a username on these forms to typing in a podUrl
2. The form file itself converts that podUrl to a webId before passing it into the functions from `session-core.js`
3. Will error and not submit form until inputs are filled
4. podUrl input will error if user types in their own podUrl and not submit form

---
## The files this PR effects:

### Components
`SetAclPermissionForm.jsx`
`SetAclPermsDocContainerForm.jsx`

### Tests
`session-core.test.js`

### Other Files
`session-core.js`

---
## Additional Context (optional):
Decided to go the route of leaving the button enabled, but fields will error until filled out.
This was due to all other forms/modals being this way.  In the `Upload Document Modal` the `upload` button is disabled, but once you choose a file it is enabled whether or not the rest of the required fields are filled in - it relies on MUIs checking of the required attribute.  So, all current forms are now similar in this aspect.

---
## Future Steps/PRs Needed to Finish This Work (optional):
**1.** Need to move these into modals/dialogs instead so they are not showing on the profile page until an onClick
          - Current idea is to make a `Set Permission for Container` button next to the `Add Document` button to trigger the container modal & add an icon or link in the document table row to trigger the document modal.
**2.** Need to update `userslist` or something similar to create a list of `contacts`
**3.** Use that list of contacts to replace the text input of podUrl with a select input of the user's contacts.

---