### PR TITLE
Cleaner format for GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,38 +7,48 @@ assignees: ''
 
 ---
 
-**Bug Title**: [Concise description of the bug]
+### Bug Title:
+Please provide a CONCISE description of the bug.
 
-**Bug Description**:
-Please provide a detailed description of the bug.
+---
+### Bug Description:
+Please provide a DETAILED description of the bug.
 
-**Reproduction Steps**:
-1. 
-2. 
-3. 
+---
+### Reproduction Steps:    
+**1.**    
+**2.** If needed, delete if not    
+**3.** If needed, delete if not
 
-**Expected Behavior**:
+---
+### Expected Behavior:
 What should have happened if the bug didn't occur.
 
-**Actual Behavior**:
+---
+### Actual Behavior:
 What actually happened, and how it differed from the expected behavior.
 
-**Screenshots (If applicable)**:
+---
+### Screenshots (If applicable):
 If possible, add screenshots to help explain the problem.
 
-**Desktop (please complete the following information):**
+---
+### Desktop (please complete the following information):
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+---
+### Smartphone (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 
-**Additional Context**:
+---
+### Additional Context (optional):
 Add any other context about the problem here.
 
-**Possible Solution (optional)**:
+---
+### Possible Solution (optional):
 If you have a suggestion on how to fix this bug.

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -7,17 +7,21 @@ assignees: ''
 
 ---
 
-**Describe the Current Behavior/Feature**:
+### Describe the Current Behavior/Feature:
 Provide a clear and concise description of the current behavior or feature.
 
-**Proposed Behavior/Feature**:
+---
+### Proposed Behavior/Feature:
 A clear and concise description of the enhancement you want. 
 
-**Rationale**:
+---
+### Rationale:
 Please outline why this enhancement is needed and how it will benefit the project.
 
-**Proposed Implementation (if applicable)**:
+---
+### Proposed Implementation (if applicable):
 Provide a detailed low level description of how you propose the enhancement should be implemented.
 
-**Additional context**:
+---
+### Additional context:
 Add any other context or screenshots about the enhancement request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,22 +8,29 @@ assignees: ''
 ---
 
 
-**Feature Title**: [Concise description of the feature]
+### Feature Title:
+Please provide a CONCISE description of the proposed feature.
 
-**Feature Description**:
-Please provide a detailed description of the proposed feature.
+---
+### Feature Description:
+Please provide a DETAILED description of the proposed feature.
 
-**Use Case**:
+---
+### Use Case:
 Explain when and why this feature would be used. Try to include as much detail as possible.
 
-**Proposed Solution**:
-If you have a solution in mind, please outline it here. If not, that's okay too.
+---
+### Proposed Solution:
+If you have a solution in mind, please outline it here.
 
-**Alternative Solutions**:
+---
+### Alternative Solutions:
 If there are alternative ways to solve this problem, please list them here.
 
-**Screenshots (if applicable)**:
+---
+### Screenshots (if applicable):
 Include any screenshots that may be helpful.
 
-**Additional Context**:
+---
+### Additional Context:
 Please provide any other information that might be helpful.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+---
+name: Pull Request
+about: Create a pull request to merge your code into the PASS codebase
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## CONCISE description of PR (PR Title)
+
+---
+## This PR:
+**1.**    
+**2.** If needed, delete if not    
+**3.** If needed, delete if not
+
+---
+## The files this PR effects:
+
+### Components
+List file names here
+
+### Tests
+List file names here
+
+### Other Files
+List file names here
+
+---
+## Screenshots (if applicable):
+Add any screenshots/videos here.
+
+---
+## Additional Context (optional):
+Add any other context about the PR here.
+
+---
+## Future Steps/PRs Needed to Finish This Work (optional):
+Add any other steps/PRs that may be needed to continue this work if this PR is just a step in the right direction.
+
+---
+## Issues needing discussion/feedback (optional):
+**1.**    
+**2.** If needed, delete if not    
+**3.** If needed, delete if not


### PR DESCRIPTION
## Updating GitHub PR and Issue templates that are available when creating a new one

---
## This PR:
1. Creates a PR template as well.
2. Makes each section a header instead of bold.
3. Separates each section via a horizontal rule.

---
## The files this PR effects:

### Components
None

### Tests
None

### Other Files
.github/
`pull_request_template.md`

.github/ISSUE_TEMPLATE/
`bug_report.md`
`enhancement_request.md`
`feature_request.md`