### PR TITLE
Issue 329 update pass color scheme

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -7,7 +7,7 @@ const theme = createTheme({
       light: '#039686',
       main: '#6750a4',
       dark: '#004d3e',
-      slight: '#8fc2bb',
+      slight: '#eaddff',
       contrastText: '#fff'
     },
     secondary: {

--- a/src/theme.js
+++ b/src/theme.js
@@ -32,36 +32,36 @@ const greenTheme = createTheme({
   }
 })
 
-const purpleTheme = createTheme({
-  typography: { fontFamily: 'Roboto, sans-serif' },
-  palette: {
-    primary: {
-      light: '#039686',
-      main: '#6750a4',
-      dark: '#004d3e',
-      slight: '#eaddff',
-      contrastText: '#fff'
-    },
-    secondary: {
-      light: '#b32126',
-      main: '#625b71',
-      dark: '#790111',
-      contrastText: '#fff'
-    },
-    tertiary: {
-      light: '#dbc584',
-      main: '#7d5260',
-      dark: '#dbb032',
-      contrastText: '#fff'
-    },
-    status: {
-      danger: '#b3261e'
-    },
-    neutral: {
-      main: '#64748B',
-      contrastText: '#fff'
-    }
-  }
-});
+// const purpleTheme = createTheme({
+//   typography: { fontFamily: 'Roboto, sans-serif' },
+//   palette: {
+//     primary: {
+//       light: '#039686',
+//       main: '#6750a4',
+//       dark: '#004d3e',
+//       slight: '#eaddff',
+//       contrastText: '#fff'
+//     },
+//     secondary: {
+//       light: '#b32126',
+//       main: '#625b71',
+//       dark: '#790111',
+//       contrastText: '#fff'
+//     },
+//     tertiary: {
+//       light: '#dbc584',
+//       main: '#7d5260',
+//       dark: '#dbb032',
+//       contrastText: '#fff'
+//     },
+//     status: {
+//       danger: '#b3261e'
+//     },
+//     neutral: {
+//       main: '#64748B',
+//       contrastText: '#fff'
+//     }
+//   }
+// });
 
 export default greenTheme;

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,6 +1,6 @@
 import { createTheme } from '@mui/material/styles';
 
-const theme = createTheme({
+const purpleTheme = createTheme({
   typography: { fontFamily: 'Roboto, sans-serif' },
   palette: {
     primary: {
@@ -32,4 +32,4 @@ const theme = createTheme({
   }
 });
 
-export default theme;
+export default purpleTheme;

--- a/src/theme.js
+++ b/src/theme.js
@@ -5,25 +5,25 @@ const theme = createTheme({
   palette: {
     primary: {
       light: '#039686',
-      main: '#017969',
+      main: '#6750a4',
       dark: '#004d3e',
       slight: '#8fc2bb',
       contrastText: '#fff'
     },
     secondary: {
       light: '#b32126',
-      main: '#961020',
+      main: '#625b71',
       dark: '#790111',
       contrastText: '#fff'
     },
     tertiary: {
       light: '#dbc584',
-      main: '#DEBC59',
+      main: '#7d5260',
       dark: '#dbb032',
       contrastText: '#fff'
     },
     status: {
-      danger: '#e53e3e'
+      danger: '#b3261e'
     },
     neutral: {
       main: '#64748B',

--- a/src/theme.js
+++ b/src/theme.js
@@ -30,7 +30,7 @@ const greenTheme = createTheme({
       contrastText: '#fff'
     }
   }
-})
+});
 
 // const purpleTheme = createTheme({
 //   typography: { fontFamily: 'Roboto, sans-serif' },


### PR DESCRIPTION
This branch now has both color schemes in the theme. To switch from one to the other, just change the name of the export in theme.js to greenTheme or purpleTheme and uncomment the theme if commented out. For reference I'm including a screen grab of the purple theme. 

Should we send a screen grab to the UX team? 
![Screen Shot 2023-08-01 at 2 52 21 PM](https://github.com/codeforpdx/PASS/assets/81979567/44467d6f-5997-4ea4-860a-2390cc775df5)
