### PR TITLE
Refactor Footer

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -1,138 +1,24 @@
 // React Imports
 import React from 'react';
-// Other Library Imports
-import dayjs from 'dayjs';
 // Material UI Imports
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import Divider from '@mui/material/Divider';
-import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
-import Typography from '@mui/material/Typography';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
-// Material Icons Imports
-import TwitterIcon from '@mui/icons-material/Twitter';
-import FacebookIcon from '@mui/icons-material/Facebook';
-import InstagramIcon from '@mui/icons-material/Instagram';
-
-// top section of footer
-const RenderCallToActionSection = ({ isReallySmallScreen }) => (
-  <Stack width={isReallySmallScreen ? 1 : 3 / 5} alignItems="center" justifyContent="center">
-    <Typography variant="h5" color="tertiary.main">
-      Want to partner with PASS?
-    </Typography>
-    <Typography variant="body1" color="#fff" sx={{ width: 3 / 4 }}>
-      If your organization is interested in partnering with PASS and would like to discuss further,
-      contact us below.
-    </Typography>
-    <Button variant="contained" color="secondary" sx={{ my: '1rem', width: 1 / 2 }}>
-      Proposal
-    </Button>
-  </Stack>
-);
-
-const socialLinks = [
-  {
-    href: 'https://twitter.com/',
-    icon: <TwitterIcon />
-  },
-  {
-    href: 'https://www.facebook.com/',
-    icon: <FacebookIcon />
-  },
-  {
-    href: 'https://www.instagram.com/',
-    icon: <InstagramIcon />
-  }
-];
-
-// middle section of footer
-const RenderCompanyInfoSection = ({ isReallySmallScreen }) => (
-  <Stack
-    width={isReallySmallScreen ? 1 : 1 / 5}
-    spacing={2}
-    justifyContent="space-around"
-    alignItems="center"
-  >
-    <Box>
-      <Typography color="tertiary.main">PASS LOGO</Typography>
-      <Typography color="#fff">tagline</Typography>
-    </Box>
-    <Box>
-      <Typography color="tertiary.main">Follow Us</Typography>
-      <Stack direction="row" spacing={1}>
-        {socialLinks.map(({ href, icon }) => (
-          <Link key={href} href={href} target="_blank" rel="noopener" color="#fff">
-            {icon}
-          </Link>
-        ))}
-      </Stack>
-    </Box>
-    <Box>
-      <Typography color="tertiary.main">Built By:</Typography>
-      <Link href="https://www.codeforpdx.org/" target="_blank" rel="noopener">
-        <Typography variant="body2" color="#fff">
-          C4PDX LOGO
-        </Typography>
-      </Link>
-    </Box>
-  </Stack>
-);
-
-const legalLinks = [
-  {
-    href: 'https://www.codeforpdx.org/',
-    title: 'Privacy Policy'
-  },
-  {
-    href: 'https://www.codeforpdx.org/',
-    title: 'Terms and Conditions'
-  },
-  {
-    href: 'https://www.codeforpdx.org/',
-    target: '_blank',
-    rel: 'noopenner',
-    ml: 0.5,
-    text: `©${dayjs().year()}`,
-    title: 'Code for PDX'
-  }
-];
-
-// bottom section of footer
-const RenderCopyrightAndLinksSection = ({ isReallySmallScreen }) => (
-  <Stack
-    orientation="column"
-    width={isReallySmallScreen ? 1 : 1 / 5}
-    spacing={2}
-    justifyContent="space-around"
-  >
-    {legalLinks.map((link) => (
-      <Typography key={link.title} variant="body2" color="tertiary.main">
-        {link.text ?? null}
-        <Link
-          href={link.href}
-          underline="none"
-          color="tertiary.main"
-          target={link.target ?? null}
-          rel={link.rel ?? null}
-          ml={link.ml ?? null}
-        >
-          {link.title}
-        </Link>
-      </Typography>
-    ))}
-  </Stack>
-);
+// Component Imports
+import RenderCallToActionSection from './RenderCallToActionSection';
+import RenderCompanyInfoSection from './RenderCompanyInfoSection';
+import RenderCopyrightAndLinksSection from './RenderCopyrightAndLinksSection';
 
 /**
  * Footer Component - Generates the responsive footer used in PASS
  *
  * @memberof Footer
  * @name Footer
+ * @returns {React.JSX.Element} The Footer component
  */
-
 const Footer = () => {
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));

--- a/src/components/Footer/RenderCallToActionSection.jsx
+++ b/src/components/Footer/RenderCallToActionSection.jsx
@@ -1,0 +1,34 @@
+// React Imports
+import React from 'react';
+// Material UI Imports
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+/**
+ * @typedef {import("../../typedefs.js").footerProps} footerProps
+ */
+
+/**
+ * The RenderCallToActionSection component renders information about policy,
+ * terms and conditions, and the site to Code for PDX
+ *
+ * @param {footerProps} isReallySmallScreen - The props for footer sub-component
+ * @returns {React.JSX.Element} The RenderCallToActionSection component
+ */
+const RenderCallToActionSection = ({ isReallySmallScreen }) => (
+  <Stack width={isReallySmallScreen ? 1 : 3 / 5} alignItems="center" justifyContent="center">
+    <Typography variant="h5" color="tertiary.main">
+      Want to partner with PASS?
+    </Typography>
+    <Typography variant="body1" color="#fff" sx={{ width: 3 / 4 }}>
+      If your organization is interested in partnering with PASS and would like to discuss further,
+      contact us below.
+    </Typography>
+    <Button variant="contained" color="secondary" sx={{ my: '1rem', width: 1 / 2 }}>
+      Proposal
+    </Button>
+  </Stack>
+);
+
+export default RenderCallToActionSection;

--- a/src/components/Footer/RenderCallToActionSection.jsx
+++ b/src/components/Footer/RenderCallToActionSection.jsx
@@ -13,7 +13,7 @@ import Typography from '@mui/material/Typography';
  * The RenderCallToActionSection component renders information about policy,
  * terms and conditions, and the site to Code for PDX
  *
- * @param {footerProps} isReallySmallScreen - The props for footer sub-component
+ * @param {footerProps} Props - The props for footer sub-component
  * @returns {React.JSX.Element} The RenderCallToActionSection component
  */
 const RenderCallToActionSection = ({ isReallySmallScreen }) => (

--- a/src/components/Footer/RenderCompanyInfoSection.jsx
+++ b/src/components/Footer/RenderCompanyInfoSection.jsx
@@ -33,7 +33,7 @@ const socialLinks = [
  * The RenderCompanyInfoSection component renders information about policy,
  * terms and conditions, and the site to Code for PDX
  *
- * @param {footerProps} isReallySmallScreen - The props for footer sub-component
+ * @param {footerProps} Props - The props for footer sub-component
  * @returns {React.JSX.Element} The RenderCompanyInfoSection component
  */
 const RenderCompanyInfoSection = ({ isReallySmallScreen }) => (

--- a/src/components/Footer/RenderCompanyInfoSection.jsx
+++ b/src/components/Footer/RenderCompanyInfoSection.jsx
@@ -1,0 +1,71 @@
+// React Imports
+import React from 'react';
+// Material UI Imports
+import Box from '@mui/material/Box';
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import TwitterIcon from '@mui/icons-material/Twitter';
+import FacebookIcon from '@mui/icons-material/Facebook';
+import InstagramIcon from '@mui/icons-material/Instagram';
+
+// Links for component
+const socialLinks = [
+  {
+    href: 'https://twitter.com/',
+    icon: <TwitterIcon />
+  },
+  {
+    href: 'https://www.facebook.com/',
+    icon: <FacebookIcon />
+  },
+  {
+    href: 'https://www.instagram.com/',
+    icon: <InstagramIcon />
+  }
+];
+
+/**
+ * @typedef {import("../../typedefs.js").footerProps} footerProps
+ */
+
+/**
+ * The RenderCompanyInfoSection component renders information about policy,
+ * terms and conditions, and the site to Code for PDX
+ *
+ * @param {footerProps} isReallySmallScreen - The props for footer sub-component
+ * @returns {React.JSX.Element} The RenderCompanyInfoSection component
+ */
+const RenderCompanyInfoSection = ({ isReallySmallScreen }) => (
+  <Stack
+    width={isReallySmallScreen ? 1 : 1 / 5}
+    spacing={2}
+    justifyContent="space-around"
+    alignItems="center"
+  >
+    <Box>
+      <Typography color="tertiary.main">PASS LOGO</Typography>
+      <Typography color="#fff">tagline</Typography>
+    </Box>
+    <Box>
+      <Typography color="tertiary.main">Follow Us</Typography>
+      <Stack direction="row" spacing={1}>
+        {socialLinks.map(({ href, icon }) => (
+          <Link key={href} href={href} target="_blank" rel="noopener" color="#fff">
+            {icon}
+          </Link>
+        ))}
+      </Stack>
+    </Box>
+    <Box>
+      <Typography color="tertiary.main">Built By:</Typography>
+      <Link href="https://www.codeforpdx.org/" target="_blank" rel="noopener">
+        <Typography variant="body2" color="#fff">
+          C4PDX LOGO
+        </Typography>
+      </Link>
+    </Box>
+  </Stack>
+);
+
+export default RenderCompanyInfoSection;

--- a/src/components/Footer/RenderCopyrightAndLinksSection.jsx
+++ b/src/components/Footer/RenderCopyrightAndLinksSection.jsx
@@ -1,0 +1,66 @@
+// React Imports
+import React from 'react';
+// Other Library Imports
+import dayjs from 'dayjs';
+// Material UI Imports
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+// Links for component
+const legalLinks = [
+  {
+    href: 'https://www.codeforpdx.org/',
+    title: 'Privacy Policy'
+  },
+  {
+    href: 'https://www.codeforpdx.org/',
+    title: 'Terms and Conditions'
+  },
+  {
+    href: 'https://www.codeforpdx.org/',
+    target: '_blank',
+    rel: 'noopenner',
+    ml: 0.5,
+    text: `©${dayjs().year()}`,
+    title: 'Code for PDX'
+  }
+];
+
+/**
+ * @typedef {import("../../typedefs.js").footerProps} footerProps
+ */
+
+/**
+ * The RenderCopyrightAndLinksSection component renders information about policy,
+ * terms and conditions, and the site to Code for PDX
+ *
+ * @param {footerProps} isReallySmallScreen - The props for footer sub-component
+ * @returns {React.JSX.Element} The RenderCopyrightAndLinksSection component
+ */
+const RenderCopyrightAndLinksSection = ({ isReallySmallScreen }) => (
+  <Stack
+    orientation="column"
+    width={isReallySmallScreen ? 1 : 1 / 5}
+    spacing={2}
+    justifyContent="space-around"
+  >
+    {legalLinks.map((link) => (
+      <Typography key={link.title} variant="body2" color="tertiary.main">
+        {link.text ?? null}
+        <Link
+          href={link.href}
+          underline="none"
+          color="tertiary.main"
+          target={link.target ?? null}
+          rel={link.rel ?? null}
+          ml={link.ml ?? null}
+        >
+          {link.title}
+        </Link>
+      </Typography>
+    ))}
+  </Stack>
+);
+
+export default RenderCopyrightAndLinksSection;

--- a/src/components/Footer/RenderCopyrightAndLinksSection.jsx
+++ b/src/components/Footer/RenderCopyrightAndLinksSection.jsx
@@ -35,7 +35,7 @@ const legalLinks = [
  * The RenderCopyrightAndLinksSection component renders information about policy,
  * terms and conditions, and the site to Code for PDX
  *
- * @param {footerProps} isReallySmallScreen - The props for footer sub-component
+ * @param {footerProps} Props - The props for footer sub-component
  * @returns {React.JSX.Element} The RenderCopyrightAndLinksSection component
  */
 const RenderCopyrightAndLinksSection = ({ isReallySmallScreen }) => (

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -283,4 +283,14 @@ const React = require('react');
  * @memberof typedefs
  */
 
+/**
+ * footerProps is an object that stores the props for the Footer subcomponents
+ *
+ * @exports footerProps
+ * @typedef {object} footerProps
+ * @property {boolean} isReallySmallScreen - Boolean for if screen is below theme
+ * breakdown of 'sm' for MUI
+ * @memberof typedefs
+ */
+
 exports.unused = {};


### PR DESCRIPTION
This PR is largely focused on refactoring the Footer sub-components out into their own file.

Even though the file is still pretty manageable (under 200 lines), think it'll be easier to tailor/manage/refactor the Footer component once we start transitioning our current footer to something closer to what the UX team creates or even what Hauvert have created recently on Adobe.

Not much is changed here outside of file restructuring in `src/components/Footer` and including JSDocs and typedefs.