### PR TITLE
Fix Vite alias pathing for Intellisense

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@hooks": ["./src/hooks"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@contexts": ["./src/contexts"],
+      "@contexts/*": ["./src/contexts/*"],
+      "@pages": ["./src/pages"],
+      "@pages/*": ["./src/pages/*"],
+      "@utils": ["./src/utils"],
+      "@utils/*": ["./src/utils/*"],
+      "@components": ["./src/components"],
+      "@components/*": ["./src/components/*"],
+      "@constants": ["./src/constants"],
+      "@constants/*": ["./src/constants/*"],
+      "@inrupt/solid-client": ["./node_modules/@inrupt/solid-client/dist"],
+      "@inrupt/solid-client-authn-core": ["./node_modules/@inrupt/solid-client-authn-core/dist"]
+    }
+  }
+}


### PR DESCRIPTION
## Fix Vite alias pathing for Intellisense

At the moment, we utilizes Vite aliases to help link our modules/components with the "@" symbol (i.e. `@hooks` for `./src/hooks`). However, Intellisense doesn't seem to be picking up the correcting paths to these files. To fix this, I've coded up a `jsconfig.json` file in the project root to resolve this problem.

---
## This PR:
**1.**    Allows Intellisense to pick up the pathing to Vite aliases

---
## The files this PR effects:

All files that utilizes Vite aliases as a shortcut to components/modules/etc.

### Other Files
- `./jsconfig.json`

---
## Screenshots (if applicable):

Without jsconfig.json and Intellisense support:

<img width="1440" alt="Screen Shot 2023-09-13 at 6 28 54" src="https://github.com/codeforpdx/PASS/assets/14917816/920683c6-b0fb-44e8-99f8-7176e3a0d659">

With jsconfig.json and Intellisense support:

<img width="1440" alt="Screen Shot 2023-09-13 at 6 30 00" src="https://github.com/codeforpdx/PASS/assets/14917816/d7e2281b-c1f7-49f3-b4ee-68e54c1ab3a8">
