### PR TITLE
Improve accessible name for images on home page and prop names for HomeSection

### DIFF
--- a/src/components/Footer/RenderCompanyInfoSection.jsx
+++ b/src/components/Footer/RenderCompanyInfoSection.jsx
@@ -12,7 +12,11 @@ import SvgIcon from '@mui/material/SvgIcon';
 
 // new Twitter Icon
 const TwitterIcon = () => (
-  <SvgIcon viewBox="0 0 512 512" sx={{ width: '1.25em', height: '1.25em' }}>
+  <SvgIcon
+    viewBox="0 0 512 512"
+    sx={{ width: '1.25em', height: '1.25em' }}
+    titleAccess="Twitter logo"
+  >
     <path
       d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"
       fill="#fff"
@@ -32,14 +36,14 @@ const socialLinks = [
   {
     name: 'Facebook',
     href: 'https://www.facebook.com/',
-    icon: <FacebookIcon fontSize="large" />,
+    icon: <FacebookIcon fontSize="large" titleAccess="Facebook logo" />,
     target: '_blank',
     rel: 'noopenner'
   },
   {
     name: 'Instagram',
     href: 'https://www.instagram.com/',
-    icon: <InstagramIcon fontSize="large" />,
+    icon: <InstagramIcon fontSize="large" titleAccess="Instagram logo" />,
     target: '_blank',
     rel: 'noopenner'
   }

--- a/src/components/Home/HomeSection.jsx
+++ b/src/components/Home/HomeSection.jsx
@@ -6,8 +6,8 @@ import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 /**
  * @typedef {object} HomeSectionParams
- * @property {string} src - image src
- * @property {string} alt - image alt
+ * @property {string} componentImageSrc - image src
+ * @property {string} componentImageAlt - image alt
  * @property {string} title - section title
  * @property {string} description - section description
  * @property {string} button - section button
@@ -25,8 +25,8 @@ import Button from '@mui/material/Button';
  */
 
 const HomeSection = ({
-  src,
-  alt,
+  componentImageSrc,
+  componentImageAlt,
   title,
   description,
   button,
@@ -37,8 +37,8 @@ const HomeSection = ({
   <>
     <Box
       component="img"
-      src={src}
-      alt={alt}
+      src={componentImageSrc}
+      alt={componentImageAlt}
       sx={{
         width: isReallySmallScreen ? 1 : 2 / 4
       }}

--- a/src/components/NavBar/NavbarDesktop.jsx
+++ b/src/components/NavBar/NavbarDesktop.jsx
@@ -62,7 +62,7 @@ const NavbarDesktop = ({ setShowConfirmation }) => {
       <AppBar position="static" color="primary">
         <Toolbar sx={{ minHeight: '64px' }}>
           <Link to="/" aria-label="Home">
-            <img src="/pass-logo.png" alt="CODE PDX logo" style={{ marginRight: '2rem' }} />
+            <img src="/pass-logo.png" alt="PASS logo" style={{ marginRight: '2rem' }} />
           </Link>
           <NavbarLinks aria-label="navigation links" />
           <Box sx={{ flexGrow: 1 }} />

--- a/src/components/NavBar/NavbarDesktop.jsx
+++ b/src/components/NavBar/NavbarDesktop.jsx
@@ -62,12 +62,7 @@ const NavbarDesktop = ({ setShowConfirmation }) => {
       <AppBar position="static" color="primary">
         <Toolbar sx={{ minHeight: '64px' }}>
           <Link to="/" aria-label="Home">
-            <img
-              src="/pass-logo.png"
-              alt="logo"
-              style={{ marginRight: '2rem' }}
-              aria-label="logo"
-            />
+            <img src="/pass-logo.png" alt="CODE PDX logo" style={{ marginRight: '2rem' }} />
           </Link>
           <NavbarLinks aria-label="navigation links" />
           <Box sx={{ flexGrow: 1 }} />

--- a/src/components/NavBar/NavbarLoggedOut.jsx
+++ b/src/components/NavBar/NavbarLoggedOut.jsx
@@ -21,7 +21,7 @@ const NavbarLoggedOut = () => (
     <AppBar position="static" color="primary">
       <Toolbar sx={{ minHeight: '64px' }}>
         <Link to="/" aria-label="Home">
-          <img src="/pass-logo.png" alt="CODE PDX logo" style={{ marginRight: '2rem' }} />
+          <img src="/pass-logo.png" alt="PASS logo" style={{ marginRight: '2rem' }} />
         </Link>
         <OidcLoginComponent />
       </Toolbar>

--- a/src/components/NavBar/NavbarLoggedOut.jsx
+++ b/src/components/NavBar/NavbarLoggedOut.jsx
@@ -21,7 +21,7 @@ const NavbarLoggedOut = () => (
     <AppBar position="static" color="primary">
       <Toolbar sx={{ minHeight: '64px' }}>
         <Link to="/" aria-label="Home">
-          <img src="/pass-logo.png" alt="logo" style={{ marginRight: '2rem' }} aria-label="logo" />
+          <img src="/pass-logo.png" alt="CODE PDX logo" style={{ marginRight: '2rem' }} />
         </Link>
         <OidcLoginComponent />
       </Toolbar>

--- a/src/components/NavBar/NavbarMobile.jsx
+++ b/src/components/NavBar/NavbarMobile.jsx
@@ -58,7 +58,7 @@ const NavbarMobile = ({ setShowConfirmation }) => {
       <AppBar position="static" color="primary">
         <Toolbar sx={{ minHeight: '64px' }}>
           <Link to="/" aria-label="Home">
-            <img src="/pass-logo.png" alt="CODE PDX logo" style={{ marginRight: '2rem' }} />
+            <img src="/pass-logo.png" alt="PASS logo" style={{ marginRight: '2rem' }} />
           </Link>
           <NavbarLinks aria-label="navigation links" />
           <Box sx={{ flexGrow: 1 }} />

--- a/src/components/NavBar/NavbarMobile.jsx
+++ b/src/components/NavBar/NavbarMobile.jsx
@@ -58,12 +58,7 @@ const NavbarMobile = ({ setShowConfirmation }) => {
       <AppBar position="static" color="primary">
         <Toolbar sx={{ minHeight: '64px' }}>
           <Link to="/" aria-label="Home">
-            <img
-              src="/pass-logo.png"
-              alt="logo"
-              style={{ marginRight: '2rem' }}
-              aria-label="logo"
-            />
+            <img src="/pass-logo.png" alt="CODE PDX logo" style={{ marginRight: '2rem' }} />
           </Link>
           <NavbarLinks aria-label="navigation links" />
           <Box sx={{ flexGrow: 1 }} />

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -42,7 +42,7 @@ const Home = () => {
             <HomeSection
               isReallySmallScreen={isReallySmallScreen}
               src="/assets/web-security-green.png"
-              alt="Web security"
+              alt=""
               title="Keep Your Documents Safe and Secure Using Decentralized Technology"
               description="Our innovative solution empowers individuals to manage their critical documents and control access for trusted organizations. PASS simplifies service access, enabling seamless documents requests and secure data sharing for a smoother support process."
               button="Request a Demo"
@@ -51,14 +51,14 @@ const Home = () => {
             <HomeSection
               isReallySmallScreen={isReallySmallScreen}
               src="/assets/app-green.png"
-              alt="Web App"
+              alt=""
               title="An App Built for Caseworkers"
               description="PASS allows users to quickly and securely share documents of their clients within the app. The app helps caseworkers verify and share documents such as ID and proof of income while retaining total control of them."
             />
             <HomeSection
               isReallySmallScreen={isReallySmallScreen}
               src="/assets/key-features-green.png"
-              alt="Key Features"
+              alt=""
               title="Key Features"
             />
             <KeyFeatures

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -41,8 +41,8 @@ const Home = () => {
           <Stack alignItems="center" justifyContent="center">
             <HomeSection
               isReallySmallScreen={isReallySmallScreen}
-              src="/assets/web-security-green.png"
-              alt=""
+              componentImageSrc="/assets/web-security-green.png"
+              componentImageAlt=""
               title="Keep Your Documents Safe and Secure Using Decentralized Technology"
               description="Our innovative solution empowers individuals to manage their critical documents and control access for trusted organizations. PASS simplifies service access, enabling seamless documents requests and secure data sharing for a smoother support process."
               button="Request a Demo"
@@ -50,15 +50,15 @@ const Home = () => {
             />
             <HomeSection
               isReallySmallScreen={isReallySmallScreen}
-              src="/assets/app-green.png"
-              alt=""
+              componentImageSrc="/assets/app-green.png"
+              componentImageAlt=""
               title="An App Built for Caseworkers"
               description="PASS allows users to quickly and securely share documents of their clients within the app. The app helps caseworkers verify and share documents such as ID and proof of income while retaining total control of them."
             />
             <HomeSection
               isReallySmallScreen={isReallySmallScreen}
-              src="/assets/key-features-green.png"
-              alt=""
+              componentImageSrc="/assets/key-features-green.png"
+              componentImageAlt=""
               title="Key Features"
             />
             <KeyFeatures

--- a/test/components/NavBar/NavbarDesktop.test.jsx
+++ b/test/components/NavBar/NavbarDesktop.test.jsx
@@ -5,13 +5,13 @@ import { expect, it } from 'vitest';
 import NavbarDesktop from '../../../src/components/NavBar/NavbarDesktop';
 
 it('renders icon menu when on screen larger than mobile', () => {
-  const { queryByLabelText } = render(
+  const { queryByLabelText, queryByRole } = render(
     <BrowserRouter>
       <NavbarDesktop />
     </BrowserRouter>
   );
 
-  const logo = queryByLabelText('logo');
+  const logo = queryByRole('img', { name: /logo$/ });
   const navLinks = queryByLabelText('navigation tabs');
   const iconMenu = queryByLabelText('menu');
 

--- a/test/components/NavBar/NavbarLoggedOut.test.jsx
+++ b/test/components/NavBar/NavbarLoggedOut.test.jsx
@@ -11,8 +11,8 @@ it('renders login button when user is logged out', () => {
     </BrowserRouter>
   );
 
-  const logo = queryByLabelText('logo');
-  const loginButton = queryByRole('button');
+  const logo = queryByRole('img', { name: /logo$/ });
+  const loginButton = queryByLabelText('Login Button');
 
   expect(logo).not.toBeNull();
   expect(loginButton).not.toBeNull();

--- a/test/components/NavBar/NavbarLoggedOut.test.jsx
+++ b/test/components/NavBar/NavbarLoggedOut.test.jsx
@@ -5,14 +5,14 @@ import { BrowserRouter } from 'react-router-dom';
 import NavbarLoggedOut from '../../../src/components/NavBar/NavbarLoggedOut';
 
 it('renders login button when user is logged out', () => {
-  const { queryByLabelText, queryByRole } = render(
+  const { queryByRole } = render(
     <BrowserRouter>
       <NavbarLoggedOut />
     </BrowserRouter>
   );
 
   const logo = queryByRole('img', { name: /logo$/ });
-  const loginButton = queryByLabelText('Login Button');
+  const loginButton = queryByRole('button');
 
   expect(logo).not.toBeNull();
   expect(loginButton).not.toBeNull();

--- a/test/components/NavBar/NavbarMobile.test.jsx
+++ b/test/components/NavBar/NavbarMobile.test.jsx
@@ -5,13 +5,13 @@ import { expect, it } from 'vitest';
 import NavbarMobile from '../../../src/components/NavBar/NavbarMobile';
 
 it('renders hamburger menu when on mobile', () => {
-  const { queryByLabelText } = render(
+  const { queryByLabelText, queryByRole } = render(
     <BrowserRouter>
       <NavbarMobile />
     </BrowserRouter>
   );
 
-  const logo = queryByLabelText('logo');
+  const logo = queryByRole('img', { name: /logo$/ });
   const navLinks = queryByLabelText('navigation tabs');
   const hamburgerMenu = queryByLabelText('mobile menu');
 

--- a/test/pages/__snapshots__/Home.test.jsx.snap
+++ b/test/pages/__snapshots__/Home.test.jsx.snap
@@ -15,7 +15,7 @@ exports[`Home Page > renders 1`] = `
           class="MuiStack-root css-1z0rh7t-MuiStack-root"
         >
           <img
-            alt="Web security"
+            alt=""
             class="MuiBox-root css-11ze7cv"
             src="/assets/web-security-green.png"
           />
@@ -42,7 +42,7 @@ exports[`Home Page > renders 1`] = `
             />
           </a>
           <img
-            alt="Web App"
+            alt=""
             class="MuiBox-root css-11ze7cv"
             src="/assets/app-green.png"
           />
@@ -59,7 +59,7 @@ exports[`Home Page > renders 1`] = `
             PASS allows users to quickly and securely share documents of their clients within the app. The app helps caseworkers verify and share documents such as ID and proof of income while retaining total control of them.
           </h5>
           <img
-            alt="Key Features"
+            alt=""
             class="MuiBox-root css-11ze7cv"
             src="/assets/key-features-green.png"
           />


### PR DESCRIPTION
## This PR:

Improves accessible name for images on home page.
 
**1.**  Adds context for all logo images
**2.** Removes unnecessary `aria-label`s
**3.** Mark decorative (non-informative images) as such using an empty `alt` attribute

## The files this PR effects:

### Components

```
src/components/Footer/RenderCompanyInfoSection.jsx
src/components/NavBar/NavbarDesktop.jsx
src/components/NavBar/NavbarLoggedOut.jsx
src/components/NavBar/NavbarMobile.jsx
src/pages/Home.jsx
```

### Tests

```
test/components/NavBar/NavbarDesktop.test.jsx
test/components/NavBar/NavbarLoggedOut.test.jsx
test/components/NavBar/NavbarMobile.test.jsx
test/pages/__snapshots__/Home.test.jsx.snap
```

## Screenshots (if applicable):

Should be no difference visually.

## Additional Context (optional):

Following guidance around [decorative](https://www.w3.org/WAI/tutorials/images/decorative/#example-1-image-used-as-part-of-page-design)/[informative](https://www.w3.org/WAI/tutorials/images/informative/) images from W3. Verified using [this extension](https://accessibilityinsights.io/) and DevTools.