### PR TITLE
improve react query behavior

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,8 +22,14 @@ import Layout from './layouts/Layout';
 /**
  * @typedef {import("./typedefs").messageListObject} messageListObject
  */
-
-const queryClient = new QueryClient();
+const queryClientConfig = {
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 // one minute
+    }
+  }
+};
+const queryClient = new QueryClient(queryClientConfig);
 
 const App = () => (
   <QueryClientProvider client={queryClient}>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,13 +15,6 @@ import theme from './theme';
 import AppRoutes from './AppRoutes';
 import Layout from './layouts/Layout';
 
-/**
- * @typedef {import("./typedefs").userListObject} userListObject
- */
-
-/**
- * @typedef {import("./typedefs").messageListObject} messageListObject
- */
 const queryClientConfig = {
   defaultOptions: {
     queries: {


### PR DESCRIPTION
A small improvement to react query behavior. React query automatically refetches any data marked as "stale" when it's requested. By default `staleTime` is set to zero, everything is automatically stale and always refetched. This change sets `staleTime` to one minute. Documents won't be refetched until they're a minute old. This should reduce some redundant fetches.