### PR TITLE
Limit size of file upload for profile photo

### DIFF
--- a/src/components/Profile/ProfileImageField.jsx
+++ b/src/components/Profile/ProfileImageField.jsx
@@ -11,6 +11,7 @@ import ImageIcon from '@mui/icons-material/Image';
 import Typography from '@mui/material/Typography';
 // Contexts Imports
 import { SignedInUserContext } from '@contexts';
+import useNotification from '../../hooks/useNotification';
 
 /**
  * @typedef {import("../../typedefs").profileImageFieldProps} profileImageFieldProps
@@ -26,19 +27,24 @@ import { SignedInUserContext } from '@contexts';
  * @returns {React.JSX.Element} React component for NewMessage
  */
 const ProfileImageField = ({ loadProfileData, contactProfile }) => {
+  const { addNotification } = useNotification();
   const { session } = useSession();
   const { profileData, fetchProfileInfo, removeProfileImage, uploadProfileImage } =
     useContext(SignedInUserContext);
   const [profileImg, setProfileImg] = useState(localStorage.getItem('profileImage'));
 
   const handleProfileImage = async (event) => {
-    await uploadProfileImage(session, profileData, event.target.files[0]);
+    if (event.target.files[0].size > 1 * 1000 * 1024) {
+      addNotification('error', 'Profile images have a maximum size of 1MB.');
+    } else {
+      await uploadProfileImage(session, profileData, event.target.files[0]);
 
-    const updatedProfileData = await fetchProfileInfo(session, session.info.webId);
-    localStorage.setItem('profileImage', updatedProfileData.profileInfo.profileImage);
-    setProfileImg(updatedProfileData.profileInfo.profileImage);
+      const updatedProfileData = await fetchProfileInfo(session, session.info.webId);
+      localStorage.setItem('profileImage', updatedProfileData.profileInfo.profileImage);
+      setProfileImg(updatedProfileData.profileInfo.profileImage);
 
-    loadProfileData();
+      loadProfileData();
+    }
   };
 
   const handleRemoveProfileImg = async () => {


### PR DESCRIPTION
## This PR:
Resolves #289 
 
**1.**  Limits profile photo file size to 1MB
**2.** Shows an error in bottom left if the photo size is greater than 1MB

## Screenshots (if applicable):
https://github.com/codeforpdx/PASS/assets/3335277/69b8a420-5658-4e60-b257-8c8889acbdcf

## Additional Context (optional):
Just a limit for the small avatar image, so that it is no longer unconstrained. 

## Future Steps/PRs Needed to Finish This Work (optional):
We may want to revisit and adjust the profile photo file size requirement during user testing.

## Issues needing discussion/feedback (optional):

None for this PR, but there are a couple of items mentioned in issue #289 worth future discussions:

**1.** See @timbot1789 notes on limiting document uploads with an environment variable configurable by the hosting org.
**2.** Similarly, we might consider a configurable total pod size constraint so that the total storage size of a pod is limited so that dimension is not unconstrained. This is more of a concern for the pod hosting organization whoever that ends up being. 
