### PR TITLE
Cleaning up existing JSDoc comments; Excluding props for typedefs

### DIFF
--- a/src/components/Contacts/ContactListTable.jsx
+++ b/src/components/Contacts/ContactListTable.jsx
@@ -8,11 +8,9 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
-
 // MUI Theme
 import { ThemeProvider } from '@mui/material/styles';
 import theme from '../../theme';
-
 // Component Imports
 import ContactListTableRow from './ContactListTableRow';
 
@@ -20,13 +18,7 @@ import ContactListTableRow from './ContactListTableRow';
 const columnTitlesArray = ['Contact', 'Pin', 'Delete'];
 
 /**
- * contactListTableProps is an object that stores the props for the
- * ContactListTable component
- *
- * @typedef {object} contactListTableProps
- * @property {Array} contacts - this list of contacts to display
- * @property {Function} deleteContact - method to delete contact
- * @memberof typedefs
+ * @typedef {import("../../typedefs.js").userListObject} userListObject
  */
 
 /**
@@ -34,7 +26,9 @@ const columnTitlesArray = ['Contact', 'Pin', 'Delete'];
  *
  * @memberof Contacts
  * @name ContactListTable
- * @param {contactListTableProps} Props - Props for ContactListTable
+ * @param {object} Props - Props for ContactListTable
+ * @param {userListObject[]} Props.contacts - this list of contacts to display
+ * @param {Function} Props.deleteContact - method to delete contact
  * @returns {React.JSX.Element} The ContactListTable Component
  */
 const ContactListTable = ({ contacts, deleteContact }) => {

--- a/src/components/Contacts/ContactListTableRow.jsx
+++ b/src/components/Contacts/ContactListTableRow.jsx
@@ -11,25 +11,16 @@ import PushPinIcon from '@mui/icons-material/PushPin';
 import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
-
 // Context Imports
 import { DocumentListContext } from '@contexts';
-
+// Custom Hook Imports
+import useNotification from '@hooks/useNotification';
 // MUI Theme
 import { ThemeProvider } from '@mui/material/styles';
 import theme from '../../theme';
 
-// Custom Hook Imports
-import useNotification from '../../hooks/useNotification';
-
 /**
- * contactListTableRowProps is an object that stores the props for the
- * ContactListTableRow component
- *
- * @typedef {object} contactListTableRowProps
- * @property {object} contact - Object containing contact information
- * @property {Function} deleteContact
- * - function to delete a chosen contact
+ * @typedef {import("../../typedefs.js").userListObject} userListObject
  */
 
 /**
@@ -38,7 +29,10 @@ import useNotification from '../../hooks/useNotification';
  *
  * @memberof Contacts
  * @name ContactListTableRow
- * @param {contactListTableRowProps} Props - Props for ContactListTableRow
+ * @param {object} Props - Props for ContactListTableRow
+ * @param {userListObject} Props.contact - contact object that store's contact
+ * information
+ * @param {Function} Props.deleteContact - method to delete contact
  * @returns {React.JSX.Element} The ContactListTableRow Component
  */
 const ContactListTableRow = ({ contact, deleteContact }) => {

--- a/src/components/Documents/DocumentTable.jsx
+++ b/src/components/Documents/DocumentTable.jsx
@@ -11,7 +11,6 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 // Context Imports
 import { DocumentListContext } from '@contexts';
-
 // Component Imports
 import { ThemeProvider } from '@mui/material/styles';
 import theme from '../../theme';
@@ -19,16 +18,17 @@ import DocumentTableRow from './DocumentTableRow';
 import { EmptyListNotification, LoadingAnimation } from '../Notification';
 
 /**
- * @typedef {import("../../typedefs.js").documentTableProps} documentTableProps
- */
-
-/**
  * DocumentTable Component - The Document Table that shows the list of documents
  * stored on Solid
  *
  * @memberof Documents
  * @name DocumentTable
- * @param {documentTableProps} Props - Props for DocumentTable component
+ * @param {object} Props - Props for DocumentTable component
+ * @param {(modalType: string, docName: string, docType: string)
+ * => void} Props.handleAclPermissionsModal - Function for setting up the
+ * correct version of the SetAclPermissions Modal, and opening it.
+ * @param {(document: object) => void} Props.handleSelectDeleteDoc - method
+ * to delete document
  * @returns {React.JSX.Element} The DocumentTable component
  */
 const DocumentTable = ({ handleAclPermissionsModal, handleSelectDeleteDoc }) => {

--- a/src/components/Documents/DocumentTableRow.jsx
+++ b/src/components/Documents/DocumentTableRow.jsx
@@ -9,27 +9,26 @@ import IconButton from '@mui/material/IconButton';
 import ShareIcon from '@mui/icons-material/Share';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
-
 // Utility Imports
 import { getBlobFromSolid } from '@utils';
-
 // MUI Theme
 import { ThemeProvider } from '@mui/material/styles';
 import theme from '../../theme';
-
 // Constants Imports
 import DOC_TYPES from '../../constants/doc_types';
-
-/**
- * @typedef {import("../../typedefs.js").documentTableRowProps} documentTableRowProps
- */
 
 /**
  * DocumentTableRow Component - A row in the Document Table
  *
  * @memberof Documents
  * @name DocumentTableRow
- * @param {documentTableRowProps} Props - Props for DocumentTableRow
+ * @param {object} Props - Props for DocumentTableRow
+ * @param {File} Props.document - File object containing the document
+ * @param {(modalType: string, docName: string, docType: string)
+ * => void} Props.handleAclPermissionsModal - Function for setting up the
+ * correct version of the SetAclPermissions Modal, and opening it.
+ * @param {(document: object) => void} Props.handleSelectDeleteDoc - method
+ * to delete document
  * @returns {React.JSX.Element} The DocumentTableRow component
  */
 const DocumentTableRow = ({ document, handleAclPermissionsModal, handleSelectDeleteDoc }) => {

--- a/src/components/Footer/RenderCallToActionSection.jsx
+++ b/src/components/Footer/RenderCallToActionSection.jsx
@@ -6,14 +6,12 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 
 /**
- * @typedef {import("../../typedefs.js").footerProps} footerProps
- */
-
-/**
  * The RenderCallToActionSection component renders information about policy,
  * terms and conditions, and the site to Code for PDX
  *
- * @param {footerProps} Props - The props for footer sub-component
+ * @param {object} Props - The props for footer sub-component
+ * @param {boolean} Props.isReallySmallScreen - Boolean for if screen is below theme
+ * breakdown of 'sm' for MUI
  * @returns {React.JSX.Element} The RenderCallToActionSection component
  */
 const RenderCallToActionSection = ({ isReallySmallScreen }) => (

--- a/src/components/Footer/RenderCompanyInfoSection.jsx
+++ b/src/components/Footer/RenderCompanyInfoSection.jsx
@@ -5,7 +5,6 @@ import Box from '@mui/material/Box';
 import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-
 import FacebookIcon from '@mui/icons-material/Facebook';
 import InstagramIcon from '@mui/icons-material/Instagram';
 import SvgIcon from '@mui/material/SvgIcon';
@@ -50,14 +49,12 @@ const socialLinks = [
 ];
 
 /**
- * @typedef {import("../../typedefs.js").footerProps} footerProps
- */
-
-/**
  * The RenderCompanyInfoSection component renders information about policy,
  * terms and conditions, and the site to Code for PDX
  *
- * @param {footerProps} Props - The props for footer sub-component
+ * @param {object} Props - The props for footer sub-component
+ * @param {boolean} Props.isReallySmallScreen - Boolean for if screen is below theme
+ * breakdown of 'sm' for MUI
  * @returns {React.JSX.Element} The RenderCompanyInfoSection component
  */
 const RenderCompanyInfoSection = ({ isReallySmallScreen }) => (

--- a/src/components/Footer/RenderCopyrightAndLinksSection.jsx
+++ b/src/components/Footer/RenderCopyrightAndLinksSection.jsx
@@ -28,14 +28,12 @@ const legalLinks = [
 ];
 
 /**
- * @typedef {import("../../typedefs.js").footerProps} footerProps
- */
-
-/**
  * The RenderCopyrightAndLinksSection component renders information about policy,
  * terms and conditions, and the site to Code for PDX
  *
- * @param {footerProps} Props - The props for footer sub-component
+ * @param {object} Props - The props for footer sub-component
+ * @param {boolean} Props.isReallySmallScreen - Boolean for if screen is below theme
+ * breakdown of 'sm' for MUI
  * @returns {React.JSX.Element} The RenderCopyrightAndLinksSection component
  */
 const RenderCopyrightAndLinksSection = ({ isReallySmallScreen }) => (

--- a/src/components/Form/DocumentSelection.jsx
+++ b/src/components/Form/DocumentSelection.jsx
@@ -15,8 +15,13 @@ import DOC_TYPES from '../../constants/doc_types';
  *
  * @memberof Forms
  * @name DocumentSelection
+ * @param {object} Props - Props for DocumentSelection Component
+ * @param {string} Props.htmlForAndIdProp - String for HTML for and id
+ * @param {(event) => void} Props.handleDocType - Handler function for selecting
+ * doc type
+ * @param {string} Props.docType - The specific doc type selected
+ * @returns {React.JSX.Element} - The Document Selection Component
  */
-
 const DocumentSelection = ({ htmlForAndIdProp, handleDocType, docType }) => (
   <Box>
     <FormControl required fullWidth>

--- a/src/components/Form/FormSection.jsx
+++ b/src/components/Form/FormSection.jsx
@@ -3,11 +3,6 @@ import React from 'react';
 // Material UI Imports
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-// Component Imports
-
-/**
- * @typedef {import('../../typedefs').formSectionProps} formSectionProps
- */
 
 /**
  * FormSection Component - Component that wraps section with title and MUI Box
@@ -15,10 +10,12 @@ import Typography from '@mui/material/Typography';
  *
  * @memberof Forms
  * @name FormSection
- * @param {formSectionProps} formSectionProps - A React prop that consists of
+ * @param {object} Props - A React prop that consists of
  * that consist of title and children (see {@link formSectionProps})
+ * @param {string} Props.title - Title of form section
+ * @param {React.ReactElement} Props.children - JSX Element of the wrapped form
+ * @returns {React.JSX.Element} - The FormSection Component
  */
-
 const FormSection = ({ title, children }) => (
   <Box
     sx={{

--- a/src/components/Home/HomeSection.jsx
+++ b/src/components/Home/HomeSection.jsx
@@ -4,26 +4,23 @@ import React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
-/**
- * @typedef {object} HomeSectionParams
- * @property {string} componentImageSrc - image src
- * @property {string} componentImageAlt - image alt
- * @property {string} title - section title
- * @property {string} description - section description
- * @property {string} button - section button
- * @property {string} href - section button href
- * @property {string} label - section button aria-label
- * @property {boolean} isReallySmallScreen - screen size
- */
+
 /**
  * Represents a home section component
  *
- *  @memberof Home
+ * @memberof Home
  * @name HomeSecton
- * @param {HomeSectionParams} props - the component props
+ * @param {object} Props - the component props
+ * @param {string} Props.componentImageSrc - image src
+ * @param {string} Props.componentImageAlt - image alt
+ * @param {string} Props.title - section title
+ * @param {string} Props.description - section description
+ * @param {string} Props.button - section button
+ * @param {string} Props.href - section button href
+ * @param {string} Props.label - section button aria-label
+ * @param {boolean} Props.isReallySmallScreen - screen size
  * @returns {React.JSX.Element} - the home section component
  */
-
 const HomeSection = ({
   componentImageSrc,
   componentImageAlt,

--- a/src/components/Home/KeyFeatures.jsx
+++ b/src/components/Home/KeyFeatures.jsx
@@ -3,23 +3,19 @@ import React from 'react';
 // Material UI Imports
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-/**
- * @typedef {object} KeyFeaturesParams
- * @property {string} icon - icon
- * @property {string} title - key feature title
- * @property {string} description - key feature description
- * @property {boolean} isReallySmallScreen - screen size
- */
 
 /**
  * Represents key features section component
  *
  * @memberof Home
  * @name KeyFeatures
- * @param {KeyFeaturesParams} props - the props
+ * @param {object} Props - the props
+ * @param {string} Props.icon - icon
+ * @param {string} Props.title - key feature title
+ * @param {string} Props.description - key feature description
+ * @param {boolean} Props.isReallySmallScreen - screen size
  * @returns {React.JSX.Element} the KeyFeatures section component
  */
-
 const KeyFeatures = ({ icon, title, description, isReallySmallScreen }) => (
   <>
     <Box

--- a/src/components/Messages/MessageFolder.jsx
+++ b/src/components/Messages/MessageFolder.jsx
@@ -17,16 +17,19 @@ import { EmptyListNotification, LoadingAnimation } from '../Notification';
  */
 
 /**
- * @typedef {import("../../typedefs.js").messageFolderProps} messageFolderProps
- */
-
-/**
  * MessageFolder Component - The general component used for Message Folders Inbox
  * and Outbox
  *
  * @memberof Messages
  * @name MessageFolder
- * @param {messageFolderProps} Props - Component props for MessageFolder
+ * @param {object} Props - Component props for MessageFolder
+ * @param {string} Props.folderType - The name of the message box, i.e. "inbox"
+ * or "outbox"
+ * @param {() => Promise<void>} Props.handleRefresh - The handle function for
+ * message folder refresh
+ * @param {boolean} Props.loadMessages - Boolean for triggering loading message
+ * @param {messageListObject[]} Props.messageList - A list of messages from
+ * Solid Pod
  * @returns {React.JSX.Element} React component for MessageFolder
  */
 const MessageFolder = ({ folderType, handleRefresh, loadMessages, messageList }) => {

--- a/src/components/Messages/MessagePreview.jsx
+++ b/src/components/Messages/MessagePreview.jsx
@@ -19,7 +19,7 @@ import { MessageContext, SignedInUserContext } from '@contexts';
 import { NewMessageModal } from '../Modals';
 
 /**
- * @typedef {import("../../typedefs.js").messagePreviewProps} messagePreviewProps
+ * @typedef {import("../../typedefs.js").messageListObject} messageListObject
  */
 
 /**
@@ -28,7 +28,9 @@ import { NewMessageModal } from '../Modals';
  *
  * @memberof Messages
  * @name MessagePreview
- * @param {messagePreviewProps} Props - Component props for MessagePreview
+ * @param {object} Props - Component props for MessagePreview
+ * @param {messageListObject} Props.message - The message object
+ * @param {string} Props.folderType - Type of message box
  * @returns {React.JSX.Element} React component for MessagePreview
  */
 const MessagePreview = ({ message, folderType }) => {

--- a/src/components/Modals/AddContactModal.jsx
+++ b/src/components/Modals/AddContactModal.jsx
@@ -11,9 +11,10 @@ import FormControl from '@mui/material/FormControl';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import TextField from '@mui/material/TextField';
+// Custom Hook Imports
+import useNotification from '@hooks/useNotification';
 // Component Imports
 import { FormSection } from '../Form';
-import useNotification from '../../hooks/useNotification';
 
 /**
  * @memberof Contcts

--- a/src/components/Modals/ConfirmationButton.jsx
+++ b/src/components/Modals/ConfirmationButton.jsx
@@ -5,23 +5,15 @@ import Button from '@mui/material/Button';
 import CheckIcon from '@mui/icons-material/Check';
 
 /**
- * confirmationButtonProps is an object that stores the props for the
- * ConfirmationModal component
- *
- * @typedef {object} confirmationButtonProps
- * @property {string} title - text rendered in confirmationButton
- * @property {Function} confirmFunction - method that runs onClick of button
- * @property {boolean} processing - state used to disable button
- * @memberof typedefs
- */
-
-/**
  * ConfirmationButton Component - Component that renders the confirm/affirm/yes
  * button on the ConfirmationModal Component
  *
  * @memberof Modals
  * @name ConfirmationButton
- * @param {confirmationButtonProps} props - Props used for ConfirmationButton
+ * @param {object} Props - Props used for ConfirmationButton
+ * @param {string} Props.title - text rendered in confirmationButton
+ * @param {Function} Props.confirmFunction - method that runs onClick of button
+ * @param {boolean} Props.processing - state used to disable button
  * @returns {React.JSX.Element} - The confirmation button
  */
 const ConfirmationButton = ({ title, confirmFunction, processing }) => (

--- a/src/components/Modals/ConfirmationModal.jsx
+++ b/src/components/Modals/ConfirmationModal.jsx
@@ -13,27 +13,21 @@ import ConfirmationButton from './ConfirmationButton';
 import LogoutButton from './LogoutButton';
 
 /**
- * confirmationModalProps is an object that stores the props for the
- * ConfirmationModal component
- *
- * @typedef {object} confirmationModalProps
- * @property {boolean} showConfirmationModal - toggle showing modal
- * @property {React.Dispatch<React.SetStateAction<boolean>>} setShowConfirmationModal - used to close the modal
- * @property {string} title - text rendered in dialog title & confirmationButton
- * @property {string} text - text rendered in dialog content text
- * @property {Function} confirmFunction - method that runs onClick of button
- * @property {boolean} processing - state used to disable button
- * @property {boolean} [isLogout] - boolean to wrap button with inrupt logout functionality
- * @memberof typedefs
- */
-
-/**
  * ConfirmationModal Component - Component that allows users to cancel or
  * confirm their previously chosen action
  *
  * @memberof Modals
  * @name ConfirmationModal
- * @param {confirmationModalProps} props - Props used for ConfirmationModal
+ * @param {object} Props - Props used for ConfirmationModal
+ * @param {boolean} Props.showConfirmationModal - toggle showing modal
+ * @param {React.Dispatch<React.SetStateAction<boolean>>} Props.setShowConfirmationModal
+ * - used to close the modal
+ * @param {string} Props.title - text rendered in dialog title & confirmationButton
+ * @param {string} Props.text - text rendered in dialog content text
+ * @param {Function} Props.confirmFunction - method that runs onClick of button
+ * @param {boolean} Props.processing - state used to disable button
+ * @param {boolean} [Props.isLogout] - boolean to wrap button with inrupt logout
+ * functionality
  * @returns {React.JSX.Element} - The confirmation modal
  */
 const ConfirmationModal = ({

--- a/src/components/Modals/NewMessageModal.jsx
+++ b/src/components/Modals/NewMessageModal.jsx
@@ -12,12 +12,12 @@ import DialogActions from '@mui/material/DialogActions';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 // Utility Imports
-import { sendMessageTTL, getMessageTTL } from '../../utils';
+import { sendMessageTTL, getMessageTTL } from '@utils';
 // Context Imports
-import { MessageContext, SignedInUserContext } from '../../contexts';
+import { MessageContext, SignedInUserContext } from '@contexts';
 
 /**
- * @typedef {import("../../typedefs.js").newMessageModalProps} newMessageModalProps
+ * @typedef {import("../../typedefs.js").messageListObject} messageListObject
  */
 
 /**
@@ -26,7 +26,12 @@ import { MessageContext, SignedInUserContext } from '../../contexts';
  *
  * @memberof Modals
  * @name NewMessageModal
- * @param {newMessageModalProps} Props - Props used for NewMessageModal
+ * @param {object} Props - Props used for NewMessageModal
+ * @param {boolean} Props.showModal - Boolean for showing message modal
+ * @param {React.Dispatch<React.SetStateAction<boolean>>} Props.setShowModal
+ * - React set function for showModal
+ * @param {messageListObject|string} Props.oldMessage - The previous message
+ * object when using the modal to reply, else uses a string if empty
  * @returns {React.JSX.Element} React component for NewMessageModal
  */
 const NewMessageModal = ({ showModal, setShowModal, oldMessage = '' }) => {

--- a/src/components/Modals/SetAclPermissionsModal.jsx
+++ b/src/components/Modals/SetAclPermissionsModal.jsx
@@ -21,17 +21,19 @@ import { FormSection } from '../Form';
 import useNotification from '../../hooks/useNotification';
 
 /**
- * @typedef {import("../../typedefs.js").setAclPermissionsModalProps} setAclPermissionsModalProps
- */
-
-/**
  * SetPermissionsModal Component - Modal component that generates the form for
  * setting ACL permissions to another user's documents, or document container
  * in their Solid Pod via Solid Session.
  *
  * @memberof Modals
  * @name SetAclPermissionsModal
- * @param {setAclPermissionsModalProps} Props - Props for SetAclPermissionsModal component
+ * @param {object} Props - Props for SetAclPermissionsModal component
+ * @param {boolean} Props.showModal - Boolean for showing setAclPermissionsModal.
+ * @param {React.Dispatch<React.SetStateAction<boolean>>} Props.setShowModal
+ * - React set function for setting showModal state
+ * @param {object} Props.dataset - State object containing information for which
+ * version of modal to display, a relevant file name (if any), and a relevant
+ * document type (if any).
  * @returns {React.JSX.Element} The SetAclPermissionsModal Component
  */
 const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {

--- a/src/components/Modals/UploadButtonGroup.jsx
+++ b/src/components/Modals/UploadButtonGroup.jsx
@@ -6,6 +6,17 @@ import Button from '@mui/material/Button';
 import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
 import SearchIcon from '@mui/icons-material/Search';
 
+/**
+ * The UploadButtonGroup Component is a component that renders the upload document
+ * buttons and renders a capture image button when screen width is below 768px
+ *
+ * @memberof Modals
+ * @name UploadButtonGroup
+ * @param {object} Props - The props for UploadButtonGroup Component
+ * @param {File} Props.file - The selected file
+ * @param {Function} Props.setFile - The set function for handling files
+ * @returns {React.JSX.Element} - The UploadButtonGroup Component
+ */
 const UploadButtonGroup = ({ file, setFile }) => (
   <Box sx={{ display: 'flex', padding: '8px 8px 0', boxSizing: 'border-box' }}>
     <Button

--- a/src/components/Modals/UploadDocumentModal.jsx
+++ b/src/components/Modals/UploadDocumentModal.jsx
@@ -22,16 +22,15 @@ import UploadButtonGroup from './UploadButtonGroup';
 import useNotification from '../../hooks/useNotification';
 
 /**
- * @typedef {import("../../typedefs.js").uploadDocumentModalProps} uploadDocumentModalProps
- */
-
-/**
  * UploadDocumentModal Component - Component that generates the form for uploading
  * a specific document type to a user's Solid Pod via Solid Session
  *
  * @memberof Modals
  * @name UploadDocumentModal
- * @param {uploadDocumentModalProps} Props - Props for UploadDocumentModal component
+ * @param {object} Props - Props for UploadDocumentModal component
+ * @param {boolean} Props.showModal - Boolean for showing upload documents modal
+ * @param {React.Dispatch<React.SetStateAction<boolean>>} Props.setShowModal
+ * - React set function for setting showModal state
  * @returns {React.JSX.Element} The UploadDocumentModal Component
  */
 const UploadDocumentModal = ({ showModal, setShowModal }) => {

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -14,7 +14,7 @@ import NavbarMobile from './NavbarMobile';
 /**
  * NavBar Component - Component that generates proper NavBar section for PASS
  *
- * @memberof GlobalComponents
+ * @memberof NavBar
  * @name NavBar
  * @returns {React.JSX.Element} - The Navbar component
  */

--- a/src/components/NavBar/NavMenu.jsx
+++ b/src/components/NavBar/NavMenu.jsx
@@ -20,10 +20,22 @@ import { DocumentListContext, MessageContext } from '@contexts';
 /**
  * NavMenu Component - Component that generates NavMenu section for PASS
  *
- * @memberof GlobalComponents
+ * @memberof NavBar
  * @name NavMenu
+ * @param {object} Props - The props for NavMenu Component
+ * @param {string} Props.menuId - The menu id
+ * @param {boolean} Props.openMenu - The state for opening menu
+ * @param {React.Dispatch<React.SetStateAction<boolean>>} Props.setOpenMenu
+ * - The set function for openMenu
+ * @param {any} Props.anchorEl - The state for anchorEl
+ * @param {React.Dispatch<any>} Props.setAnchorEl - The set function for anchorEl
+ * @param {React.Dispatch<React.SetStateAction<boolean>>} Props.setShowConfirmation
+ * - The set function for showConfirmationModal
+ * @param {(event) => void} Props.handleNotificationsMenu - Handler function for
+ * Notification Menu
+ * @param {string} Props.profileImg - String for profile image
+ * @returns {React.JSX.Element} - The NavMenu Component
  */
-
 const NavMenu = ({
   menuId,
   openMenu,

--- a/src/components/NavBar/NavbarDesktop.jsx
+++ b/src/components/NavBar/NavbarDesktop.jsx
@@ -23,10 +23,13 @@ import NavMenu from './NavMenu';
  * NavbarDesktop Component - Component that generates Navbar section for PASS
  * when a user is logged in on larger than mobile screen device
  *
- * @memberof GlobalComponents
+ * @memberof NavBar
  * @name NavbarDesktop
+ * @param {object} Props - The props for NavbarDesktop Component
+ * @param {React.Dispatch<React.SetStateAction<boolean>>} Props.setShowConfirmation
+ * - The set function for showConfirmationModal
+ * @returns {React.JSX.Element} - The Desktop version of Navbar Component
  */
-
 const NavbarDesktop = ({ setShowConfirmation }) => {
   const theme = useTheme();
   const { numUnreadMessages } = useContext(MessageContext);

--- a/src/components/NavBar/NavbarLinks.jsx
+++ b/src/components/NavBar/NavbarLinks.jsx
@@ -12,8 +12,8 @@ import Tabs from '@mui/material/Tabs';
  *
  * @memberof NavBar
  * @name NavbarLinks
+ * @returns {React.JSX.Element} - The Navbar Links for Routing
  */
-
 const NavbarLinks = () => {
   // Tabs workaround to match route on login
   let location = useLocation().pathname.split('/')[1];

--- a/src/components/NavBar/NavbarLoggedOut.jsx
+++ b/src/components/NavBar/NavbarLoggedOut.jsx
@@ -12,10 +12,10 @@ import OidcLoginComponent from './OidcLoginComponent';
  * NavbarLoggedOut Component - Component that generates Navbar section for PASS
  * when a user is logged out
  *
- * @memberof GlobalComponents
+ * @memberof NavBar
  * @name NavbarLoggedOut
+ * @returns {React.JSX.Element} - The NavbarLoggedOut Component
  */
-
 const NavbarLoggedOut = () => (
   <Box sx={{ flexGrow: 1 }}>
     <AppBar position="static" color="primary">

--- a/src/components/NavBar/NavbarMobile.jsx
+++ b/src/components/NavBar/NavbarMobile.jsx
@@ -20,10 +20,13 @@ import { SignedInUserContext } from '../../contexts';
  * when a user is logged in on a mobile screen device
  *
  *
- * @memberof GlobalComponents
- * @name NavbarLoggedOut
+ * @memberof NavBar
+ * @name NavbarMobile
+ * @param {object} Props - The props for NavbarMobile Component
+ * @param {React.Dispatch<React.SetStateAction<boolean>>} Props.setShowConfirmation
+ * - The set function for showConfirmationModal
+ * @returns {React.JSX.Element} - The Mobile version of the Navbar Component
  */
-
 const NavbarMobile = ({ setShowConfirmation }) => {
   const theme = useTheme();
 

--- a/src/components/NavBar/OidcLoginComponent.jsx
+++ b/src/components/NavBar/OidcLoginComponent.jsx
@@ -9,6 +9,14 @@ import TextField from '@mui/material/TextField';
 // Constants Imports
 import { ENV } from '../../constants';
 
+/**
+ * The OidcLoginComponent is a component that renders the login button for PASS
+ * and linked to the login of a specific Solid IDP
+ *
+ * @memberof NavBar
+ * @name OidcLoginComponent
+ * @returns {React.JSX.Element} - The OidcLoginComponent Component
+ */
 const OidcLoginComponent = () => {
   const { login } = useSession();
   const defaultOidc = ENV.VITE_SOLID_IDENTITY_PROVIDER || '';

--- a/src/components/Notification/BasicNotification.jsx
+++ b/src/components/Notification/BasicNotification.jsx
@@ -9,7 +9,15 @@ import useNotification from '@hooks/useNotification';
 
 const TransitionUp = (props) => <Slide {...props} direction="up" />;
 
-const BasicNotification = ({ severity, message, id, 'data-testid': dataTestId }) => {
+/**
+ *
+ * @param {object} Props - The props for BasicNotification Component
+ * @param {string} Props.severity - The severity level of the notification
+ * @param {string} Props.message - The notification message
+ * @param {number} Props.id - The unique setTimeout ID
+ * @returns {React.JSX.Element} - The BasicNotification Component
+ */
+const BasicNotification = ({ severity, message, id }) => {
   const [open, setOpen] = useState(false);
   const { remove } = useNotification();
 
@@ -43,7 +51,6 @@ const BasicNotification = ({ severity, message, id, 'data-testid': dataTestId })
       open={open}
       onClose={handleClose}
       id={id}
-      data-testid={dataTestId}
       TransitionComponent={TransitionUp}
       autoHideDuration={6000}
     >

--- a/src/components/Notification/EmptyListNotification.jsx
+++ b/src/components/Notification/EmptyListNotification.jsx
@@ -14,8 +14,10 @@ import Typography from '@mui/material/Typography';
  *
  * @memberof Notification
  * @name EmptyListNotification
+ * @param {object} Props - The Props for EmptyNotification Component
+ * @param {string} Props.type - The type of list notification is used for
+ * @returns {React.JSX.Element} - The EmptyNotification Component
  */
-
 const EmptyListNotification = ({ type }) => {
   const str1 = `No ${type} found.`;
   const str2 = type === 'clients' ? 'Added' : 'Uploaded';

--- a/src/components/Notification/InactivityMessage.jsx
+++ b/src/components/Notification/InactivityMessage.jsx
@@ -15,14 +15,14 @@ import LogoutIcon from '@mui/icons-material/Logout';
 import LogoutButton from '../Modals/LogoutButton';
 
 /**
- * Inactivity Notification Component - Component that displays a popup modal
+ * InactivityMessage Component is a component that displays a popup modal
  * after 25 minutes of inactivity, prompting the user to either logout or
  * continue their session.
  *
  * @memberof Notification
  * @name InactivityMessage
+ * @returns {React.JSX.Element} - The InactivityMessage Component
  */
-
 const InactivityMessage = () => {
   const { session, logout } = useSession();
   const [showPopup, setShowPopup] = useState(false);

--- a/src/components/Notification/LoadingAnimation.jsx
+++ b/src/components/Notification/LoadingAnimation.jsx
@@ -7,17 +7,19 @@ import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 
 /**
- * @typedef {import("../../typedefs.js").loadingAnimationProps} loadingAnimationProps
- */
-
-/**
  * LoadingAnimation Component - Displays a div containing title of what is being
  * loaded and an animated loading progress bar. Must pass loadingItem attribute
- * as a string of the "title" of what is being loaded.
+ * as a string of the "title" of what is being loaded. By default LinearProgress
+ * will be used as the default animation, if used as a provider (i.e. wrapping
+ * children animation components), the wrapped component will be used instead for
+ * animation
  *
  * @memberof Notification
  * @name LoadingAnimation
- * @param {loadingAnimationProps} Props - Component props for LoadingAnimation
+ * @param {object} Props - Component props for LoadingAnimation
+ * @param {string} Props.loadingItem - The name of what you plan on loading
+ * @param {React.JSX.Element} [Props.children] - If used as a provider, wrapped
+ * component will be used as the animation
  * @returns {React.ReactElement} a div of what is currently loading
  */
 const LoadingAnimation = ({ loadingItem, children }) => (

--- a/src/components/Notification/NotificationContainer.jsx
+++ b/src/components/Notification/NotificationContainer.jsx
@@ -1,6 +1,17 @@
 import React from 'react';
 import BasicNotification from './BasicNotification';
 
+/**
+ * The NotificationContainer Component is a component that renders and contains
+ * the MUI snackbar when a notification is being displayed
+ *
+ * @memberof Notification
+ * @name NotificationContainer
+ * @param {object} Props - The Props for NotificationContainer Component
+ * @param {object} Props.notifications - An object containing information about
+ * the notification in question
+ * @returns {React.JSX.Element} - The NotificationContainer Component
+ */
 const NotificationContainer = ({ notifications }) => (
   <div>
     {notifications.map((notification) => (
@@ -9,7 +20,6 @@ const NotificationContainer = ({ notifications }) => (
         id={notification.id}
         message={notification.message}
         severity={notification.severity}
-        data-testid="noteTest"
       />
     ))}
   </div>

--- a/src/components/Profile/ProfileComponent.jsx
+++ b/src/components/Profile/ProfileComponent.jsx
@@ -19,16 +19,14 @@ import ProfileInputField from './ProfileInputField';
 import ProfileEditButtonGroup from './ProfileEditButtonGroup';
 
 /**
- * @typedef {import("../../typedefs.js").profileComponentProps} profileComponentProps
- */
-
-/**
  * The UserProfile Component is a component that renders the user's profile on
  * PASS
  *
  * @memberof Profile
  * @name ProfileComponent
- * @param {profileComponentProps} Props - Props for ClientProfile component
+ * @param {object} Props - Props for ClientProfile component
+ * @param {object} [Props.contactProfile] - Contact object with data from profile
+ * or null if user profile is selected
  * @returns {React.JSX.Element} The UserProfile Component
  */
 const ProfileComponent = ({ contactProfile }) => {

--- a/src/components/Profile/ProfileEditButtonGroup.jsx
+++ b/src/components/Profile/ProfileEditButtonGroup.jsx
@@ -8,16 +8,18 @@ import ClearIcon from '@mui/icons-material/Clear';
 import EditIcon from '@mui/icons-material/Edit';
 
 /**
- * @typedef {import("../../typedefs.js").profileEditButtonGroupProps} profileEditButtonGroupProps
- */
-
-/**
  * The ProfileEditButtonGroup Component is a component that consist of the profile
  * page edit buttons for the ProfileInputField component
  *
  * @memberof Profile
  * @name ProfileEditButtonGroup
- * @param {profileEditButtonGroupProps} Props - Props for Profile Edit buttons
+ * @param {object} Props - Props for Profile Edit buttons
+ * @param {boolean} Props.edit - Boolean state for editing values in the
+ * ProfileInputField component
+ * @param {() => void} Props.handleCancelEdit - Handler function for canceling
+ * edit for ProfileInputField component
+ * @param {() => void} Props.handleEditInput - Handler function for editing the
+ * ProfileInputField component
  * @returns {React.JSX.Element} The ProfileEditButtonGroup
  */
 const ProfileEditButtonGroup = ({ edit, handleCancelEdit, handleEditInput }) => (

--- a/src/components/Profile/ProfileImageField.jsx
+++ b/src/components/Profile/ProfileImageField.jsx
@@ -14,16 +14,16 @@ import { SignedInUserContext } from '@contexts';
 import useNotification from '../../hooks/useNotification';
 
 /**
- * @typedef {import("../../typedefs").profileImageFieldProps} profileImageFieldProps
- */
-
-/**
  * ProfileImageField Component - Component that creates the editable inputs fields
  * for the Profile page
  *
  * @memberof Profile
  * @name ProfileImageField
- * @param {profileImageFieldProps} Props - Props used for NewMessage
+ * @param {object} Props - Props used for NewMessage
+ * @param {() => void} Props.loadProfileData - Handler function for setting local
+ * state for profile card in PASS
+ * @param {object} [Props.contactProfile] - Contact object with data from profile
+ * or null if user profile is selected
  * @returns {React.JSX.Element} React component for NewMessage
  */
 const ProfileImageField = ({ loadProfileData, contactProfile }) => {

--- a/src/components/Profile/ProfileInputField.jsx
+++ b/src/components/Profile/ProfileInputField.jsx
@@ -6,16 +6,17 @@ import Input from '@mui/material/Input';
 import InputLabel from '@mui/material/InputLabel';
 
 /**
- * @typedef {import("../../typedefs").profileInputFieldProps} profileInputFieldProps
- */
-
-/**
  * ProfileInputField Component - Component that creates the editable inputs fields
  * for the Profile page
  *
  * @memberof Profile
  * @name ProfileInputField
- * @param {profileInputFieldProps} Props - Props used for NewMessage
+ * @param {object} Props - Props used for NewMessage
+ * @param {string} Props.inputName - Name of input field
+ * @param {string} Props.inputValue - Value of input field used for updating profile
+ * @param {(value: React.SetStateAction<string|null>) => void} Props.setInputValue
+ * - Set function for inputValue
+ * @param {boolean} Props.edit - Boolean used to toggle edit inputs
  * @returns {React.JSX.Element} React component for NewMessage
  */
 const ProfileInputField = ({ inputName, inputValue, setInputValue, edit }) => (

--- a/src/contexts/MessageContext.jsx
+++ b/src/contexts/MessageContext.jsx
@@ -7,10 +7,6 @@ import { createPASSContainer, getMessageTTL } from '../utils';
 import { SignedInUserContext } from './SignedInUserContext';
 
 /**
- * @typedef {import("../typedefs").messageListObject} messageListObject
- */
-
-/**
  * React Context for messages from Solid Pod
  *
  * @name MessageContext

--- a/src/model-helpers/DocumentList.js
+++ b/src/model-helpers/DocumentList.js
@@ -19,10 +19,6 @@ import { saveSourceUrlToThing } from '../utils';
  */
 
 /**
- * @typedef {import("../typedefs").userListObject} userListObject
- */
-
-/**
  * @typedef {import("@inrupt/solid-client").SolidDataset} SolidDataset
  */
 

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -1,5 +1,3 @@
-const React = require('react');
-
 /**
  * @namespace typedefs
  */
@@ -18,16 +16,6 @@ const React = require('react');
  */
 
 /**
- * A React props object for FormSection component
- *
- * @exports formSectionProps
- * @typedef {object} formSectionProps
- * @property {string} title - Title of form section
- * @property {React.ReactElement} children - JSX Element of the wrapped form
- * @memberof typedefs
- */
-
-/**
  * An object that stores the user's name and their Pod URL
  *
  * @exports userListObject
@@ -35,6 +23,7 @@ const React = require('react');
  * @property {string} person - Full name of user
  * @property {string} givenName - First/given name of user
  * @property {string} familyName - Last/family name of user
+ * @property {URL} podUrl - A user's Solid pod URL
  * @property {URL} webId - A user's webId
  * @memberof typedefs
  */
@@ -54,174 +43,6 @@ const React = require('react');
  * @property {string} recipient - Name of recipient
  * @property {boolean} readStatus - Boolean of read status with true meaning have been
  * read before
- * @memberof typedefs
- */
-
-/**
- * messageFolderProps is an object that stores the props for the MessageFolder
- * component
- *
- * @exports messageFolderProps
- * @typedef {object} messageFolderProps
- * @property {string} folderType - The name of the message box, i.e. "inbox" or
- * "outbox"
- * @property {() => Promise<void>} handleRefresh - The handle function for message
- * folder refresh
- * @property {boolean} loadMessages - Boolean for triggering loading message
- * @property {messageListObject[]} messageList - A list of messages from Solid Pod
- * @memberof typedefs
- */
-
-/**
- * messagePreviewProps is an object that stores the props for the MessageFolder
- * component
- *
- * @exports messagePreviewProps
- * @typedef {object} messagePreviewProps
- * @property {messageListObject} message - The message object
- * @property {string} folderType - Type of message box
- * @memberof typedefs
- */
-
-/**
- * newMessageModalProps is an object that stores the props for the NewMessageModal
- * component
- *
- * @exports newMessageModalProps
- * @typedef {object} newMessageModalProps
- * @property {boolean} showModal - Boolean for showing message modal
- * @property {React.Dispatch<React.SetStateAction<boolean>>} setShowModal
- * - React set function for showModal
- * @property {messageListObject|string} oldMessage - The previous message object
- * when using the modal to reply, else uses a string if empty
- * @memberof typedefs
- */
-
-/**
- * loadingAnimationProps is an object that stores the props for the LoadingAnimation
- * component; By default LinearProgress will be used as the default animation,
- * if used as a provider, i.e. wrapping children animation components, the wrapped
- * component will be used instead for animation
- *
- * @exports loadingAnimationProps
- * @typedef {object} loadingAnimationProps
- * @property {string} loadingItem - The name of what you plan on loading
- * @property {React.JSX.Element} [children] - If used as a provider, wrapped component
- * will be used as the animation
- * @memberof typedefs
- */
-
-/**
- * uploadDocumentModalProps is an object that stores the props for the
- * UploadDocumentModal component
- *
- * @exports uploadDocumentModalProps
- * @typedef {object} uploadDocumentModalProps
- * @property {boolean} showModal - Boolean for showing upload documents modal
- * @property {React.Dispatch<React.SetStateAction<boolean>>} setShowModal
- * - React set function for setting showModal state
- * @memberof typedefs
- */
-
-/**
- * documentTableProps is an object that stores the props for the DocumentTable
- * component.
- *
- * @exports documentTableProps
- * @typedef {object} documentTableProps
- * @property {(modalType: string, docName: string, docType: string) => void} handleAclPermissionsModal
- * - Function for setting up the correct version of the SetAclPermissions Modal, and opening it.
- * @property {(document: object) => void} handleSelectDeleteDoc - method to delete document
- * @memberof typedefs
- */
-
-/**
- * documentTableRowProps is an object that stores the props for the DocumentTableRow
- * component
- *
- * @exports documentTableRowProps
- * @typedef {object} documentTableRowProps
- * @property {File} document - File object containing the document
- * @property {(documentName: string, modalType: string, docType: string) => void} handleAclPermissionsModal
- * - Function for setting up the correct version of the SetAclPermissions Modal, and opening it.
- * @property {(document: object) => void} handleSelectDeleteDoc - method to delete document
- * @memberof typedefs
- */
-
-/**
- * profileComponentProps is an object that stores the props for the
- * ProfileComponent component
- *
- * @exports profileComponentProps
- * @typedef {object} profileComponentProps
- * @property {object} [contactProfile] - Contact object with data from profile
- * or null if user profile is selected
- * @memberof typedefs
- */
-
-/**
- * profileImageFieldProps is an object that stores the props for the ProfileInputField
- * component
- *
- * @exports profileImageFieldProps
- * @typedef {object} profileImageFieldProps
- * @property {() => void} loadProfileData - Handler function for setting local
- * state for profile card in PASS
- * @property {object} [contactProfile] - Contact object with data from profile
- * or null if user profile is selected
- * @memberof typedefs
- */
-
-/**
- * profileInputFieldProps is an object that stores the props for the ProfileInputField
- * component
- *
- * @exports profileInputFieldProps
- * @typedef {object} profileInputFieldProps
- * @property {string} inputName - Name of input field
- * @property {string} inputValue - Value of input field used for updating profile
- * @property {(value: React.SetStateAction<string|null>) => void} setInputValue - Set
- * function for inputValue
- * @property {boolean} edit - Boolean used to toggle edit inputs
- * @memberof typedefs
- */
-
-/**
- * profileEditButtonGroupProps is an object that stores the props for the
- * ProfileInputField component
- *
- * @exports profileEditButtonGroupProps
- * @typedef {object} profileEditButtonGroupProps
- * @property {boolean} edit - Boolean state for editing values in the
- * ProfileInputField component
- * @property {() => void} handleCancelEdit - Handler function for canceling edit for
- * ProfileInputField component
- * @property {() => void} handleEditInput - Handler function for editing the
- * ProfileInputField component
- * @memberof typedefs
- */
-
-/**
- * footerProps is an object that stores the props for the Footer subcomponents
- *
- * @exports footerProps
- * @typedef {object} footerProps
- * @property {boolean} isReallySmallScreen - Boolean for if screen is below theme
- * breakdown of 'sm' for MUI
- * @memberof typedefs
- */
-
-/**
- * setAclPermissionsModalProps is an object that stores the props for the setAclPermissionsModal component.
- *
- * @exports setAclPermissionsModalProps
- * @typedef {object} setAclPermissionsModalProps
- * @property {boolean} showModal - Boolean for showing setAclPermissionsModal.
- * @property {React.Dispatch<React.SetStateAction<boolean>>} setShowModal
- * - React set function for setting showModal state
- * @property {object} dataset
- * - State object containing information for which version of modal to display,
- * a relevant file name (if any), and a relevant document type (if any).
  * @memberof typedefs
  */
 

--- a/src/utils/network/session-core.js
+++ b/src/utils/network/session-core.js
@@ -29,14 +29,6 @@ import { RDF_PREDICATES } from '../../constants';
  */
 
 /**
- * @typedef {import('../../typedefs').fileObjectType} fileObjectType
- */
-
-/**
- * @typedef {import("../../typedefs").userListObject} userListObject
- */
-
-/**
  * @typedef {import("../../typedefs").messageListObject} messageListObject
  */
 

--- a/test/components/Notification/NotificationContainer.test.jsx
+++ b/test/components/Notification/NotificationContainer.test.jsx
@@ -18,9 +18,7 @@ it('renders all the notifications from notification context', () => {
   ];
 
   render(<MockNotificationContainer notifications={notifications} />);
-  const allNotifications = screen.getAllByTestId('noteTest');
 
-  expect(allNotifications.length).toBe(3);
   expect(screen.getByText('this is a success')).not.toBeNull();
   expect(screen.getByText('this is and error test')).not.toBeNull();
   expect(screen.getByText('this is an info test')).not.toBeNull();


### PR DESCRIPTION
## This PR:

Originally planned to fix Issue #471 with this PR, but the idea fell out when the solution failed to work. In the meantime, I've patched most of the JSDoc comments in the codebase in several locations.

This PR moves all component Props out of `typedefs.js` and having it closer to the component. This is done by having them defined directly in the JSDoc comment above the component.

## Future Steps/PRs Needed to Finish This Work (optional):

While this cleans up some of the JSDoc comments, the bug pointed out in Issue #471 remains. At this time, there isn't a ESLint rule in our existing configuration to pick up when a specific typedef is no longer in use in the file like that of a unused variable or module/library import. For that I'll be issuing a new issue for `eslint-plugin-jsdoc` on their GitHub repo about this. Hopefully there's a solution to this or a new ESLint rule could be included for that.

## Issues needing discussion/feedback (optional):
**1.**    Issue #471
