### PR TITLE
Use snackbar to display new message notifications

### DIFF
--- a/src/components/Modals/NewMessageModal.jsx
+++ b/src/components/Modals/NewMessageModal.jsx
@@ -87,7 +87,7 @@ const NewMessageModal = ({ showModal, setShowModal, oldMessage = '' }) => {
         addNotification('success', `Message successfully sent to ${message.recipientPodUrl}`);
       } catch (err) {
         // TODO: Make sure invalid username is the only possible error
-        addNotification('error', `Invalid username: ${message.recipientPodUrl}`);
+        addNotification('error', `Invalid recipient: ${message.recipientPodUrl}`);
       } finally {
         setOriginalMessage('');
         setTimeout(() => {

--- a/src/components/Modals/NewMessageModal.jsx
+++ b/src/components/Modals/NewMessageModal.jsx
@@ -1,7 +1,7 @@
 // React Imports
 import React, { useState, useContext } from 'react';
 // Inrupt Library Imports
-import { useSession } from '@hooks';
+import { useNotification, useSession } from '@hooks';
 // Material UI Imports
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -40,6 +40,7 @@ const NewMessageModal = ({ showModal, setShowModal, oldMessage = '' }) => {
   const { session } = useSession();
   const { outboxList, setOutboxList } = useContext(MessageContext);
   const { podUrl } = useContext(SignedInUserContext);
+  const { addNotification } = useNotification();
   const [originalMessage, setOriginalMessage] = useState(oldMessage.message);
 
   const [message, setMessage] = useState({
@@ -49,9 +50,6 @@ const NewMessageModal = ({ showModal, setShowModal, oldMessage = '' }) => {
     inReplyTo: oldMessage ? oldMessage.messageId : '',
     messageUrl: oldMessage ? oldMessage.messageUrl : ''
   });
-  const [error, setError] = useState('');
-  const [success, setSuccess] = useState('');
-  const [successTimeout, setSuccessTimeout] = useState(false);
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -72,11 +70,11 @@ const NewMessageModal = ({ showModal, setShowModal, oldMessage = '' }) => {
     e.preventDefault();
 
     if (!message.title) {
-      setError('Please enter a title');
+      addNotification('error', 'Please enter a title');
     } else if (!message.recipientPodUrl) {
-      setError('Please enter a recipient Pod URL');
+      addNotification('error', 'Please enter a recipient Pod URL');
     } else if (!message.message) {
-      setError('Please enter a message');
+      addNotification('error', 'Please enter a message');
     } else {
       try {
         await sendMessageTTL(session, message, podUrl);
@@ -86,15 +84,10 @@ const NewMessageModal = ({ showModal, setShowModal, oldMessage = '' }) => {
           title: '',
           message: ''
         });
-        setError('');
-        setSuccess(`Message successfully sent to ${message.recipientPodUrl}`);
-        setSuccessTimeout(true);
-        setTimeout(() => {
-          setSuccessTimeout(false);
-        }, 10000);
+        addNotification('success', `Message successfully sent to ${message.recipientPodUrl}`);
       } catch (err) {
         // TODO: Make sure invalid username is the only possible error
-        setError(err.message);
+        addNotification('error', `Invalid username: ${message.recipientPodUrl}`);
       } finally {
         setOriginalMessage('');
         setTimeout(() => {
@@ -226,8 +219,6 @@ const NewMessageModal = ({ showModal, setShowModal, oldMessage = '' }) => {
               </Button>
             </Box>
           </DialogActions>
-          {error && <div>{error}</div>}
-          {success && successTimeout && <div>{success}</div>}
         </form>
       </Box>
     </Dialog>


### PR DESCRIPTION
## This PR:
Resolves #495
 
**1.**  Removes internal success and error states and associated JSX elements from the NewMessageModal component.
**2.** Removes successTimeout state from NewMessageModal component.
**3.** Send success and error statuses for new messages to the existing notification context, which displays the messages as [MUI snackbars](https://mui.com/material-ui/react-snackbar/). This is consistent with the way notifications are displayed elsewhere throughout the app.

## Screenshots (if applicable):
<img width="397" alt="PASS_New_Message_Error_Screenshot" src="https://github.com/codeforpdx/PASS/assets/55720928/29bed991-35af-425d-adf6-18a959afa956">
<img width="534" alt="PASS_New_Message_Success_Screenshot" src="https://github.com/codeforpdx/PASS/assets/55720928/f58bc9c4-a097-4d2c-88fb-0e8ae3e40c0c">
