### PR TITLE
[New Feature] - Issue 488/breadcrumb navigation

### DIFF
--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -39,13 +39,13 @@ const AppRoutes = () => {
         }
       />
       <Route element={<ProtectedRoute isLoggedIn={session.info.isLoggedIn} />}>
-        <Route path="/contacts" element={<Contacts />} />
-        <Route path="/messages" element={<Messages />} />
-        <Route path="/profile">
-          <Route index element={<Profile />} />
+        <Route path="/contacts">
+          <Route index element={<Contacts />} />
           <Route path=":webId" element={<Profile />} />
         </Route>
-        <Route path="civic_profile" element={<CivicProfile />}>
+        <Route path="/messages" element={<Messages />} />
+        <Route path="/profile" element={<Profile />} />
+        <Route path="/civic-profile" element={<CivicProfile />}>
           {CIVIC_FORM_LIST.map((formProps) => (
             <Route
               {...formProps}

--- a/src/components/CivicProfileForms/FormList.js
+++ b/src/components/CivicProfileForms/FormList.js
@@ -3,10 +3,10 @@ import FinancialInfo from './FinancialInfo';
 import HousingInfo from './HousingInfo';
 
 const CIVIC_FORM_LIST = [
-  { path: 'basic_info', label: 'Basic Information', element: BasicInfo, key: 'basic_info' },
-  { path: 'housing_info', label: 'Housing Information', element: HousingInfo, key: 'housing_info' },
+  { path: 'basic-info', label: 'Basic Information', element: BasicInfo, key: 'basic_info' },
+  { path: 'housing-info', label: 'Housing Information', element: HousingInfo, key: 'housing_info' },
   {
-    path: 'financial_info',
+    path: 'financial-info',
     label: 'Financial Information',
     element: FinancialInfo,
     key: 'financial_info'

--- a/src/components/Contacts/ContactProfileIcon.jsx
+++ b/src/components/Contacts/ContactProfileIcon.jsx
@@ -47,7 +47,7 @@ const ContactProfileIcon = ({ contact }) => {
 
   return (
     <Link
-      to={`/profile/${encodeURIComponent(contact.id)}`}
+      to={`/contacts/${encodeURIComponent(contact.id)}`}
       state={{ contact: contact.value }}
       onClick={() => handleSelectProfile(contact.value)}
       style={{ display: 'flex', alignItems: 'center' }}

--- a/src/components/NavBar/NavMenu.jsx
+++ b/src/components/NavBar/NavMenu.jsx
@@ -93,7 +93,7 @@ const NavMenu = ({
               </MenuItem>
             </Link>
             <Link
-              to="/civic_profile/basic_info"
+              to="/civic-profile/basic-info"
               style={{ textDecoration: 'none', color: theme.palette.primary.main }}
             >
               <MenuItem

--- a/src/components/NavBar/NavbarLinks.jsx
+++ b/src/components/NavBar/NavbarLinks.jsx
@@ -24,7 +24,7 @@ const NavbarLinks = () => {
   // array of current nav links for menus
   const routesArray = [
     { label: 'Contacts', path: '/contacts' },
-    { label: 'Civic Profile', path: '/civic_profile/basic_info' }
+    { label: 'Civic Profile', path: '/civic-profile/basic-info' }
   ];
 
   return (

--- a/src/layouts/Breadcrumbs.jsx
+++ b/src/layouts/Breadcrumbs.jsx
@@ -36,7 +36,7 @@ const Breadcrumbs = () => {
     <MUIBreadcrumbs
       aria-label="breadcrumb"
       separator={<NavigateNextIcon fontSize="small" />}
-      sx={{ margin: '20px 80px', width: '100%' }}
+      sx={{ margin: '20px 80px' }}
     >
       {crumbs.map((crumb, index) =>
         index !== crumbs.length - 1 ? (

--- a/src/layouts/Breadcrumbs.jsx
+++ b/src/layouts/Breadcrumbs.jsx
@@ -36,7 +36,7 @@ const Breadcrumbs = () => {
     <MUIBreadcrumbs
       aria-label="breadcrumb"
       separator={<NavigateNextIcon fontSize="small" />}
-      sx={{ margin: '20px 80px' }}
+      sx={{ margin: { xs: '20px', sm: '20px 80px' } }}
     >
       {crumbs.map((crumb, index) =>
         index !== crumbs.length - 1 ? (

--- a/src/layouts/Breadcrumbs.jsx
+++ b/src/layouts/Breadcrumbs.jsx
@@ -6,6 +6,14 @@ import { Breadcrumbs as MUIBreadcrumbs } from '@mui/material';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import Typography from '@mui/material/Typography';
 
+/**
+ * The Breadcrumbs Component is part of the layout of PASS where it renders the
+ * navigation links to previous sections of the website utilizing MUI's
+ * Breadcrumbs and React Router's useLocation hook
+ *
+ * @name Breadcrumbs
+ * @returns {React.JSX.Element} The Breadcrumbs Component
+ */
 const Breadcrumbs = () => {
   const location = useLocation();
 

--- a/src/layouts/Breadcrumbs.jsx
+++ b/src/layouts/Breadcrumbs.jsx
@@ -1,0 +1,53 @@
+// React Imports
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+// Material UI Imports
+import { Breadcrumbs as MUIBreadcrumbs } from '@mui/material';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+import Typography from '@mui/material/Typography';
+
+const Breadcrumbs = () => {
+  const location = useLocation();
+
+  const crumbs = location?.pathname
+    .split('/')
+    .slice(1)
+    .map((crumb) => {
+      let string = crumb;
+      string = decodeURIComponent(crumb.replace('-', ' '));
+      if (!string.includes('http')) {
+        string = string
+          .split(' ')
+          .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+          .join(' ');
+      }
+      return string;
+    });
+
+  return (
+    <MUIBreadcrumbs
+      aria-label="breadcrumb"
+      separator={<NavigateNextIcon fontSize="small" />}
+      sx={{ margin: '20px 80px', width: '100%' }}
+    >
+      {crumbs.map((crumb, index) =>
+        index !== crumbs.length - 1 ? (
+          <Link
+            to={`/${crumbs
+              .slice(0, index + 1)
+              .join('/')
+              .replaceAll(' ', '-')
+              .toLowerCase()}`}
+            key={crumb}
+          >
+            {crumb}
+          </Link>
+        ) : (
+          <Typography key={crumb}>{crumb}</Typography>
+        )
+      )}
+    </MUIBreadcrumbs>
+  );
+};
+
+export default Breadcrumbs;

--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -19,7 +19,7 @@ const Layout = ({ ariaLabel, children }) => {
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
   const isLoggedInSmallScreen = () =>
-    session.info.isLoggedIn ? '64px 64px 1fr 1fr' : '64px 1fr 1fr';
+    session.info.isLoggedIn ? '64px 64px 1fr 560px' : '64px 1fr 560px';
 
   const isLoggedInDesktop = () =>
     session.info.isLoggedIn ? '64px 64px 1fr 280px' : '64px 1fr 280px';

--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -1,9 +1,13 @@
 // React Imports
 import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
 // Inrupt Library Imports
 import { useSession } from '@hooks';
 // Material UI Imports
 import Box from '@mui/material/Box';
+import Breadcrumbs from '@mui/material/Breadcrumbs';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+import Typography from '@mui/material/Typography';
 // Component Imports
 import { NavBar } from '../components/NavBar';
 import { InactivityMessage } from '../components/Notification';
@@ -14,17 +18,60 @@ import useNotification from '../hooks/useNotification';
 const Layout = ({ ariaLabel, children }) => {
   const { session } = useSession();
   const { state } = useNotification();
+  const location = useLocation();
+
+  const crumbs = location?.pathname
+    .split('/')
+    .slice(1)
+    .map((crumb) => {
+      let string = crumb;
+      string = decodeURIComponent(crumb.replace('-', ' '));
+      if (!string.includes('http')) {
+        string = string
+          .split(' ')
+          .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+          .join(' ');
+      }
+      return string;
+    });
 
   return (
     <Box
       aria-label={ariaLabel}
       sx={{
         display: 'grid',
-        gridTemplateRows: { xs: 'none', sm: '64px 1fr 280px' },
+        gridTemplateRows: {
+          xs: 'none',
+          sm: session.info.isLoggedIn ? '64px 64px 1fr 280px' : '64px 1fr 280px'
+        },
         minHeight: '100vh'
       }}
     >
       <NavBar />
+      {session.info.isLoggedIn && (
+        <Breadcrumbs
+          aria-label="breadcrumb"
+          separator={<NavigateNextIcon fontSize="small" />}
+          sx={{ margin: '20px 80px', width: '100%' }}
+        >
+          {crumbs.map((crumb, index) =>
+            index !== crumbs.length - 1 ? (
+              <Link
+                to={`/${crumbs
+                  .slice(0, index + 1)
+                  .join('/')
+                  .replaceAll(' ', '-')
+                  .toLowerCase()}`}
+                key={crumb}
+              >
+                {crumb}
+              </Link>
+            ) : (
+              <Typography key={crumb}>{crumb}</Typography>
+            )
+          )}
+        </Breadcrumbs>
+      )}
       {children}
       {session.info.isLoggedIn && <InactivityMessage />}
       <Footer />

--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -1,39 +1,18 @@
 // React Imports
 import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
 // Inrupt Library Imports
-import { useSession } from '@hooks';
+import { useSession, useNotification } from '@hooks';
 // Material UI Imports
 import Box from '@mui/material/Box';
-import Breadcrumbs from '@mui/material/Breadcrumbs';
-import NavigateNextIcon from '@mui/icons-material/NavigateNext';
-import Typography from '@mui/material/Typography';
 // Component Imports
 import { NavBar } from '../components/NavBar';
-import { InactivityMessage } from '../components/Notification';
+import { InactivityMessage, NotificationContainer } from '../components/Notification';
 import Footer from '../components/Footer/Footer';
-import NotificationContainer from '../components/Notification/NotificationContainer';
-import useNotification from '../hooks/useNotification';
+import Breadcrumbs from './Breadcrumbs';
 
 const Layout = ({ ariaLabel, children }) => {
   const { session } = useSession();
   const { state } = useNotification();
-  const location = useLocation();
-
-  const crumbs = location?.pathname
-    .split('/')
-    .slice(1)
-    .map((crumb) => {
-      let string = crumb;
-      string = decodeURIComponent(crumb.replace('-', ' '));
-      if (!string.includes('http')) {
-        string = string
-          .split(' ')
-          .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
-          .join(' ');
-      }
-      return string;
-    });
 
   return (
     <Box
@@ -48,30 +27,7 @@ const Layout = ({ ariaLabel, children }) => {
       }}
     >
       <NavBar />
-      {session.info.isLoggedIn && (
-        <Breadcrumbs
-          aria-label="breadcrumb"
-          separator={<NavigateNextIcon fontSize="small" />}
-          sx={{ margin: '20px 80px', width: '100%' }}
-        >
-          {crumbs.map((crumb, index) =>
-            index !== crumbs.length - 1 ? (
-              <Link
-                to={`/${crumbs
-                  .slice(0, index + 1)
-                  .join('/')
-                  .replaceAll(' ', '-')
-                  .toLowerCase()}`}
-                key={crumb}
-              >
-                {crumb}
-              </Link>
-            ) : (
-              <Typography key={crumb}>{crumb}</Typography>
-            )
-          )}
-        </Breadcrumbs>
-      )}
+      {session.info.isLoggedIn && <Breadcrumbs />}
       {children}
       {session.info.isLoggedIn && <InactivityMessage />}
       <Footer />

--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -18,15 +18,18 @@ const Layout = ({ ariaLabel, children }) => {
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
+  const isLoggedInSmallScreen = () =>
+    session.info.isLoggedIn ? '64px 64px 1fr 1fr' : '64px 1fr 1fr';
+
+  const isLoggedInDesktop = () =>
+    session.info.isLoggedIn ? '64px 64px 1fr 280px' : '64px 1fr 280px';
+
   return (
     <Box
       aria-label={ariaLabel}
       sx={{
         display: 'grid',
-        gridTemplateRows: {
-          xs: 'none',
-          sm: session.info.isLoggedIn ? '64px 64px 1fr 280px' : '64px 1fr 280px'
-        },
+        gridTemplateRows: isSmallScreen ? isLoggedInSmallScreen() : isLoggedInDesktop(),
         minHeight: '100vh'
       }}
     >

--- a/src/pages/Contacts.jsx
+++ b/src/pages/Contacts.jsx
@@ -72,7 +72,6 @@ const Contacts = () => {
           size="small"
           startIcon={<AddIcon />}
           onClick={() => setShowAddContactModal(true)}
-          sx={{ marginTop: '3rem' }}
         >
           Add Contact
         </Button>

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -34,7 +34,11 @@ import { fetchProfileInfo } from '../model-helpers';
 const Profile = () => {
   // Route related states
   const location = useLocation();
-  localStorage.setItem('restorePath', '/profile');
+  if (location.pathname.split('/')[1] === 'contacts') {
+    localStorage.setItem('restorePath', '/contacts');
+  } else {
+    localStorage.setItem('restorePath', '/profile');
+  }
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 

--- a/test/layouts/Breadcrumbs.test.jsx
+++ b/test/layouts/Breadcrumbs.test.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import Breadcrumbs from '../../src/layouts/Breadcrumbs';
+
+vi.mock('react-router-dom', async () => {
+  const actual = vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useLocation: vi.fn().mockReturnValue({
+      pathname: '/apple-pie/banana-pie/cherry-pie'
+    }),
+    Link: vi.fn().mockImplementation(({ to, children }) => <a href={to}>{children}</a>)
+  };
+});
+
+it('Renders correct routes and links', () => {
+  const { queryByText } = render(<Breadcrumbs />);
+
+  const aPath = queryByText('Apple Pie');
+  const bPath = queryByText('Banana Pie');
+  const cPath = queryByText('Cherry Pie');
+
+  expect(aPath).not.toBeNull();
+  expect(bPath).not.toBeNull();
+  expect(cPath).not.toBeNull();
+
+  expect(aPath.getAttribute('href')).toBe('/apple-pie');
+  expect(bPath.getAttribute('href')).toBe('/apple-pie/banana-pie');
+  expect(cPath.getAttribute('href')).not.toBe('/apple-pie/banana-pie/cherry-pie');
+  expect(cPath.getAttribute('href')).toBeNull();
+});

--- a/test/layouts/Layout.test.jsx
+++ b/test/layouts/Layout.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import * as hooks from '@hooks';
@@ -8,6 +8,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import { NavBar } from '@components/NavBar';
 import Layout from '../../src/layouts/Layout';
 import theme from '../../src/theme';
+import createMatchMedia from '../helpers/createMatchMedia';
 
 const MockLayout = () => (
   <ThemeProvider theme={theme}>
@@ -19,37 +20,98 @@ const MockLayout = () => (
   </ThemeProvider>
 );
 
-it('Renders breadcrumb', () => {
-  vi.spyOn(hooks, 'useNotification').mockReturnValue({
-    state: { notifications: [] }
-  });
-  const { queryByLabelText } = render(
-    <SessionContext.Provider
-      value={{
-        session: {
-          info: {
-            isLoggedIn: true,
-            webId: 'https://example.com/pod/profile/card#me'
+describe('Desktop view', () => {
+  it('Renders breadcrumb when logged in, layout grid-template-rows as 64px 64px 1fr 280px', () => {
+    vi.spyOn(hooks, 'useNotification').mockReturnValue({
+      state: { notifications: [] }
+    });
+    const { queryByLabelText } = render(
+      <SessionContext.Provider
+        value={{
+          session: {
+            info: {
+              isLoggedIn: true,
+              webId: 'https://example.com/pod/profile/card#me'
+            }
           }
-        }
-      }}
-    >
-      <MockLayout />
-    </SessionContext.Provider>
-  );
+        }}
+      >
+        <MockLayout />
+      </SessionContext.Provider>
+    );
 
-  const breadcrumb = queryByLabelText('breadcrumb');
+    const breadcrumb = queryByLabelText('breadcrumb');
 
-  expect(breadcrumb).not.toBeNull();
+    expect(breadcrumb).not.toBeNull();
+
+    const test = queryByLabelText('test');
+    const cssProperty = getComputedStyle(test);
+
+    expect(cssProperty['grid-template-rows']).toBe('64px 64px 1fr 280px');
+  });
+
+  it('renders no breadcrumbs, layout grid-template-rows as 64px 1fr 280px when logged out', () => {
+    vi.spyOn(hooks, 'useNotification').mockReturnValue({
+      state: { notifications: [] }
+    });
+    const { queryByLabelText } = render(<MockLayout />);
+
+    const breadcrumb = queryByLabelText('breadcrumb');
+
+    expect(breadcrumb).toBeNull();
+
+    const test = queryByLabelText('test');
+    const cssProperty = getComputedStyle(test);
+
+    expect(cssProperty['grid-template-rows']).toBe('64px 1fr 280px');
+  });
 });
 
-it('Does not render breadcrumb when logged in', () => {
-  vi.spyOn(hooks, 'useNotification').mockReturnValue({
-    state: { notifications: [] }
+describe('Mobile view below 600px', () => {
+  it('Renders breadcrumb when logged in, layout grid-template-rows as 64px 64px 1fr 560px', () => {
+    window.matchMedia = createMatchMedia(599);
+    vi.spyOn(hooks, 'useNotification').mockReturnValue({
+      state: { notifications: [] }
+    });
+    const { queryByLabelText } = render(
+      <SessionContext.Provider
+        value={{
+          session: {
+            info: {
+              isLoggedIn: true,
+              webId: 'https://example.com/pod/profile/card#me'
+            }
+          }
+        }}
+      >
+        <MockLayout />
+      </SessionContext.Provider>
+    );
+
+    const breadcrumb = queryByLabelText('breadcrumb');
+
+    expect(breadcrumb).not.toBeNull();
+
+    const test = queryByLabelText('test');
+    const cssProperty = getComputedStyle(test);
+
+    expect(cssProperty['grid-template-rows']).toBe('64px 64px 1fr 560px');
   });
-  const { queryByLabelText } = render(<MockLayout />);
 
-  const breadcrumb = queryByLabelText('breadcrumb');
+  it('renders no breadcrumbs, layout grid-template-rows as 64px 1fr 560px when logged out', () => {
+    window.matchMedia = createMatchMedia(599);
+    vi.spyOn(hooks, 'useNotification').mockReturnValue({
+      state: { notifications: [] }
+    });
+    const { queryByLabelText } = render(<MockLayout />);
 
-  expect(breadcrumb).toBeNull();
+    const breadcrumb = queryByLabelText('breadcrumb');
+
+    expect(breadcrumb).toBeNull();
+
+    const test = queryByLabelText('test');
+    const cssProperty = getComputedStyle(test);
+
+    expect(cssProperty['grid-template-rows']).toBe('64px 1fr 560px');
+  });
 });

--- a/test/layouts/Layout.test.jsx
+++ b/test/layouts/Layout.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import * as hooks from '@hooks';
+import { SessionContext } from '@contexts';
+import { ThemeProvider } from '@mui/material/styles';
+import { NavBar } from '@components/NavBar';
+import Layout from '../../src/layouts/Layout';
+import theme from '../../src/theme';
+
+const MockLayout = () => (
+  <ThemeProvider theme={theme}>
+    <BrowserRouter>
+      <Layout ariaLabel="test">
+        <NavBar />
+      </Layout>
+    </BrowserRouter>
+  </ThemeProvider>
+);
+
+it('Renders breadcrumb', () => {
+  vi.spyOn(hooks, 'useNotification').mockReturnValue({
+    state: { notifications: [] }
+  });
+  const { queryByLabelText } = render(
+    <SessionContext.Provider
+      value={{
+        session: {
+          info: {
+            isLoggedIn: true,
+            webId: 'https://example.com/pod/profile/card#me'
+          }
+        }
+      }}
+    >
+      <MockLayout />
+    </SessionContext.Provider>
+  );
+
+  const breadcrumb = queryByLabelText('breadcrumb');
+
+  expect(breadcrumb).not.toBeNull();
+});
+
+it('Does not render breadcrumb when logged in', () => {
+  vi.spyOn(hooks, 'useNotification').mockReturnValue({
+    state: { notifications: [] }
+  });
+  const { queryByLabelText } = render(<MockLayout />);
+
+  const breadcrumb = queryByLabelText('breadcrumb');
+
+  expect(breadcrumb).toBeNull();
+});


### PR DESCRIPTION
## This PR:

Resolves Issue #488. This PR also includes minor updates to routes and routing names for easier route management for the new Breadcrumbs implementation. The new Breadcrumbs component will be placed under `src/Layouts` as `Breadcrumbs.jsx` and imported as part of `Layout.jsx`. It renders only when logged into PASS (See clip below)

For the route which the person navigated to will be turned into a text element rather than a link, but all parent routes remains a link.

Other changes include routing changes from `/profile/:webId` to `/contacts/:webId`. While it's intuitive to place profiles under "/profiles" and any potential children routes, it makes more sense to have it placed under "/contacts/:webId" instead since that's where people are accessing their profile from. The existing "/profile" route, however, remains the same for the user's own profile page.

## Screenshots (if applicable):

https://github.com/codeforpdx/PASS/assets/14917816/d689b55e-f364-472c-a960-3527d96e0b31
