### PR TITLE
Use `getByRole` where appropriate and improve some test magic numbers

### DIFF
--- a/src/components/NavBar/NavbarDesktop.jsx
+++ b/src/components/NavBar/NavbarDesktop.jsx
@@ -69,7 +69,7 @@ const NavbarDesktop = ({ setShowConfirmation }) => {
           </Link>
           <NavbarLinks aria-label="navigation links" />
           <Box sx={{ flexGrow: 1 }} />
-          <Box aria-label="menu" sx={{ display: { xs: 'none', md: 'flex' } }}>
+          <Box sx={{ display: { xs: 'none', md: 'flex' } }} data-testid="navbar-menu">
             {/* messages icon */}
             <IconButton
               component={NavLink}

--- a/src/components/NavBar/NavbarDesktop.jsx
+++ b/src/components/NavBar/NavbarDesktop.jsx
@@ -69,7 +69,7 @@ const NavbarDesktop = ({ setShowConfirmation }) => {
           </Link>
           <NavbarLinks aria-label="navigation links" />
           <Box sx={{ flexGrow: 1 }} />
-          <Box sx={{ display: { xs: 'none', md: 'flex' } }} data-testid="navbar-menu">
+          <Box sx={{ display: { xs: 'none', md: 'flex' } }} role="group">
             {/* messages icon */}
             <IconButton
               component={NavLink}

--- a/test/components/Contacts/ContactsListTable.test.jsx
+++ b/test/components/Contacts/ContactsListTable.test.jsx
@@ -68,5 +68,5 @@ it('sorts clients by familyName', () => {
   const client1 = getByRole('cell', { name: 'Zeigler' });
   const client2 = getByRole('cell', { name: 'Builder' });
 
-  expect(client1.compareDocumentPosition(client2)).toBe(2);
+  expect(client1.compareDocumentPosition(client2)).toBe(Node.DOCUMENT_POSITION_PRECEDING);
 });

--- a/test/components/NavBar/NavBar.test.jsx
+++ b/test/components/NavBar/NavBar.test.jsx
@@ -30,7 +30,7 @@ describe('resize tests', () => {
   it('renders NavbarDesktop when user is logged in on larger screen device', () => {
     window.matchMedia = createMatchMedia(1200);
 
-    const { getByTestId } = render(
+    const { getByRole } = render(
       <SessionContext.Provider value={{ session: { info: { isLoggedIn: true } } }}>
         <BrowserRouter>
           <NavBar />
@@ -38,7 +38,7 @@ describe('resize tests', () => {
       </SessionContext.Provider>
     );
 
-    const iconMenu = getByTestId('navbar-menu');
+    const iconMenu = getByRole('group');
 
     expect(iconMenu).not.toBeNull();
   });

--- a/test/components/NavBar/NavBar.test.jsx
+++ b/test/components/NavBar/NavBar.test.jsx
@@ -30,7 +30,7 @@ describe('resize tests', () => {
   it('renders NavbarDesktop when user is logged in on larger screen device', () => {
     window.matchMedia = createMatchMedia(1200);
 
-    const { getByLabelText } = render(
+    const { getByTestId } = render(
       <SessionContext.Provider value={{ session: { info: { isLoggedIn: true } } }}>
         <BrowserRouter>
           <NavBar />
@@ -38,7 +38,7 @@ describe('resize tests', () => {
       </SessionContext.Provider>
     );
 
-    const iconMenu = getByLabelText('menu');
+    const iconMenu = getByTestId('navbar-menu');
 
     expect(iconMenu).not.toBeNull();
   });
@@ -46,7 +46,7 @@ describe('resize tests', () => {
   it('renders NavbarMobile when user is logged in on smaller screen device', () => {
     window.matchMedia = createMatchMedia(500);
 
-    const { getByLabelText } = render(
+    const { getByRole } = render(
       <SessionContext.Provider value={{ session: { info: { isLoggedIn: true } } }}>
         <BrowserRouter>
           <NavBar />
@@ -54,7 +54,7 @@ describe('resize tests', () => {
       </SessionContext.Provider>
     );
 
-    const hamburgerMenu = getByLabelText('mobile menu');
+    const hamburgerMenu = getByRole('button', { name: /mobile/ });
 
     expect(hamburgerMenu).not.toBeNull();
   });

--- a/test/components/NavBar/NavbarDesktop.test.jsx
+++ b/test/components/NavBar/NavbarDesktop.test.jsx
@@ -5,17 +5,17 @@ import { expect, it } from 'vitest';
 import NavbarDesktop from '../../../src/components/NavBar/NavbarDesktop';
 
 it('renders icon menu when on screen larger than mobile', () => {
-  const { queryByLabelText, queryByRole } = render(
+  const { queryByRole, queryByTestId } = render(
     <BrowserRouter>
       <NavbarDesktop />
     </BrowserRouter>
   );
 
   const logo = queryByRole('img', { name: /logo$/ });
-  const navLinks = queryByLabelText('navigation tabs');
-  const iconMenu = queryByLabelText('menu');
+  const navLinks = queryByRole('tablist', { name: 'navigation tabs' });
+  const navbarMenu = queryByTestId('navbar-menu');
 
   expect(logo).not.toBeNull();
   expect(navLinks).not.toBeNull();
-  expect(iconMenu).not.toBeNull();
+  expect(navbarMenu).not.toBeNull();
 });

--- a/test/components/NavBar/NavbarDesktop.test.jsx
+++ b/test/components/NavBar/NavbarDesktop.test.jsx
@@ -5,7 +5,7 @@ import { expect, it } from 'vitest';
 import NavbarDesktop from '../../../src/components/NavBar/NavbarDesktop';
 
 it('renders icon menu when on screen larger than mobile', () => {
-  const { queryByRole, queryByTestId } = render(
+  const { queryByRole } = render(
     <BrowserRouter>
       <NavbarDesktop />
     </BrowserRouter>
@@ -13,7 +13,7 @@ it('renders icon menu when on screen larger than mobile', () => {
 
   const logo = queryByRole('img', { name: /logo$/ });
   const navLinks = queryByRole('tablist', { name: 'navigation tabs' });
-  const navbarMenu = queryByTestId('navbar-menu');
+  const navbarMenu = queryByRole('group');
 
   expect(logo).not.toBeNull();
   expect(navLinks).not.toBeNull();

--- a/test/components/NavBar/NavbarMobile.test.jsx
+++ b/test/components/NavBar/NavbarMobile.test.jsx
@@ -6,15 +6,15 @@ import NavbarMobile from '../../../src/components/NavBar/NavbarMobile';
 import createMatchMedia from '../../helpers/createMatchMedia';
 
 it('renders hamburger menu when on mobile', () => {
-  const { queryByLabelText, queryByRole } = render(
+  const { queryByRole } = render(
     <BrowserRouter>
       <NavbarMobile />
     </BrowserRouter>
   );
 
   const logo = queryByRole('img', { name: /logo$/ });
-  const navLinks = queryByLabelText('navigation tabs');
-  const hamburgerMenu = queryByLabelText('mobile menu');
+  const navLinks = queryByRole('tablist');
+  const hamburgerMenu = queryByRole('button', { name: /mobile/ });
 
   expect(logo).not.toBeNull();
   expect(navLinks).not.toBeNull();

--- a/test/components/Notification/BasicNotification.test.jsx
+++ b/test/components/Notification/BasicNotification.test.jsx
@@ -46,13 +46,14 @@ it('calls remove after 8 seconds', () => {
 
 it('calls remove with the correct id', () => {
   const remove = vi.fn();
+  const id = '123456';
 
   render(
     <NotificationContext.Provider value={{ remove }}>
       <BasicNotification
         severity="success"
         message="my test message"
-        id={123456}
+        id={id}
         dataTestId="test-id"
       />
     </NotificationContext.Provider>
@@ -62,5 +63,5 @@ it('calls remove with the correct id', () => {
     vi.advanceTimersByTime(8000);
   });
 
-  expect(remove).toHaveBeenCalledWith(123456);
+  expect(remove).toHaveBeenCalledWith(id);
 });

--- a/test/components/Notification/BasicNotification.test.jsx
+++ b/test/components/Notification/BasicNotification.test.jsx
@@ -6,16 +6,12 @@ import BasicNotification from '../../../src/components/Notification/BasicNotific
 import { NotificationContext } from '../../../src/contexts/NotificationContext';
 
 it('renders correctly', () => {
+  const message = 'my test message';
   render(
-    <BasicNotification
-      severity="success"
-      message="my test message"
-      id={123456}
-      dataTestId="test-id"
-    />
+    <BasicNotification severity="success" message={message} id={123456} dataTestId="test-id" />
   );
 
-  expect(screen.getByText('my test message')).not.toBeNull();
+  expect(screen.getByRole('alert').textContent).toBe(message);
 });
 
 beforeEach(() => {

--- a/test/components/Notification/BasicNotification.test.jsx
+++ b/test/components/Notification/BasicNotification.test.jsx
@@ -11,7 +11,8 @@ it('renders correctly', () => {
     <BasicNotification severity="success" message={message} id={123456} dataTestId="test-id" />
   );
 
-  expect(screen.getByRole('alert').textContent).toBe(message);
+  const notification = screen.getByRole('alert');
+  expect(notification.textContent).toBe(message);
 });
 
 beforeEach(() => {

--- a/test/components/Signup/PodRegistrationForm.test.jsx
+++ b/test/components/Signup/PodRegistrationForm.test.jsx
@@ -17,7 +17,7 @@ describe('PodRegistrationForm', () => {
       </Router>
     );
 
-    const textField = screen.getByLabelText('Email');
+    const textField = screen.getByRole('textbox', { name: 'Email' });
     const inputElementPassword = screen.getByLabelText('Password');
     const inputElementConfirmPassord = screen.getByLabelText('Confirm Password');
 

--- a/test/pages/Contacts.test.jsx
+++ b/test/pages/Contacts.test.jsx
@@ -21,15 +21,16 @@ describe('Contacts Page', () => {
 
   it('displays Loading message while loading', () => {
     useContactsList.mockReturnValue({ isLoading: true });
-    const { getByText } = render(<Contacts />);
-    const button = getByText('Loading Contacts...');
-    expect(button).not.toBeNull();
+    const { getByRole } = render(<Contacts />);
+    const heading = getByRole('heading');
+    expect(heading.textContent).toBe('Loading Contacts...');
   });
 
   it('displays Errors when fetch errors', () => {
-    useContactsList.mockReturnValue({ isError: true, error: { message: 'error' } });
+    const errorMessage = 'error';
+    useContactsList.mockReturnValue({ isError: true, error: { message: errorMessage } });
     const { getByText } = render(<Contacts />);
-    const text = getByText('Error loading contacts list: error');
+    const text = getByText(`Error loading contacts list: ${errorMessage}`);
     expect(text).not.toBeNull();
   });
 

--- a/test/pages/Signup.test.jsx
+++ b/test/pages/Signup.test.jsx
@@ -50,7 +50,7 @@ describe('Signup Page', () => {
       }
     };
     const { getByRole } = render(<MockSignupContexts session={sessionObj} />);
-    expect(getByRole('heading')).not.toBeNull();
+    expect(getByRole('heading', { name: 'Register For PASS' })).not.toBeNull();
   });
   it('lets users request to create pods', async () => {
     const session = {

--- a/test/pages/Signup.test.jsx
+++ b/test/pages/Signup.test.jsx
@@ -49,8 +49,8 @@ describe('Signup Page', () => {
         }
       }
     };
-    const { getByText } = render(<MockSignupContexts session={sessionObj} />);
-    expect(getByText('Register for PASS', { exact: false })).not.toBeNull();
+    const { getByRole } = render(<MockSignupContexts session={sessionObj} />);
+    expect(getByRole('heading')).not.toBeNull();
   });
   it('lets users request to create pods', async () => {
     const session = {


### PR DESCRIPTION
Resolves #449 
 
**1.** Uses `getByRole` where appropriate and updates components with appropriate roles where missing.
**2.** Removed some "magic" variables in tests.