### PR TITLE
Cleanup Constants Directory

### DIFF
--- a/src/constants/doc_types.js
+++ b/src/constants/doc_types.js
@@ -5,16 +5,16 @@
  * @memberof utils
  * @name docTypes
  * @type {Array<string>}
- * @property {string} BankStatement - Bank Statemet
- * @property {string} Passport - Passport
- * @property {string} DriversLicense - Drivers License
- * @property {string} Other - Anything Else
+ * @property {string} bankStatement - Bank Statemet
+ * @property {string} passport - Passport
+ * @property {string} driversLicense - Drivers License
+ * @property {string} other - Anything Else
  */
 const DOC_TYPES = {
-  BankStatement: 'Bank Statement',
-  Passport: 'Passport',
-  DriversLicense: "Driver's License",
-  Other: 'Other'
+  bankStatement: 'Bank Statement',
+  passport: 'Passport',
+  driversLicense: "Driver's License",
+  other: 'Other'
 };
 
 export default DOC_TYPES;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,5 +1,4 @@
 import RDF_PREDICATES from './rdf_predicates';
-import INTERACTION_TYPES from './interaction_types';
 import ENV from './environment';
 
-export { RDF_PREDICATES, INTERACTION_TYPES, ENV };
+export { RDF_PREDICATES, ENV };

--- a/src/constants/interaction_types.js
+++ b/src/constants/interaction_types.js
@@ -1,6 +1,0 @@
-const INTERACTION_TYPES = {
-  SELF: 'self',
-  CROSS: 'cross'
-};
-
-export default INTERACTION_TYPES;


### PR DESCRIPTION
## This PR:

Cleans up our constants directory with the removal of `src/constants/type_interactions.js`, which is no longer in use, and updated the casing in `doc_types.js` to camelCasing to make things consistent with other files in constants like `rdf_predicates.js`.
