### PR TITLE
Make footer headings the appropriate heading level

### DIFF
--- a/src/components/Footer/RenderCallToActionSection.jsx
+++ b/src/components/Footer/RenderCallToActionSection.jsx
@@ -16,7 +16,7 @@ import Typography from '@mui/material/Typography';
  */
 const RenderCallToActionSection = ({ isReallySmallScreen }) => (
   <Stack width={isReallySmallScreen ? 1 : 3 / 5} alignItems="center" justifyContent="center">
-    <Typography variant="h5" color="tertiary.main">
+    <Typography variant="h5" component="h2" color="tertiary.main">
       Want to partner with PASS?
     </Typography>
     <Typography variant="body1" color="#fff" sx={{ width: 3 / 4 }}>

--- a/src/components/Footer/RenderCompanyInfoSection.jsx
+++ b/src/components/Footer/RenderCompanyInfoSection.jsx
@@ -60,7 +60,7 @@ const socialLinks = [
 const RenderCompanyInfoSection = ({ isReallySmallScreen }) => (
   <Stack width={isReallySmallScreen ? 1 : 1 / 5} justifyContent="space-between" alignItems="center">
     <Box>
-      <Typography color="tertiary.main" variant="h5" mb={1}>
+      <Typography color="tertiary.main" variant="h5" component="h2" mb={1}>
         Follow Us
       </Typography>
       <Stack direction="row" spacing={isReallySmallScreen ? 3 : 2} alignItems="center">

--- a/test/components/Footer/Footer.test.jsx
+++ b/test/components/Footer/Footer.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { render, cleanup, screen } from '@testing-library/react';
+import { expect, it, afterEach, describe } from 'vitest';
+import { SessionContext } from '@contexts';
+import { ThemeProvider } from '@mui/material/styles';
+import theme from '../../../src/theme';
+import Footer from '../../../src/components/Footer/Footer';
+
+// clear created dom after each test, to start fresh for next
+afterEach(() => {
+  cleanup();
+});
+
+describe('Footer', () => {
+  it('renders `h2` elements for headings', () => {
+    render(
+      <SessionContext.Provider value={{ session: { info: { isLoggedIn: false } } }}>
+        <ThemeProvider theme={theme}>
+          <BrowserRouter>
+            <Footer />
+          </BrowserRouter>
+        </ThemeProvider>
+      </SessionContext.Provider>
+    );
+
+    const headings = screen.getAllByRole('heading', { level: 2 });
+
+    expect(headings.length).toBe(2);
+  });
+});


### PR DESCRIPTION
Was mentioned in #456, but was small enough I thought could make it a small PR.

Since the footer is separate from the main content, and a page should only have one `h1`, this means that a footer should have their headings start at `h2`.