### PR TITLE
Make `h1` hold full title while maintaining formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@mui/material": "^5.12.2",
         "@mui/styled-engine-sc": "^5.12.0",
         "@mui/system": "^5.12.1",
+        "@mui/utils": "^5.14.18",
         "@mui/x-data-grid": "^6.16.2",
         "@mui/x-date-pickers": "^6.5.0",
         "@tanstack/react-query": "^4.32.0",
@@ -4253,12 +4254,12 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.14.16",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.16.tgz",
-      "integrity": "sha512-3xV31GposHkwRbQzwJJuooWpK2ybWdEdeUPtRjv/6vjomyi97F3+68l+QVj9tPTvmfSbr2sx5c/NuvDulrdRmA==",
+      "version": "5.14.18",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.18.tgz",
+      "integrity": "sha512-HZDRsJtEZ7WMSnrHV9uwScGze4wM/Y+u6pDVo+grUjt5yXzn+wI8QX/JwTHh9YSw/WpnUL80mJJjgCnWj2VrzQ==",
       "dependencies": {
         "@babel/runtime": "^7.23.2",
-        "@types/prop-types": "^15.7.9",
+        "@types/prop-types": "^15.7.10",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
       },
@@ -5275,9 +5276,9 @@
       "integrity": "sha512-3YmXzzPAdOTVljVMkTMBdBEvlOLg2cDQaDhnnhT3nT9uDbnJzjWhKlzb+desT12Y7tGqaN6d+AbozcKzyL36Ng=="
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.9",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.9.tgz",
-      "integrity": "sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g=="
+      "version": "15.7.10",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.10.tgz",
+      "integrity": "sha512-mxSnDQxPqsZxmeShFH+uwQ4kO4gcJcGahjjMFeLbKE95IAZiiZyiEepGZjtXJ7hN/yfu0bu9xN2ajcU0JcxX6A=="
     },
     "node_modules/@types/proper-lockfile": {
       "version": "4.1.3",
@@ -19602,12 +19603,12 @@
       "requires": {}
     },
     "@mui/utils": {
-      "version": "5.14.16",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.16.tgz",
-      "integrity": "sha512-3xV31GposHkwRbQzwJJuooWpK2ybWdEdeUPtRjv/6vjomyi97F3+68l+QVj9tPTvmfSbr2sx5c/NuvDulrdRmA==",
+      "version": "5.14.18",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.18.tgz",
+      "integrity": "sha512-HZDRsJtEZ7WMSnrHV9uwScGze4wM/Y+u6pDVo+grUjt5yXzn+wI8QX/JwTHh9YSw/WpnUL80mJJjgCnWj2VrzQ==",
       "requires": {
         "@babel/runtime": "^7.23.2",
-        "@types/prop-types": "^15.7.9",
+        "@types/prop-types": "^15.7.10",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
       }
@@ -20427,9 +20428,9 @@
       "integrity": "sha512-3YmXzzPAdOTVljVMkTMBdBEvlOLg2cDQaDhnnhT3nT9uDbnJzjWhKlzb+desT12Y7tGqaN6d+AbozcKzyL36Ng=="
     },
     "@types/prop-types": {
-      "version": "15.7.9",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.9.tgz",
-      "integrity": "sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g=="
+      "version": "15.7.10",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.10.tgz",
+      "integrity": "sha512-mxSnDQxPqsZxmeShFH+uwQ4kO4gcJcGahjjMFeLbKE95IAZiiZyiEepGZjtXJ7hN/yfu0bu9xN2ajcU0JcxX6A=="
     },
     "@types/proper-lockfile": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@mui/material": "^5.12.2",
     "@mui/styled-engine-sc": "^5.12.0",
     "@mui/system": "^5.12.1",
+    "@mui/utils": "^5.14.18",
     "@mui/x-data-grid": "^6.16.2",
     "@mui/x-date-pickers": "^6.5.0",
     "@tanstack/react-query": "^4.32.0",

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -56,7 +56,7 @@ const Home = () => {
     </Typography>
   ) : (
     <Typography component="h1" color="primary" data-testid="testHomeH1">
-      <Stack direction="column" justifyContent="center" alignItems="center" spacing={4}>
+      <Stack justifyContent="center" alignItems="center" spacing={4} mb={18}>
         <Stack
           component="span"
           direction="row"
@@ -70,7 +70,7 @@ const Home = () => {
             {punctuation}
           </Typography>
         </Stack>
-        <Typography variant="h3" component="span" fontWeight="600" mb={18}>
+        <Typography variant="h3" component="span" fontWeight="600">
           {subheading}
         </Typography>
       </Stack>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -12,6 +12,7 @@ import SupportIcon from '@mui/icons-material/Support';
 import Typography from '@mui/material/Typography';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
+import { visuallyHidden } from '@mui/utils';
 // Components Import
 import { HomeSection, KeyFeatures } from '@components/Home';
 
@@ -31,32 +32,49 @@ const Home = () => {
 
   const handleClick = () => aboutRef.current.scrollIntoView({ behavior: 'smooth' });
 
+  // Logo section elements
+  const heading = 'PASS';
+  const punctuation = (
+    <Box component="span" sx={visuallyHidden}>
+      :
+    </Box>
+  );
+  const subheading = 'Personal Access System for Services';
+
   const logoSection = isReallySmallScreen ? (
-    <Stack justifyContent="center" alignItems="center" spacing={2} mb={2}>
-      <Typography
-        variant="h1"
-        fontWeight="500"
-        fontSize="72px"
-        color="primary"
-        data-testid="testHomeH1"
-      >
-        PASS
-      </Typography>
-      <Box component="img" src="/assets/PASSLogolightmode.png" alt="PASS logo" width="50%" />
-    </Stack>
+    <Typography component="h1" color="primary" data-testid="testHomeH1">
+      <Stack component="span" justifyContent="center" alignItems="center" spacing={2} mb={2}>
+        <Typography variant="h1" component="span" fontWeight="500" fontSize="72px">
+          {heading}
+          {punctuation}
+        </Typography>
+        <Box component="img" src="/assets/PASSLogolightmode.png" alt="" width="50%" />
+        <Typography variant="h4" component="span" fontWeight="600" mb={8}>
+          {subheading}
+        </Typography>
+      </Stack>
+    </Typography>
   ) : (
-    <Stack direction="row" justifyContent="center" alignItems="center" spacing={4}>
-      <Box component="img" src="/assets/PASSLogolightmode.png" alt="PASS logo" width="150px" />
-      <Typography
-        variant="h1"
-        fontWeight="500"
-        fontSize="144px"
-        color="primary"
-        data-testid="testHomeH1"
-      >
-        PASS
-      </Typography>
-    </Stack>
+    <Typography component="h1" color="primary" data-testid="testHomeH1">
+      <Stack direction="column" justifyContent="center" alignItems="center" spacing={4}>
+        <Stack
+          component="span"
+          direction="row"
+          justifyContent="center"
+          alignItems="center"
+          spacing={4}
+        >
+          <Box component="img" src="/assets/PASSLogolightmode.png" alt="" width="150px" />
+          <Typography variant="h1" component="span" fontWeight="500" fontSize="144px">
+            {heading}
+            {punctuation}
+          </Typography>
+        </Stack>
+        <Typography variant="h3" component="span" fontWeight="600" mb={18}>
+          {subheading}
+        </Typography>
+      </Stack>
+    </Typography>
   );
 
   return (
@@ -81,15 +99,6 @@ const Home = () => {
               alignItems="center"
             >
               {logoSection}
-              <Typography
-                variant={isReallySmallScreen ? 'h4' : 'h3'}
-                component="p"
-                fontWeight="600"
-                mb={isReallySmallScreen ? 8 : 18}
-                color="primary"
-              >
-                Personal Access System for Services
-              </Typography>
               <Typography color="secondary.main" sx={{ fontSize: '24px' }}>
                 Learn More
               </Typography>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -46,9 +46,15 @@ const Home = () => {
   const subheading = 'Personal Access System for Services';
 
   const logoSection = isReallySmallScreen ? (
-    <Typography component="h1" color="primary" data-testid="testHomeH1">
+    <Typography component="h1" color="primary">
       <Stack component="span" justifyContent="center" alignItems="center" spacing={2} mb={2}>
-        <Typography variant="h1" component="span" fontWeight="500" fontSize="72px">
+        <Typography
+          variant="h1"
+          component="span"
+          fontWeight="500"
+          fontSize="72px"
+          data-testid="testHomeH1"
+        >
           {heading}
         </Typography>
         <Box component="img" src="/assets/PASSLogolightmode.png" alt="" width="50%" />
@@ -58,7 +64,7 @@ const Home = () => {
       </Stack>
     </Typography>
   ) : (
-    <Typography component="h1" color="primary" data-testid="testHomeH1">
+    <Typography component="h1" color="primary">
       <Stack justifyContent="center" alignItems="center" spacing={4} mb={18}>
         <Stack
           component="span"
@@ -68,7 +74,13 @@ const Home = () => {
           spacing={4}
         >
           <Box component="img" src="/assets/PASSLogolightmode.png" alt="" width="150px" />
-          <Typography variant="h1" component="span" fontWeight="500" fontSize="144px">
+          <Typography
+            variant="h1"
+            component="span"
+            fontWeight="500"
+            fontSize="144px"
+            data-testid="testHomeH1"
+          >
             {heading}
           </Typography>
         </Stack>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -33,11 +33,15 @@ const Home = () => {
   const handleClick = () => aboutRef.current.scrollIntoView({ behavior: 'smooth' });
 
   // Logo section elements
-  const heading = 'PASS';
-  const punctuation = (
-    <Box component="span" sx={visuallyHidden}>
-      :
-    </Box>
+  const heading = (
+    <>
+      PASS
+      {/* This is added for better screen reader experience by adding a pause
+          between the acronym and the expanded acronym. */}
+      <Box component="span" sx={visuallyHidden}>
+        :
+      </Box>
+    </>
   );
   const subheading = 'Personal Access System for Services';
 
@@ -46,7 +50,6 @@ const Home = () => {
       <Stack component="span" justifyContent="center" alignItems="center" spacing={2} mb={2}>
         <Typography variant="h1" component="span" fontWeight="500" fontSize="72px">
           {heading}
-          {punctuation}
         </Typography>
         <Box component="img" src="/assets/PASSLogolightmode.png" alt="" width="50%" />
         <Typography variant="h4" component="span" fontWeight="600" mb={8}>
@@ -67,7 +70,6 @@ const Home = () => {
           <Box component="img" src="/assets/PASSLogolightmode.png" alt="" width="150px" />
           <Typography variant="h1" component="span" fontWeight="500" fontSize="144px">
             {heading}
-            {punctuation}
           </Typography>
         </Stack>
         <Typography variant="h3" component="span" fontWeight="600">


### PR DESCRIPTION
Part of [PR 516](https://github.com/codeforpdx/PASS/pull/516).

This puts the whole heading and subheading within the `h1`, maintaining formatting and visuals.

<img width="649" alt="Screen Shot 2023-11-16 at 8 45 23 PM" src="https://github.com/codeforpdx/PASS/assets/65684361/0686b392-1804-4cf2-8935-be5bf21fe483">

<img width="1392" alt="Screen Shot 2023-11-16 at 8 45 19 PM" src="https://github.com/codeforpdx/PASS/assets/65684361/3347897f-adab-4827-9444-5f0337eab674">
