### PR TITLE
Add max height for autocomplete and signInModal components

### DIFF
--- a/src/components/Modals/SignInModal.jsx
+++ b/src/components/Modals/SignInModal.jsx
@@ -26,6 +26,7 @@ const SignInModal = ({ showSignInModal, setShowSignInModal }) => (
     aria-labelledby="dialog-title"
     aria-describedby="dialog-description"
     onClose={() => setShowSignInModal(false)}
+    PaperProps={{ sx: { maxHeight: '20rem', overflow: 'clip' } }}
   >
     <DialogTitle id="dialog-title" textAlign="center">
       Sign In

--- a/src/components/NavBar/OidcLoginComponent.jsx
+++ b/src/components/NavBar/OidcLoginComponent.jsx
@@ -79,6 +79,7 @@ const OidcLoginComponent = ({ setShowSignInModal }) => {
         onInputChange={(_, newInputValue) => {
           setOidcIssuer(newInputValue);
         }}
+        ListboxProps={{ style: { maxHeight: '12rem' } }}
         renderInput={(renderParams) => (
           <TextField
             {...renderParams}


### PR DESCRIPTION
## This PR:
Resolves #539

## Screenshots (if applicable):

https://github.com/codeforpdx/PASS/assets/55720928/713f6846-be49-4fb2-a6df-447355ce373f

## Additional Context (optional):
The issue this PR resolves is actually asking to add vertical scrolling functionality to the Autocomplete. However, adding a max height to the component addresses the issue... The Autocomplete component had scrollable functionality all along, so by limiting its height, this allows the component's content to be scrollable.