### PR TITLE
Issue 509/splitting messages inbox outbox

### DIFF
--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -46,15 +46,15 @@ const AppRoutes = () => {
           <Route path=":webId" element={<Profile />} />
         </Route>
         <Route path="/messages">
-          {MESSAGE_PAGES_LIST.map((messagePages) => (
+          {MESSAGE_PAGES_LIST.map(({ path: routePath, element }) => (
             <Route
-              path={messagePages.path}
-              key={messagePages.path}
+              path={routePath}
+              key={routePath}
               element={
-                messagePages.path === '/messages' ? (
+                routePath === '/messages' ? (
                   <Navigate to="/messages/inbox" replace />
                 ) : (
-                  <MessagesLayout path={messagePages.path}>{messagePages.element}</MessagesLayout>
+                  <MessagesLayout path={routePath}>{element}</MessagesLayout>
                 )
               }
             />

--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -4,9 +4,11 @@ import { Routes, Route, Navigate, Outlet } from 'react-router-dom';
 // Inrupt Imports
 import { useSession } from '@hooks';
 import { SessionProvider } from '@contexts';
+// Component Imports
 import { CIVIC_FORM_LIST, FormLayout } from '@components/CivicProfileForms';
+import { MESSAGE_PAGES_LIST, MessagesLayout } from '@components/Messages';
 // Page Imports
-import { CivicProfile, Home, Contacts, Messages, Profile, Signup } from './pages';
+import { CivicProfile, Home, Contacts, Profile, Signup } from './pages';
 
 const ProtectedRoute = ({ isLoggedIn, children }) =>
   isLoggedIn ? children ?? <Outlet /> : <Navigate to="/" replace />;
@@ -43,7 +45,23 @@ const AppRoutes = () => {
           <Route index element={<Contacts />} />
           <Route path=":webId" element={<Profile />} />
         </Route>
-        <Route path="/messages" element={<Messages />} />
+        <Route path="/messages">
+          {MESSAGE_PAGES_LIST.map((messagePagesProps) => (
+            <Route
+              path={messagePagesProps.path}
+              key={messagePagesProps.path}
+              element={
+                messagePagesProps.path === '/messages' ? (
+                  <Navigate to="/messages/inbox" replace />
+                ) : (
+                  <MessagesLayout path={messagePagesProps.path}>
+                    {messagePagesProps.element}
+                  </MessagesLayout>
+                )
+              }
+            />
+          ))}
+        </Route>
         <Route path="/profile" element={<Profile />} />
         <Route path="/civic-profile" element={<CivicProfile />}>
           {CIVIC_FORM_LIST.map((formProps) => (

--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -46,17 +46,15 @@ const AppRoutes = () => {
           <Route path=":webId" element={<Profile />} />
         </Route>
         <Route path="/messages">
-          {MESSAGE_PAGES_LIST.map((messagePagesProps) => (
+          {MESSAGE_PAGES_LIST.map((messagePages) => (
             <Route
-              path={messagePagesProps.path}
-              key={messagePagesProps.path}
+              path={messagePages.path}
+              key={messagePages.path}
               element={
-                messagePagesProps.path === '/messages' ? (
+                messagePages.path === '/messages' ? (
                   <Navigate to="/messages/inbox" replace />
                 ) : (
-                  <MessagesLayout path={messagePagesProps.path}>
-                    {messagePagesProps.element}
-                  </MessagesLayout>
+                  <MessagesLayout path={messagePages.path}>{messagePages.element}</MessagesLayout>
                 )
               }
             />

--- a/src/components/Messages/Inbox.jsx
+++ b/src/components/Messages/Inbox.jsx
@@ -1,5 +1,8 @@
+// React Imports
 import React from 'react';
+// Custom Hooks Imports
 import { useMessageList } from '@hooks';
+// Component Imports
 import MessageFolder from './MessageFolder';
 
 const Inbox = () => {

--- a/src/components/Messages/Inbox.jsx
+++ b/src/components/Messages/Inbox.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useMessageList } from '@hooks';
+import MessageFolder from './MessageFolder';
+
+const Inbox = () => {
+  localStorage.setItem('restorePath', '/messages/inbox');
+  const { data, refetch, isFetching } = useMessageList('Inbox');
+
+  return (
+    <MessageFolder
+      folderType="Inbox"
+      handleRefresh={refetch}
+      loadMessages={isFetching}
+      messageList={data}
+    />
+  );
+};
+
+export default Inbox;

--- a/src/components/Messages/MessageButtonGroup.jsx
+++ b/src/components/Messages/MessageButtonGroup.jsx
@@ -7,6 +7,7 @@ import CreateIcon from '@mui/icons-material/Create';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import { useNavigate } from 'react-router-dom';
 
 const routesArray = [{ label: 'Inbox' }, { label: 'Outbox' }];
 
@@ -23,6 +24,14 @@ const routesArray = [{ label: 'Inbox' }, { label: 'Outbox' }];
  */
 const MessageButtonGroup = ({ setShowModal, boxType, setBoxType }) => {
   const isReallySmallScreen = useMediaQuery('(max-width: 480px)');
+  const navigate = useNavigate();
+
+  const handleNavigate = (pathLabel) => {
+    const path = pathLabel.toLowerCase();
+
+    setBoxType(path);
+    navigate(`/messages/${path}`);
+  };
 
   return (
     <Box
@@ -47,7 +56,7 @@ const MessageButtonGroup = ({ setShowModal, boxType, setBoxType }) => {
             key={`${item.label}Tab`}
             value={item.label.toLowerCase()}
             label={item.label}
-            onClick={() => setBoxType(item.label.toLowerCase())}
+            onClick={() => handleNavigate(item.label)}
           />
         ))}
       </Tabs>

--- a/src/components/Messages/MessageButtonGroup.jsx
+++ b/src/components/Messages/MessageButtonGroup.jsx
@@ -9,7 +9,10 @@ import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
-const routesArray = [{ label: 'Inbox' }, { label: 'Outbox' }];
+const routesArray = [
+  { label: 'Inbox', path: 'inbox' },
+  { label: 'Outbox', path: 'outbox' }
+];
 
 /**
  *  Renders the Message Button Group component for new message, inbox, and outbox
@@ -26,9 +29,7 @@ const MessageButtonGroup = ({ setShowModal, boxType, setBoxType }) => {
   const isReallySmallScreen = useMediaQuery('(max-width: 480px)');
   const navigate = useNavigate();
 
-  const handleNavigate = (pathLabel) => {
-    const path = pathLabel.toLowerCase();
-
+  const handleNavigate = (path) => {
     setBoxType(path);
     navigate(`/messages/${path}`);
   };
@@ -51,12 +52,12 @@ const MessageButtonGroup = ({ setShowModal, boxType, setBoxType }) => {
         New Message
       </Button>
       <Tabs value={boxType} sx={{ padding: '0 15px' }}>
-        {routesArray.map((item) => (
+        {routesArray.map(({ label, path }) => (
           <Tab
-            key={`${item.label}Tab`}
-            value={item.label.toLowerCase()}
-            label={item.label}
-            onClick={() => handleNavigate(item.label)}
+            key={`${label}Tab`}
+            value={path}
+            label={label}
+            onClick={() => handleNavigate(path)}
           />
         ))}
       </Tabs>

--- a/src/components/Messages/MessageButtonGroup.jsx
+++ b/src/components/Messages/MessageButtonGroup.jsx
@@ -1,5 +1,6 @@
 // React Imports
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 // Material UI Imports
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -7,7 +8,6 @@ import CreateIcon from '@mui/icons-material/Create';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { useNavigate } from 'react-router-dom';
 
 const routesArray = [{ label: 'Inbox' }, { label: 'Outbox' }];
 

--- a/src/components/Messages/MessagePagesList.jsx
+++ b/src/components/Messages/MessagePagesList.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Messages } from '@pages';
+import Inbox from './Inbox';
+import Outbox from './Outbox';
+
+const MESSAGE_PAGES_LIST = [
+  { path: '/messages', element: <Messages /> },
+  { path: '/messages/inbox', element: <Inbox /> },
+  { path: '/messages/outbox', element: <Outbox /> }
+];
+
+export default MESSAGE_PAGES_LIST;

--- a/src/components/Messages/MessagesLayout.jsx
+++ b/src/components/Messages/MessagesLayout.jsx
@@ -1,0 +1,30 @@
+// React Imports
+import React, { useState } from 'react';
+// Material UI Imports
+import Container from '@mui/material/Container';
+import { NewMessageModal } from '@components/Modals';
+import MessageButtonGroup from './MessageButtonGroup';
+
+/**
+ * Messages Page - Page that generates the components for the Message system
+ * in PASS
+ *
+ * @memberof Pages
+ * @name Messages
+ * @param {React.JSX.Element} chilren - The wrapped Message Component
+ * @returns {React.JSX.Element} The Messages Page
+ */
+const MessagesLayout = ({ children, path }) => {
+  const [boxType, setBoxType] = useState(path === '/messages/inbox' ? 'inbox' : 'outbox');
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <Container sx={{ display: 'grid', gridTemplateRows: '80px 1fr' }}>
+      <MessageButtonGroup setShowModal={setShowModal} boxType={boxType} setBoxType={setBoxType} />
+      {children}
+      {showModal && <NewMessageModal showModal={showModal} setShowModal={setShowModal} />}
+    </Container>
+  );
+};
+
+export default MessagesLayout;

--- a/src/components/Messages/MessagesLayout.jsx
+++ b/src/components/Messages/MessagesLayout.jsx
@@ -1,7 +1,7 @@
 // React Imports
 import React, { useState } from 'react';
 // Material UI Imports
-import Container from '@mui/material/Container';
+import Box from '@mui/material/Box';
 import { NewMessageModal } from '@components/Modals';
 import MessageButtonGroup from './MessageButtonGroup';
 
@@ -19,11 +19,11 @@ const MessagesLayout = ({ children, path }) => {
   const [showModal, setShowModal] = useState(false);
 
   return (
-    <Container sx={{ display: 'grid', gridTemplateRows: '80px 1fr' }}>
+    <Box sx={{ display: 'grid', gridTemplateRows: '80px 1fr' }}>
       <MessageButtonGroup setShowModal={setShowModal} boxType={boxType} setBoxType={setBoxType} />
       {children}
       {showModal && <NewMessageModal showModal={showModal} setShowModal={setShowModal} />}
-    </Container>
+    </Box>
   );
 };
 

--- a/src/components/Messages/Outbox.jsx
+++ b/src/components/Messages/Outbox.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useMessageList } from '@hooks';
+import MessageFolder from './MessageFolder';
+
+const Outbox = () => {
+  localStorage.setItem('restorePath', '/messages/outbox');
+  const { data, refetch, isFetching } = useMessageList('Outbox');
+
+  return (
+    <MessageFolder
+      folderType="Outbox"
+      handleRefresh={refetch}
+      loadMessages={isFetching}
+      messageList={data}
+    />
+  );
+};
+
+export default Outbox;

--- a/src/components/Messages/Outbox.jsx
+++ b/src/components/Messages/Outbox.jsx
@@ -1,5 +1,8 @@
+// React Imporst
 import React from 'react';
+// Custom Hooks Imports
 import { useMessageList } from '@hooks';
+// Component Imports
 import MessageFolder from './MessageFolder';
 
 const Outbox = () => {

--- a/src/components/Messages/index.js
+++ b/src/components/Messages/index.js
@@ -3,6 +3,8 @@ import MessageFolder from './MessageFolder';
 import MessagesLayout from './MessagesLayout';
 import MessageButtonGroup from './MessageButtonGroup';
 import MESSAGE_PAGES_LIST from './MessagePagesList';
+import Inbox from './Inbox';
+import Outbox from './Outbox';
 
 /**
  * Components and functions related to Messages functionality within project PASS
@@ -10,4 +12,12 @@ import MESSAGE_PAGES_LIST from './MessagePagesList';
  * @namespace Messages
  */
 
-export { MessagePreview, MessageFolder, MessagesLayout, MessageButtonGroup, MESSAGE_PAGES_LIST };
+export {
+  MessagePreview,
+  MessageFolder,
+  MessagesLayout,
+  MessageButtonGroup,
+  MESSAGE_PAGES_LIST,
+  Inbox,
+  Outbox
+};

--- a/src/components/Messages/index.js
+++ b/src/components/Messages/index.js
@@ -1,6 +1,8 @@
 import MessagePreview from './MessagePreview';
 import MessageFolder from './MessageFolder';
+import MessagesLayout from './MessagesLayout';
 import MessageButtonGroup from './MessageButtonGroup';
+import MESSAGE_PAGES_LIST from './MessagePagesList';
 
 /**
  * Components and functions related to Messages functionality within project PASS
@@ -8,4 +10,4 @@ import MessageButtonGroup from './MessageButtonGroup';
  * @namespace Messages
  */
 
-export { MessagePreview, MessageFolder, MessageButtonGroup };
+export { MessagePreview, MessageFolder, MessagesLayout, MessageButtonGroup, MESSAGE_PAGES_LIST };

--- a/src/pages/Messages.jsx
+++ b/src/pages/Messages.jsx
@@ -1,13 +1,8 @@
 // React Imports
-import React, { useState } from 'react';
-// Custom Hook Imports
-import { useMessageList } from '@hooks';
+import React from 'react';
 // Material UI Imports
-import Box from '@mui/material/Box';
-// Context Imports
-// Component Imports
-import { NewMessageModal } from '../components/Modals';
-import { MessageButtonGroup, MessageFolder } from '../components/Messages';
+import Container from '@mui/material/Container';
+import { Outlet } from 'react-router-dom';
 
 /**
  * Messages Page - Page that generates the components for the Message system
@@ -17,44 +12,10 @@ import { MessageButtonGroup, MessageFolder } from '../components/Messages';
  * @name Messages
  * @returns {React.JSX.Element} The Messages Page
  */
-const Messages = () => {
-  localStorage.setItem('restorePath', '/messages');
-  const {
-    data: inboxList,
-    refetch: refreshInbox,
-    isFetching: fetchingInbox
-  } = useMessageList('Inbox');
-  const {
-    data: outboxList,
-    refetch: refreshOutbox,
-    isFetching: fetchingOutbox
-  } = useMessageList('Outbox');
-
-  // Handler function for refreshing PASS messages
-  const handleMessageRefresh = async (folderType) => {
-    if (folderType === 'Inbox') {
-      await refreshInbox();
-    } else {
-      await refreshOutbox();
-    }
-  };
-
-  const [boxType, setBoxType] = useState('inbox');
-  const [showModal, setShowModal] = useState(false);
-
-  return (
-    <Box sx={{ display: 'grid', gridTemplateRows: '80px 1fr' }}>
-      <MessageButtonGroup setShowModal={setShowModal} boxType={boxType} setBoxType={setBoxType} />
-
-      <MessageFolder
-        folderType={boxType === 'inbox' ? 'Inbox' : 'Outbox'}
-        handleRefresh={handleMessageRefresh}
-        loadMessages={boxType === 'inbox' ? fetchingInbox : fetchingOutbox}
-        messageList={boxType === 'inbox' ? inboxList : outboxList}
-      />
-      {showModal && <NewMessageModal showModal={showModal} setShowModal={setShowModal} />}
-    </Box>
-  );
-};
+const Messages = () => (
+  <Container sx={{ display: 'grid', gridTemplateRows: '80px 1fr' }}>
+    <Outlet />
+  </Container>
+);
 
 export default Messages;

--- a/src/pages/Messages.jsx
+++ b/src/pages/Messages.jsx
@@ -1,7 +1,7 @@
 // React Imports
 import React from 'react';
 // Material UI Imports
-import Container from '@mui/material/Container';
+import Box from '@mui/material/Box';
 import { Outlet } from 'react-router-dom';
 
 /**
@@ -13,9 +13,9 @@ import { Outlet } from 'react-router-dom';
  * @returns {React.JSX.Element} The Messages Page
  */
 const Messages = () => (
-  <Container sx={{ display: 'grid', gridTemplateRows: '80px 1fr' }}>
+  <Box sx={{ display: 'grid', gridTemplateRows: '80px 1fr' }}>
     <Outlet />
-  </Container>
+  </Box>
 );
 
 export default Messages;

--- a/src/pages/Messages.jsx
+++ b/src/pages/Messages.jsx
@@ -1,8 +1,8 @@
 // React Imports
 import React from 'react';
+import { Outlet } from 'react-router-dom';
 // Material UI Imports
 import Box from '@mui/material/Box';
-import { Outlet } from 'react-router-dom';
 
 /**
  * Messages Page - Page that generates the components for the Message system

--- a/test/components/Messages/Inbox.test.jsx
+++ b/test/components/Messages/Inbox.test.jsx
@@ -4,11 +4,11 @@ import userEvent from '@testing-library/user-event';
 import { it, describe, expect, vi } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
 import { SessionContext } from '@contexts';
-import { Messages } from '@pages';
 import IconButton from '@mui/material/IconButton';
 import Badge from '@mui/material/Badge';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useMessageList } from '@hooks';
+import { Inbox, MessagesLayout } from '@components/Messages';
 
 vi.mock('@inrupt/solid-client');
 
@@ -87,7 +87,9 @@ const MockMessagePage = ({ session }) => {
           <IconButton aria-label="show new messages" datatestid="EmailIcon">
             <Badge badgeContent={numUnreadMessages} color="error" />
           </IconButton>
-          <Messages />
+          <MessagesLayout path="/messages/inbox">
+            <Inbox />
+          </MessagesLayout>
         </SessionContext.Provider>
       </BrowserRouter>
     </QueryClientProvider>
@@ -114,8 +116,8 @@ describe('Messages Page', () => {
   });
 
   it('should render messages', async () => {
-    const { getByText, queryByText } = render(<MockMessagePage session={sessionObj} />);
-    expect(getByText('RE:test-inbox')).not.toBeNull();
+    const { queryByText } = render(<MockMessagePage session={sessionObj} />);
+    expect(queryByText('RE:test-inbox')).not.toBeNull();
     expect(queryByText('RE:test-outbox')).toBeNull();
   });
 

--- a/test/components/Messages/MessageButtonGroup.test.jsx
+++ b/test/components/Messages/MessageButtonGroup.test.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import { expect, it } from 'vitest';
 import { MessageButtonGroup } from '@components/Messages';
 import createMatchMedia from '../../helpers/createMatchMedia';
 
-const MockMessageButtonGroup = () => <MessageButtonGroup boxType="inbox" />;
-
+const MockMessageButtonGroup = () => (
+  <BrowserRouter>
+    <MessageButtonGroup boxType="inbox" />
+  </BrowserRouter>
+);
 it('renders button group as a row default', () => {
   const { getByRole } = render(<MockMessageButtonGroup />);
   const newMessageButton = getByRole('button', { name: 'New Message' });

--- a/test/components/Messages/Outbox.test.jsx
+++ b/test/components/Messages/Outbox.test.jsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { it, describe, expect, vi } from 'vitest';
+import { BrowserRouter } from 'react-router-dom';
+import { SessionContext } from '@contexts';
+import IconButton from '@mui/material/IconButton';
+import Badge from '@mui/material/Badge';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useMessageList } from '@hooks';
+import { Outbox, MessagesLayout } from '@components/Messages';
+
+vi.mock('@inrupt/solid-client');
+
+const MockInboxList = [
+  {
+    message: 'test message',
+    messageId: '3bf2a18d-0c6a-43e4-9650-992bf4fe7fe7',
+    messageUrl:
+      'http://localhost:3000/pod-test-name-here/PASS/Inbox/RE%3Ateste-20231023-195931.ttl',
+    title: 'RE:test-inbox',
+    uploadDate: new Date('2023-10-23T19:59:31.424Z'),
+    readStatus: false,
+    sender: 'PODMAN',
+    senderWebId: 'http://localhost:3000/pod-test-name-here/profile/card#me',
+    recipient: 'PODMAN'
+  },
+  {
+    message: 'test 3',
+    messageId: '3bf2a18d-0c6a-43e4-9650-992bf4fe7fe9',
+    messageUrl:
+      'http://localhost:3000/pod-test-name-here/PASS/Inbox/RE%3Ateste-20231023-195931.ttl',
+    title: 'foo bar',
+    uploadDate: new Date('2023-10-23T19:59:31.424Z'),
+    readStatus: true,
+    sender: 'PODMAN',
+    senderWebId: 'http://localhost:3000/pod-test-name-here/profile/card#me',
+    recipient: 'PODMAN'
+  }
+];
+
+const MockOutboxList = [
+  {
+    message: 'test 2',
+    messageId: '3bf2a18d-0c6a-43e4-9650-992bf4fe7fe8',
+    messageUrl:
+      'http://localhost:3000/pod-test-name-here/PASS/Inbox/RE%3Ateste-20231023-195933.ttl',
+    title: 'RE:test-outbox',
+    uploadDate: new Date('2023-10-23T19:59:31.424Z'),
+    readStatus: true,
+    sender: 'PODMAN',
+    senderWebId: 'http://localhost:3000/pod-test-name-here/profile/card#me',
+    recipient: 'PODMAN'
+  }
+];
+
+const mockAdd = vi.fn();
+
+vi.mock('@hooks', async () => {
+  const actual = await vi.importActual('@hooks');
+
+  return {
+    ...actual,
+    useMessageList: vi.fn().mockImplementation((boxType) => {
+      if (boxType === 'Inbox') {
+        return {
+          data: MockInboxList,
+          add: mockAdd
+        };
+      }
+      return { data: MockOutboxList };
+    })
+  };
+});
+
+const queryClient = new QueryClient();
+
+const MockMessagePage = ({ session }) => {
+  const { data } = useMessageList('Outbox');
+
+  const numUnreadMessages = data?.reduce((a, m) => (!m.readStatus ? a + 1 : a), 0);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <SessionContext.Provider value={session}>
+          <IconButton aria-label="show new messages" datatestid="EmailIcon">
+            <Badge badgeContent={numUnreadMessages} color="error" />
+          </IconButton>
+          <MessagesLayout path="/messages/outbox">
+            <Outbox />
+          </MessagesLayout>
+        </SessionContext.Provider>
+      </BrowserRouter>
+    </QueryClientProvider>
+  );
+};
+
+describe('Messages Page', () => {
+  const sessionObj = {
+    login: vi.fn(),
+    fetch: vi.fn(),
+    podUrl: 'https://example.com',
+    session: {
+      fetch: vi.fn(),
+      info: {
+        webId: 'https://example.com/profile/',
+        isLoggedIn: true
+      }
+    }
+  };
+  it('renders', () => {
+    const { getByText } = render(<MockMessagePage session={sessionObj} />);
+    expect(getByText('Inbox', { exact: true })).not.toBeNull();
+    expect(getByText('Outbox', { exact: true })).not.toBeNull();
+  });
+
+  it('should render messages', async () => {
+    const { queryByText } = render(<MockMessagePage session={sessionObj} />);
+    expect(queryByText('RE:test-inbox')).toBeNull();
+    expect(queryByText('RE:test-outbox')).not.toBeNull();
+  });
+
+  it('should not trigger state update function', async () => {
+    const user = userEvent.setup();
+    render(<MockMessagePage session={sessionObj} />);
+    const unreadMessage = screen.getByLabelText(
+      'open message preview 3bf2a18d-0c6a-43e4-9650-992bf4fe7fe8'
+    );
+    expect(unreadMessage).not.toBeNull();
+    await user.click(unreadMessage);
+    await waitFor(() => expect(mockAdd).not.toBeCalled());
+  });
+});


### PR DESCRIPTION
## This PR:

Partially addresses #509 similar to PR #514. This PR is for splitting up the message pages into separate sub-routes, while retaining previous functionalities. Have updated unit tests accordingly and created separate tests for Inbox and Outbox.

## Screenshots (if applicable):

https://github.com/codeforpdx/PASS/assets/14917816/84db6895-2000-4580-b361-5f4836d69d9f

## Future Steps/PRs Needed to Finish This Work (optional):

- Updates to other Message functionalities in utils similar to what is done in PR #514, but for message building and message sending

## Issues needing discussion/feedback (optional):
**1.**    Issue #509
