### PR TITLE
[Bug] - Include validation for webIds in Add Contacts Modal

### DIFF
--- a/src/components/Modals/AddContactModal.jsx
+++ b/src/components/Modals/AddContactModal.jsx
@@ -50,6 +50,7 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
   const [userFamilyName, setUserFamilyName] = useState('');
   const [username, setUsername] = useState('');
   const [webId, setWebId] = useState('');
+  const [invalidWebId, setInvalidWebId] = useState(false);
   const [processing, setProcessing] = useState(false);
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
@@ -58,6 +59,7 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
     setUsername(value);
     const renderedWebId = renderWebId(value);
     setWebId(renderedWebId);
+    if (invalidWebId) setInvalidWebId(false);
   };
 
   const clearInputFields = () => {
@@ -65,6 +67,7 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
     setUserFamilyName('');
     setUsername('');
     setWebId('');
+    setInvalidWebId(false);
   };
 
   const handleAddContact = async (event) => {
@@ -82,6 +85,7 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
       await getWebIdDataset(userObject.webId);
     } catch {
       addNotification('error', `Add contact failed. Reason: ${userObject.webId} does not exist`);
+      setInvalidWebId(true);
       setProcessing(false);
       return;
     }
@@ -156,6 +160,11 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
             onChange={(e) => {
               setWebId(e.target.value);
             }}
+            error={invalidWebId}
+            label={invalidWebId ? 'Error' : ''}
+            // helperText for invalidWebId === false is ' ' and not '' is to
+            // prevent the field from stretching when helperText disappears
+            helperText={invalidWebId ? 'Invalid WebId.' : ' '}
             fullWidth
             InputProps={{
               endAdornment: (

--- a/src/components/Modals/AddContactModal.jsx
+++ b/src/components/Modals/AddContactModal.jsx
@@ -1,5 +1,7 @@
 // React Imports
 import React, { useState } from 'react';
+// Inrupt Imports
+import { getWebIdDataset } from '@inrupt/solid-client';
 // Material UI Imports
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -58,6 +60,13 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
     setWebId(renderedWebId);
   };
 
+  const clearInputFields = () => {
+    setUserGivenName('');
+    setUserFamilyName('');
+    setUsername('');
+    setWebId('');
+  };
+
   const handleAddContact = async (event) => {
     event.preventDefault();
     setProcessing(true);
@@ -68,6 +77,15 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
       webId: addWebId.value.trim()
     };
 
+    // Validation for webId
+    try {
+      await getWebIdDataset(userObject.webId);
+    } catch {
+      addNotification('error', `Add contact failed. Reason: ${userObject.webId} does not exist`);
+      setProcessing(false);
+      return;
+    }
+
     try {
       await addContact(userObject);
       addNotification(
@@ -77,10 +95,7 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
     } catch (e) {
       addNotification('error', `Add contact failed. Reason: ${e.message}`);
     } finally {
-      setUserGivenName('');
-      setUserFamilyName('');
-      setUsername('');
-      setWebId('');
+      clearInputFields();
       setShowAddContactModal(false);
       setProcessing(false);
     }
@@ -167,7 +182,10 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
                 variant="outlined"
                 color="error"
                 endIcon={<ClearIcon />}
-                onClick={() => setShowAddContactModal(false)}
+                onClick={() => {
+                  clearInputFields();
+                  setShowAddContactModal(false);
+                }}
                 fullWidth
               >
                 Cancel

--- a/test/components/Modals/AddContactModal.test.jsx
+++ b/test/components/Modals/AddContactModal.test.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { AddContactModal } from '@components/Modals';
+import * as solidClient from '@inrupt/solid-client';
 import createMatchMedia from '../../helpers/createMatchMedia';
 
 const MockAddContactModal = () => <AddContactModal showAddContactModal />;
@@ -26,9 +27,7 @@ it('renders button container flex-direction column mobile', () => {
   expect(cssProperty.flexDirection).toBe('column');
 });
 
-it('will submit data only after deleting leading and trailing spaces from each field', async () => {
-  const user = userEvent.setup(() => new Promise());
-
+describe('add contact', () => {
   // Mocks required so it won't crash from undefined imports
   vi.mock('@hooks/useNotification', async (importOriginal) => {
     const mod = await importOriginal();
@@ -52,32 +51,68 @@ it('will submit data only after deleting leading and trailing spaces from each f
   };
 
   const mockAdd = vi.fn();
+  vi.mock('@inrupt/solid-client');
 
-  render(
-    <AddContactModal setShowAddContactModal={() => {}} showAddContactModal addContact={mockAdd} />
-  );
+  it('will submit data only after deleting leading and trailing spaces from each field and webId exists', async () => {
+    const user = userEvent.setup(() => new Promise());
 
-  const givenName = screen.getByRole('textbox', { name: 'First/given name' });
-  const familyName = screen.getByRole('textbox', { name: 'Last/family name' });
-  const username = screen.getByRole('textbox', { name: 'Username' });
-  const submitButton = screen.getByRole('button', { name: 'Add Contact' });
+    render(
+      <AddContactModal setShowAddContactModal={() => {}} showAddContactModal addContact={mockAdd} />
+    );
 
-  await user.type(givenName, inputData.givenName);
-  await user.type(familyName, inputData.familyName);
-  await user.type(username, inputData.username);
+    const givenName = screen.getByRole('textbox', { name: 'First/given name' });
+    const familyName = screen.getByRole('textbox', { name: 'Last/family name' });
+    const username = screen.getByRole('textbox', { name: 'Username' });
+    const submitButton = screen.getByRole('button', { name: 'Add Contact' });
 
-  expect(givenName.value).toBe(inputData.givenName);
-  expect(familyName.value).toBe(inputData.familyName);
-  expect(username.value).toBe(inputData.username);
+    await user.type(givenName, inputData.givenName);
+    await user.type(familyName, inputData.familyName);
+    await user.type(username, inputData.username);
 
-  await user.click(submitButton);
+    expect(givenName.value).toBe(inputData.givenName);
+    expect(familyName.value).toBe(inputData.familyName);
+    expect(username.value).toBe(inputData.username);
 
-  expect(mockAdd).toHaveBeenCalled();
-  const userObject = mockAdd.mock.calls[0][0];
-  // Should be the input data without leading or trailing whitespace
-  expect(userObject).toMatchObject({
-    givenName: inputData.givenName.trim(),
-    familyName: inputData.familyName.trim(),
-    webId: expect.stringContaining(inputData.username.trim())
+    vi.spyOn(solidClient, 'getWebIdDataset').mockRejectedValue();
+
+    await user.click(submitButton);
+
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it('will not submit data if webId does not exist', async () => {
+    const user = userEvent.setup(() => new Promise());
+
+    render(
+      <AddContactModal setShowAddContactModal={() => {}} showAddContactModal addContact={mockAdd} />
+    );
+
+    const givenName = screen.getByRole('textbox', { name: 'First/given name' });
+    const familyName = screen.getByRole('textbox', { name: 'Last/family name' });
+    const username = screen.getByRole('textbox', { name: 'Username' });
+    const submitButton = screen.getByRole('button', { name: 'Add Contact' });
+
+    await user.type(givenName, inputData.givenName);
+    await user.type(familyName, inputData.familyName);
+    await user.type(username, inputData.username);
+
+    expect(givenName.value).toBe(inputData.givenName);
+    expect(familyName.value).toBe(inputData.familyName);
+    expect(username.value).toBe(inputData.username);
+
+    vi.spyOn(solidClient, 'getWebIdDataset').mockResolvedValue(
+      solidClient.mockSolidDatasetFrom('https://example.com/pod/profile/card#me')
+    );
+
+    await user.click(submitButton);
+
+    expect(mockAdd).toHaveBeenCalled();
+    const userObject = mockAdd.mock.calls[0][0];
+    // Should be the input data without leading or trailing whitespace
+    expect(userObject).toMatchObject({
+      givenName: inputData.givenName.trim(),
+      familyName: inputData.familyName.trim(),
+      webId: expect.stringContaining(inputData.username.trim())
+    });
   });
 });


### PR DESCRIPTION
## This PR:

Resolves #415 by including an early validation step that exits the `handleAddContact` function if `webId` being added does not exist. Minor clean-up to `AddContactModal.jsx` has also been included.

## Screenshots (if applicable):

https://github.com/codeforpdx/PASS/assets/14917816/34243825-53e1-4a86-82bc-9a54cc637ad7

## Future Steps:

Related to a new bug, but if you were to include another user with a webId that already exists, but is already included in the contacts list, the new submission will overwrite the information from the existing contact from the list.

https://github.com/codeforpdx/PASS/assets/14917816/79c1b849-9b7d-497b-a90a-3469d7029dd0
