### PR TITLE
WIP #567 Add `vitest-axe` and add a11y tests where applicable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,8 @@
         "rollup-plugin-visualizer": "^5.9.0",
         "string_decoder": "^1.3.0",
         "vite": "^4.5.0",
-        "vitest": "^0.34.6"
+        "vitest": "^0.34.6",
+        "vitest-axe": "^0.1.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10457,6 +10458,12 @@
       "version": "4.17.21",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
+    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "license": "MIT"
@@ -13937,6 +13944,35 @@
         "webdriverio": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest-axe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "dev": true,
+      "dependencies": {
+        "aria-query": "^5.0.0",
+        "axe-core": "^4.4.2",
+        "chalk": "^5.0.1",
+        "dom-accessibility-api": "^0.5.14",
+        "lodash-es": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.16.0"
+      }
+    },
+    "node_modules/vitest-axe/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/vitest/node_modules/acorn": {
@@ -21695,6 +21731,12 @@
     "lodash": {
       "version": "4.17.21"
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
+    },
     "lodash.clonedeep": {
       "version": "4.5.0"
     },
@@ -23864,6 +23906,28 @@
           "requires": {
             "@jridgewell/sourcemap-codec": "^1.4.15"
           }
+        }
+      }
+    },
+    "vitest-axe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "dev": true,
+      "requires": {
+        "aria-query": "^5.0.0",
+        "axe-core": "^4.4.2",
+        "chalk": "^5.0.1",
+        "dom-accessibility-api": "^0.5.14",
+        "lodash-es": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "rollup-plugin-visualizer": "^5.9.0",
     "string_decoder": "^1.3.0",
     "vite": "^4.5.0",
-    "vitest": "^0.34.6"
+    "vitest": "^0.34.6",
+    "vitest-axe": "^0.1.0"
   },
   "lint-staged": {
     "*.{js,css,ts,tsx,jsx}": [

--- a/test/components/CivicProfileForms/BasicInfo.test.jsx
+++ b/test/components/CivicProfileForms/BasicInfo.test.jsx
@@ -11,6 +11,6 @@ describe('Basic Info Form', () => {
   });
 
   it('should be accessible', async () => {
-    isAccessible(<BasicInfo />);
+    isAccessible(render(<BasicInfo />));
   });
 });

--- a/test/components/CivicProfileForms/BasicInfo.test.jsx
+++ b/test/components/CivicProfileForms/BasicInfo.test.jsx
@@ -10,7 +10,7 @@ describe('Basic Info Form', () => {
     expect(getByText('Basic Info')).not.toBeNull();
   });
 
-  it('should be accessible', async () => {
+  it('should be accessible', () => {
     isAccessible(render(<BasicInfo />));
   });
 });

--- a/test/components/CivicProfileForms/BasicInfo.test.jsx
+++ b/test/components/CivicProfileForms/BasicInfo.test.jsx
@@ -2,10 +2,15 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { expect, it, describe } from 'vitest';
 import { BasicInfo } from '@components/CivicProfileForms';
+import isAccessible from '../../utils/axe';
 
 describe('Basic Info Form', () => {
   it('renders', () => {
     const { getByText } = render(<BasicInfo />);
     expect(getByText('Basic Info')).not.toBeNull();
+  });
+
+  it('should be accessible', async () => {
+    isAccessible(<BasicInfo />);
   });
 });

--- a/test/components/CivicProfileForms/BasicInfo.test.jsx
+++ b/test/components/CivicProfileForms/BasicInfo.test.jsx
@@ -10,7 +10,7 @@ describe('Basic Info Form', () => {
     expect(getByText('Basic Info')).not.toBeNull();
   });
 
-  it('should be accessible', () => {
-    isAccessible(render(<BasicInfo />));
+  it('should be accessible', async () => {
+    await isAccessible(render(<BasicInfo />));
   });
 });

--- a/test/components/CivicProfileForms/BasicInfo.test.jsx
+++ b/test/components/CivicProfileForms/BasicInfo.test.jsx
@@ -10,7 +10,7 @@ describe('Basic Info Form', () => {
     expect(getByText('Basic Info')).not.toBeNull();
   });
 
-  it('should be accessible', async () => {
-    await isAccessible(render(<BasicInfo />));
+  it('should be accessible', () => {
+    isAccessible(render(<BasicInfo />));
   });
 });

--- a/test/components/CivicProfileForms/FinancialInfo.test.jsx
+++ b/test/components/CivicProfileForms/FinancialInfo.test.jsx
@@ -10,7 +10,7 @@ describe('Financial Info Form', () => {
     expect(getByText('Financial Info')).not.toBeNull();
   });
 
-  it('should be accessible', async () => {
+  it('should be accessible', () => {
     isAccessible(render(<FinancialInfo />));
   });
 });

--- a/test/components/CivicProfileForms/FinancialInfo.test.jsx
+++ b/test/components/CivicProfileForms/FinancialInfo.test.jsx
@@ -10,7 +10,7 @@ describe('Financial Info Form', () => {
     expect(getByText('Financial Info')).not.toBeNull();
   });
 
-  it('should be accessible', () => {
-    isAccessible(render(<FinancialInfo />));
+  it('should be accessible', async () => {
+    await isAccessible(render(<FinancialInfo />));
   });
 });

--- a/test/components/CivicProfileForms/FinancialInfo.test.jsx
+++ b/test/components/CivicProfileForms/FinancialInfo.test.jsx
@@ -2,10 +2,15 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { expect, it, describe } from 'vitest';
 import { FinancialInfo } from '@components/CivicProfileForms';
+import isAccessible from '../../utils/axe';
 
 describe('Financial Info Form', () => {
   it('renders', () => {
     const { getByText } = render(<FinancialInfo />);
     expect(getByText('Financial Info')).not.toBeNull();
+  });
+
+  it('should be accessible', async () => {
+    isAccessible(render(<FinancialInfo />));
   });
 });

--- a/test/components/CivicProfileForms/FinancialInfo.test.jsx
+++ b/test/components/CivicProfileForms/FinancialInfo.test.jsx
@@ -10,7 +10,7 @@ describe('Financial Info Form', () => {
     expect(getByText('Financial Info')).not.toBeNull();
   });
 
-  it('should be accessible', async () => {
-    await isAccessible(render(<FinancialInfo />));
+  it('should be accessible', () => {
+    isAccessible(render(<FinancialInfo />));
   });
 });

--- a/test/components/CivicProfileForms/FormLayout.test.jsx
+++ b/test/components/CivicProfileForms/FormLayout.test.jsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { MemoryRouter as Router } from 'react-router-dom';
 import { expect, it, describe } from 'vitest';
 import { FormLayout, CIVIC_FORM_LIST } from '@components/CivicProfileForms';
+import isAccessible from '../../utils/axe';
 
 const renderLayout = (route) =>
   render(
@@ -36,4 +37,8 @@ describe('Civic Form Layout', () => {
     expect(queryAllByRole('link').length).toEqual(1);
     expect(queryAllByRole('link')[0].getAttribute('href')).toBe(`/${prevRoute.path}`);
   });
+});
+
+it('should be accessible', () => {
+  isAccessible(renderLayout(CIVIC_FORM_LIST[0].path));
 });

--- a/test/components/CivicProfileForms/FormLayout.test.jsx
+++ b/test/components/CivicProfileForms/FormLayout.test.jsx
@@ -39,6 +39,6 @@ describe('Civic Form Layout', () => {
   });
 });
 
-it('should be accessible', async () => {
-  await isAccessible(renderLayout(CIVIC_FORM_LIST[0].path));
+it('should be accessible', () => {
+  isAccessible(renderLayout(CIVIC_FORM_LIST[0].path));
 });

--- a/test/components/CivicProfileForms/FormLayout.test.jsx
+++ b/test/components/CivicProfileForms/FormLayout.test.jsx
@@ -39,6 +39,6 @@ describe('Civic Form Layout', () => {
   });
 });
 
-it('should be accessible', () => {
-  isAccessible(renderLayout(CIVIC_FORM_LIST[0].path));
+it('should be accessible', async () => {
+  await isAccessible(renderLayout(CIVIC_FORM_LIST[0].path));
 });

--- a/test/components/CivicProfileForms/HousingInfo.test.jsx
+++ b/test/components/CivicProfileForms/HousingInfo.test.jsx
@@ -23,9 +23,9 @@ describe('Housing info form', () => {
     expect(cityField).not.toBeNull();
   });
 
-  it('should be accessible', async () => {
+  it('should be accessible', () => {
     useCivicProfile.mockReturnValue({ data: {}, isSuccess: true });
-    await isAccessible(render(<HousingInfo />));
+    isAccessible(render(<HousingInfo />));
   });
 
   it('submits an address update when you click the submit button', async () => {

--- a/test/components/CivicProfileForms/HousingInfo.test.jsx
+++ b/test/components/CivicProfileForms/HousingInfo.test.jsx
@@ -4,6 +4,7 @@ import { vi, expect, it, describe } from 'vitest';
 import { HousingInfo } from '@components/CivicProfileForms';
 import { useCivicProfile } from '@hooks';
 import userEvent from '@testing-library/user-event';
+import isAccessible from '../../utils/axe';
 
 vi.mock('@hooks', async () => {
   const actual = await vi.importActual('@hooks');
@@ -20,6 +21,11 @@ describe('Housing info form', () => {
     const { getByRole } = render(<HousingInfo />);
     const cityField = getByRole('textbox', { name: 'City:' });
     expect(cityField).not.toBeNull();
+  });
+
+  it('should be accessible', () => {
+    useCivicProfile.mockReturnValue({ data: {}, isSuccess: true });
+    isAccessible(render(<HousingInfo />));
   });
 
   it('submits an address update when you click the submit button', async () => {

--- a/test/components/CivicProfileForms/HousingInfo.test.jsx
+++ b/test/components/CivicProfileForms/HousingInfo.test.jsx
@@ -23,9 +23,9 @@ describe('Housing info form', () => {
     expect(cityField).not.toBeNull();
   });
 
-  it('should be accessible', () => {
+  it('should be accessible', async () => {
     useCivicProfile.mockReturnValue({ data: {}, isSuccess: true });
-    isAccessible(render(<HousingInfo />));
+    await isAccessible(render(<HousingInfo />));
   });
 
   it('submits an address update when you click the submit button', async () => {

--- a/test/components/Contacts/ContactsListTable.test.jsx
+++ b/test/components/Contacts/ContactsListTable.test.jsx
@@ -4,6 +4,7 @@ import { expect, it } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
 import { ContactListTable } from '@components/Contacts';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import isAccessible from '../../utils/axe';
 
 const queryClient = new QueryClient();
 
@@ -14,6 +15,25 @@ const MockTableComponent = ({ contacts }) => (
     </BrowserRouter>
   </QueryClientProvider>
 );
+
+// TODO: Fix accessibility issues within this component
+it.skip('should be accessible', async () => {
+  const contacts = [
+    {
+      familyName: 'Abby',
+      givenName: 'Aaron',
+      person: 'Aaron Abby',
+      webId: 'https://example.com/Abby'
+    },
+    {
+      familyName: 'Builder',
+      givenName: 'Bob',
+      person: 'Bob Builder',
+      webId: 'https://example.com/Builder'
+    }
+  ];
+  isAccessible(render(<MockTableComponent contacts={contacts} />));
+});
 
 it('renders all clients from client context', () => {
   const contacts = [

--- a/test/components/Contacts/ContactsListTable.test.jsx
+++ b/test/components/Contacts/ContactsListTable.test.jsx
@@ -17,7 +17,7 @@ const MockTableComponent = ({ contacts }) => (
 );
 
 // TODO: Fix accessibility issues within this component
-it.skip('should be accessible', async () => {
+it.skip('should be accessible', () => {
   const contacts = [
     {
       familyName: 'Abby',

--- a/test/components/Contacts/ContactsListTable.test.jsx
+++ b/test/components/Contacts/ContactsListTable.test.jsx
@@ -17,7 +17,7 @@ const MockTableComponent = ({ contacts }) => (
 );
 
 // TODO: Fix accessibility issues within this component
-it.skip('should be accessible', () => {
+it.skip('should be accessible', async () => {
   const contacts = [
     {
       familyName: 'Abby',
@@ -32,7 +32,7 @@ it.skip('should be accessible', () => {
       webId: 'https://example.com/Builder'
     }
   ];
-  isAccessible(render(<MockTableComponent contacts={contacts} />));
+  await isAccessible(render(<MockTableComponent contacts={contacts} />));
 });
 
 it('renders all clients from client context', () => {

--- a/test/components/Contacts/ContactsListTable.test.jsx
+++ b/test/components/Contacts/ContactsListTable.test.jsx
@@ -17,7 +17,7 @@ const MockTableComponent = ({ contacts }) => (
 );
 
 // TODO: Fix accessibility issues within this component
-it.skip('should be accessible', async () => {
+it.skip('should be accessible', () => {
   const contacts = [
     {
       familyName: 'Abby',
@@ -32,7 +32,7 @@ it.skip('should be accessible', async () => {
       webId: 'https://example.com/Builder'
     }
   ];
-  await isAccessible(render(<MockTableComponent contacts={contacts} />));
+  isAccessible(render(<MockTableComponent contacts={contacts} />));
 });
 
 it('renders all clients from client context', () => {

--- a/test/components/Documents/DocumentTable.test.jsx
+++ b/test/components/Documents/DocumentTable.test.jsx
@@ -62,7 +62,7 @@ describe('DocumentTable Component', () => {
   });
 
   // TODO: Fix accessibility issues with this component
-  it.skip('should be accessible', async () => {
+  it.skip('should be accessible', () => {
     isAccessible(render(<MockTableComponent />));
   });
 });

--- a/test/components/Documents/DocumentTable.test.jsx
+++ b/test/components/Documents/DocumentTable.test.jsx
@@ -62,7 +62,7 @@ describe('DocumentTable Component', () => {
   });
 
   // TODO: Fix accessibility issues with this component
-  it.skip('should be accessible', () => {
-    isAccessible(render(<MockTableComponent />));
+  it.skip('should be accessible', async () => {
+    await isAccessible(render(<MockTableComponent />));
   });
 });

--- a/test/components/Documents/DocumentTable.test.jsx
+++ b/test/components/Documents/DocumentTable.test.jsx
@@ -62,7 +62,7 @@ describe('DocumentTable Component', () => {
   });
 
   // TODO: Fix accessibility issues with this component
-  it.skip('should be accessible', async () => {
-    await isAccessible(render(<MockTableComponent />));
+  it.skip('should be accessible', () => {
+    isAccessible(render(<MockTableComponent />));
   });
 });

--- a/test/components/Documents/DocumentTable.test.jsx
+++ b/test/components/Documents/DocumentTable.test.jsx
@@ -3,8 +3,8 @@ import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
 import DocumentTable from '@components/Documents';
-
 import { DocumentListContext } from '@contexts';
+import isAccessible from '../../utils/axe';
 
 const mockedDocumentContext = {
   documentListObject: {
@@ -59,5 +59,10 @@ describe('DocumentTable Component', () => {
     expect(row2FileName).not.toBeNull();
     expect(row2FileType).not.toBeNull();
     expect(row2Description).not.toBeNull();
+  });
+
+  // TODO: Fix accessibility issues with this component
+  it.skip('should be accessible', async () => {
+    isAccessible(render(<MockTableComponent />));
   });
 });

--- a/test/components/Footer/Footer.test.jsx
+++ b/test/components/Footer/Footer.test.jsx
@@ -6,6 +6,7 @@ import { SessionContext } from '@contexts';
 import { ThemeProvider } from '@mui/material/styles';
 import theme from '../../../src/theme';
 import Footer from '../../../src/components/Footer/Footer';
+import isAccessible from '../../utils/axe';
 
 // clear created dom after each test, to start fresh for next
 afterEach(() => {
@@ -27,5 +28,19 @@ describe('Footer', () => {
     const headings = screen.getAllByRole('heading', { level: 2 });
 
     expect(headings.length).toBe(2);
+  });
+
+  it('should be accessible', async () => {
+    await isAccessible(
+      render(
+        <SessionContext.Provider value={{ session: { info: { isLoggedIn: false } } }}>
+          <ThemeProvider theme={theme}>
+            <BrowserRouter>
+              <Footer />
+            </BrowserRouter>
+          </ThemeProvider>
+        </SessionContext.Provider>
+      )
+    );
   });
 });

--- a/test/components/Footer/Footer.test.jsx
+++ b/test/components/Footer/Footer.test.jsx
@@ -30,8 +30,8 @@ describe('Footer', () => {
     expect(headings.length).toBe(2);
   });
 
-  it('should be accessible', async () => {
-    await isAccessible(
+  it('should be accessible', () => {
+    isAccessible(
       render(
         <SessionContext.Provider value={{ session: { info: { isLoggedIn: false } } }}>
           <ThemeProvider theme={theme}>

--- a/test/components/Form/FormSection.test.jsx
+++ b/test/components/Form/FormSection.test.jsx
@@ -13,8 +13,8 @@ const MockFormSection = () => (
   </FormSection>
 );
 
-it('should be accessible', async () => {
-  await isAccessible(render(<MockFormSection />));
+it('should be accessible', () => {
+  isAccessible(render(<MockFormSection />));
 });
 
 it('renders 20px padding by default', () => {

--- a/test/components/Form/FormSection.test.jsx
+++ b/test/components/Form/FormSection.test.jsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { expect, it } from 'vitest';
 import { FormSection } from '@components/Form';
 import createMatchMedia from '../../helpers/createMatchMedia';
+import isAccessible from '../../utils/axe';
 
 const MockChildrenComponent = () => <div />;
 
@@ -11,6 +12,10 @@ const MockFormSection = () => (
     <MockChildrenComponent />
   </FormSection>
 );
+
+it('should be accessible', async () => {
+  await isAccessible(render(<MockFormSection />));
+});
 
 it('renders 20px padding by default', () => {
   const component = render(<MockFormSection />);

--- a/test/components/Home/HomeSection.test.jsx
+++ b/test/components/Home/HomeSection.test.jsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { expect, it, describe } from 'vitest';
 import { HomeSection } from '@components/Home';
 import createMatchMedia from '../../helpers/createMatchMedia';
+import isAccessible from '../../utils/axe';
 
 const MockSection = () => <HomeSection />;
 const MockSectionDescription = () => <HomeSection description="Example Text" />;
@@ -80,5 +81,32 @@ describe('Image rendering', () => {
     const image = getComputedStyle(queryByRole('img'));
 
     expect(image.width).toBe('80%');
+  });
+});
+
+describe('Accessibility', () => {
+  // TODO: Fix accessibility issues with this component
+  it.skip('should have basic rendering be accessible', async () => {
+    await isAccessible(render(<MockSection />));
+  });
+
+  // TODO: Fix accessibility issues with this component
+  it.skip('should have description rendering be accessible', async () => {
+    await isAccessible(render(<MockSectionDescription />));
+  });
+
+  // TODO: Fix accessibility issues with this component
+  it.skip('should have description mobile rendering be accessible', async () => {
+    await isAccessible(render(<MockSectionDescriptionMobile />));
+  });
+
+  // TODO: Fix accessibility issues with this component
+  it.skip('should have button rendering be accessible', async () => {
+    await isAccessible(render(<MockSectionButton />));
+  });
+
+  // TODO: Fix accessibility issues with this component
+  it.skip('should have button mobile rendering be accessible', async () => {
+    await isAccessible(render(<MockSectionButtonMobile />));
   });
 });

--- a/test/components/Home/HomeSection.test.jsx
+++ b/test/components/Home/HomeSection.test.jsx
@@ -86,27 +86,27 @@ describe('Image rendering', () => {
 
 describe('Accessibility', () => {
   // TODO: Fix accessibility issues with this component
-  it.skip('should have basic rendering be accessible', async () => {
-    await isAccessible(render(<MockSection />));
+  it.skip('should have basic rendering be accessible', () => {
+    isAccessible(render(<MockSection />));
   });
 
   // TODO: Fix accessibility issues with this component
-  it.skip('should have description rendering be accessible', async () => {
-    await isAccessible(render(<MockSectionDescription />));
+  it.skip('should have description rendering be accessible', () => {
+    isAccessible(render(<MockSectionDescription />));
   });
 
   // TODO: Fix accessibility issues with this component
-  it.skip('should have description mobile rendering be accessible', async () => {
-    await isAccessible(render(<MockSectionDescriptionMobile />));
+  it.skip('should have description mobile rendering be accessible', () => {
+    isAccessible(render(<MockSectionDescriptionMobile />));
   });
 
   // TODO: Fix accessibility issues with this component
-  it.skip('should have button rendering be accessible', async () => {
-    await isAccessible(render(<MockSectionButton />));
+  it.skip('should have button rendering be accessible', () => {
+    isAccessible(render(<MockSectionButton />));
   });
 
   // TODO: Fix accessibility issues with this component
-  it.skip('should have button mobile rendering be accessible', async () => {
-    await isAccessible(render(<MockSectionButtonMobile />));
+  it.skip('should have button mobile rendering be accessible', () => {
+    isAccessible(render(<MockSectionButtonMobile />));
   });
 });

--- a/test/components/Home/KeyFeatures.test.jsx
+++ b/test/components/Home/KeyFeatures.test.jsx
@@ -1,11 +1,24 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { KeyFeatures } from '@components/Home';
 import createMatchMedia from '../../helpers/createMatchMedia';
+import isAccessible from '../../utils/axe';
 
 const MockKeyFeaturesDefault = () => <KeyFeatures description="Example Text" />;
 const MockKeyFeaturesMobile = () => <KeyFeatures isReallySmallScreen description="Example Text" />;
+
+describe('Accessibility', () => {
+  // TODO: Fix accessibility issues with this component
+  it.skip('should be accessible', async () => {
+    await isAccessible(render(<MockKeyFeaturesDefault />));
+  });
+
+  // TODO: Fix accessibility issues with this component
+  it.skip('should be accessible on mobile', async () => {
+    await isAccessible(render(<MockKeyFeaturesMobile />));
+  });
+});
 
 it('renders less width by default', () => {
   const { getByText } = render(<MockKeyFeaturesDefault />);

--- a/test/components/Messages/Inbox.test.jsx
+++ b/test/components/Messages/Inbox.test.jsx
@@ -112,8 +112,8 @@ describe('Messages Page', () => {
   };
 
   // TODO: Fix accessibility issues with this component
-  it.skip('should be accessible', async () => {
-    await isAccessible(render(<MockMessagePage session={sessionObj} />));
+  it.skip('should be accessible', () => {
+    isAccessible(render(<MockMessagePage session={sessionObj} />));
   });
 
   it('renders', () => {

--- a/test/components/Messages/Inbox.test.jsx
+++ b/test/components/Messages/Inbox.test.jsx
@@ -9,6 +9,7 @@ import Badge from '@mui/material/Badge';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useMessageList } from '@hooks';
 import { Inbox, MessagesLayout } from '@components/Messages';
+import isAccessible from '../../utils/axe';
 
 vi.mock('@inrupt/solid-client');
 
@@ -109,6 +110,12 @@ describe('Messages Page', () => {
       }
     }
   };
+
+  // TODO: Fix accessibility issues with this component
+  it.skip('should be accessible', async () => {
+    await isAccessible(render(<MockMessagePage session={sessionObj} />));
+  });
+
   it('renders', () => {
     const { getByText } = render(<MockMessagePage session={sessionObj} />);
     expect(getByText('Inbox', { exact: true })).not.toBeNull();

--- a/test/components/Messages/MessageButtonGroup.test.jsx
+++ b/test/components/Messages/MessageButtonGroup.test.jsx
@@ -12,8 +12,8 @@ const MockMessageButtonGroup = () => (
   </BrowserRouter>
 );
 
-it('should be accessible', async () => {
-  await isAccessible(render(<MockMessageButtonGroup />));
+it('should be accessible', () => {
+  isAccessible(render(<MockMessageButtonGroup />));
 });
 
 it('renders button group as a row default', () => {

--- a/test/components/Messages/MessageButtonGroup.test.jsx
+++ b/test/components/Messages/MessageButtonGroup.test.jsx
@@ -4,12 +4,18 @@ import { render } from '@testing-library/react';
 import { expect, it } from 'vitest';
 import { MessageButtonGroup } from '@components/Messages';
 import createMatchMedia from '../../helpers/createMatchMedia';
+import isAccessible from '../../utils/axe';
 
 const MockMessageButtonGroup = () => (
   <BrowserRouter>
     <MessageButtonGroup boxType="inbox" />
   </BrowserRouter>
 );
+
+it('should be accessible', async () => {
+  await isAccessible(render(<MockMessageButtonGroup />));
+});
+
 it('renders button group as a row default', () => {
   const { getByRole } = render(<MockMessageButtonGroup />);
   const newMessageButton = getByRole('button', { name: 'New Message' });

--- a/test/components/Messages/MessageFolder.test.jsx
+++ b/test/components/Messages/MessageFolder.test.jsx
@@ -47,13 +47,13 @@ describe('Mobile screen', () => {
 
 describe('Accessibility', () => {
   // TODO: Fix accessibility issues with this component
-  it.skip('should be accessible', async () => {
-    await isAccessible(render(<MockMessageFolder />));
+  it.skip('should be accessible', () => {
+    isAccessible(render(<MockMessageFolder />));
   });
 
   // TODO: Fix accessibility issues with this component
-  it.skip('should be accessible on mobile', async () => {
+  it.skip('should be accessible on mobile', () => {
     window.matchMedia = createMatchMedia(599);
-    await isAccessible(render(<MockMessageFolder />));
+    isAccessible(render(<MockMessageFolder />));
   });
 });

--- a/test/components/Messages/MessageFolder.test.jsx
+++ b/test/components/Messages/MessageFolder.test.jsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { MessageFolder } from '@components/Messages';
 import createMatchMedia from '../../helpers/createMatchMedia';
+import isAccessible from '../../utils/axe';
 
 const MockMessageFolder = () => <MessageFolder messageList={[]} />;
 
@@ -41,5 +42,18 @@ describe('Mobile screen', () => {
     const cssProperty = getComputedStyle(button);
 
     expect(cssProperty.margin).toBe('10px 20px');
+  });
+});
+
+describe('Accessibility', () => {
+  // TODO: Fix accessibility issues with this component
+  it.skip('should be accessible', async () => {
+    await isAccessible(render(<MockMessageFolder />));
+  });
+
+  // TODO: Fix accessibility issues with this component
+  it.skip('should be accessible on mobile', async () => {
+    window.matchMedia = createMatchMedia(599);
+    await isAccessible(render(<MockMessageFolder />));
   });
 });

--- a/test/components/Messages/MessagePreview.test.jsx
+++ b/test/components/Messages/MessagePreview.test.jsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { MessagePreview } from '@components/Messages';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import createMatchMedia from '../../helpers/createMatchMedia';
+import isAccessible from '../../utils/axe';
 
 const queryClient = new QueryClient();
 
@@ -13,6 +14,10 @@ const MockMessagePreview = () => (
     <MessagePreview message={mockMessageInfo} />
   </QueryClientProvider>
 );
+
+it('should be accessible', async () => {
+  await isAccessible(render(<MockMessagePreview />));
+});
 
 describe('Grid sizes', () => {
   it('renders grid values 5, 5, 2 default', () => {

--- a/test/components/Messages/MessagePreview.test.jsx
+++ b/test/components/Messages/MessagePreview.test.jsx
@@ -15,8 +15,8 @@ const MockMessagePreview = () => (
   </QueryClientProvider>
 );
 
-it('should be accessible', async () => {
-  await isAccessible(render(<MockMessagePreview />));
+it('should be accessible', () => {
+  isAccessible(render(<MockMessagePreview />));
 });
 
 describe('Grid sizes', () => {

--- a/test/components/Messages/Outbox.test.jsx
+++ b/test/components/Messages/Outbox.test.jsx
@@ -9,6 +9,7 @@ import Badge from '@mui/material/Badge';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useMessageList } from '@hooks';
 import { Outbox, MessagesLayout } from '@components/Messages';
+import isAccessible from '../../utils/axe';
 
 vi.mock('@inrupt/solid-client');
 
@@ -113,6 +114,11 @@ describe('Messages Page', () => {
     const { getByText } = render(<MockMessagePage session={sessionObj} />);
     expect(getByText('Inbox', { exact: true })).not.toBeNull();
     expect(getByText('Outbox', { exact: true })).not.toBeNull();
+  });
+
+  // TODO: Fix accessibility issues with this component
+  it.skip('should be accessible', async () => {
+    await isAccessible(render(<MockMessagePage session={sessionObj} />));
   });
 
   it('should render messages', async () => {

--- a/test/components/Messages/Outbox.test.jsx
+++ b/test/components/Messages/Outbox.test.jsx
@@ -117,8 +117,8 @@ describe('Messages Page', () => {
   });
 
   // TODO: Fix accessibility issues with this component
-  it.skip('should be accessible', async () => {
-    await isAccessible(render(<MockMessagePage session={sessionObj} />));
+  it.skip('should be accessible', () => {
+    isAccessible(render(<MockMessagePage session={sessionObj} />));
   });
 
   it('should render messages', async () => {

--- a/test/components/Modals/AddContactModal.test.jsx
+++ b/test/components/Modals/AddContactModal.test.jsx
@@ -9,8 +9,8 @@ import isAccessible from '../../utils/axe';
 
 const MockAddContactModal = () => <AddContactModal showAddContactModal />;
 
-it('should be accessible', async () => {
-  await isAccessible(render(<MockAddContactModal />));
+it('should be accessible', () => {
+  isAccessible(render(<MockAddContactModal />));
 });
 
 it('renders button container flex-direction row default', () => {

--- a/test/components/Modals/AddContactModal.test.jsx
+++ b/test/components/Modals/AddContactModal.test.jsx
@@ -5,8 +5,13 @@ import { describe, expect, it, vi } from 'vitest';
 import { AddContactModal } from '@components/Modals';
 import * as solidClient from '@inrupt/solid-client';
 import createMatchMedia from '../../helpers/createMatchMedia';
+import isAccessible from '../../utils/axe';
 
 const MockAddContactModal = () => <AddContactModal showAddContactModal />;
+
+it('should be accessible', async () => {
+  await isAccessible(render(<MockAddContactModal />));
+});
 
 it('renders button container flex-direction row default', () => {
   const { getByRole } = render(<MockAddContactModal />);

--- a/test/components/Modals/ConfirmationModal.test.jsx
+++ b/test/components/Modals/ConfirmationModal.test.jsx
@@ -14,10 +14,6 @@ const MockConfirmationModalLogout = () => (
 );
 
 describe('Default screen', () => {
-  it('should be accessible', async () => {
-    await isAccessible(render(<MockConfirmationModalBasic />));
-  });
-
   it('renders button container flex-direction as row default', () => {
     const { getByRole } = render(<MockConfirmationModalBasic />);
     const cancelButton = getByRole('button', { name: 'Cancel' });
@@ -38,11 +34,6 @@ describe('Default screen', () => {
 });
 
 describe('Mobile screen', () => {
-  it('should be accessible', async () => {
-    window.matchMedia = createMatchMedia(599);
-    await isAccessible(render(<MockConfirmationModalBasic />));
-  });
-
   it('renders button container flex-direction as column mobile', () => {
     window.matchMedia = createMatchMedia(599);
     const { getByRole } = render(<MockConfirmationModalBasic />);
@@ -60,6 +51,20 @@ describe('Mobile screen', () => {
     const cssProperty = getComputedStyle(buttonContainer);
 
     expect(cssProperty.flexDirection).toBe('column');
+  });
+});
+
+describe('Accessibility', () => {
+  // These are set to async/await so that they don't conflict with each other.
+  // `axe` requires synchronous execution, so if multiple are running at once,
+  // it can give false positives.
+  it('should be accessible', async () => {
+    await isAccessible(render(<MockConfirmationModalBasic />));
+  });
+
+  it('should be accessible on mobile', async () => {
+    window.matchMedia = createMatchMedia(599);
+    await isAccessible(render(<MockConfirmationModalBasic />));
   });
 });
 

--- a/test/components/Modals/ConfirmationModal.test.jsx
+++ b/test/components/Modals/ConfirmationModal.test.jsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import createMatchMedia from '../../helpers/createMatchMedia';
 import '@testing-library/jest-dom/extend-expect';
+import isAccessible from '../../utils/axe';
 
 const MockConfirmationModalBasic = () => (
   <ConfirmationModal showModal title="Action" cancelButtonText="Cancel" />
@@ -13,6 +14,10 @@ const MockConfirmationModalLogout = () => (
 );
 
 describe('Default screen', () => {
+  it('should be accessible', async () => {
+    await isAccessible(render(<MockConfirmationModalBasic />));
+  });
+
   it('renders button container flex-direction as row default', () => {
     const { getByRole } = render(<MockConfirmationModalBasic />);
     const cancelButton = getByRole('button', { name: 'Cancel' });
@@ -33,6 +38,11 @@ describe('Default screen', () => {
 });
 
 describe('Mobile screen', () => {
+  it('should be accessible', async () => {
+    window.matchMedia = createMatchMedia(599);
+    await isAccessible(render(<MockConfirmationModalBasic />));
+  });
+
   it('renders button container flex-direction as column mobile', () => {
     window.matchMedia = createMatchMedia(599);
     const { getByRole } = render(<MockConfirmationModalBasic />);

--- a/test/components/Modals/NewMessageModal.test.jsx
+++ b/test/components/Modals/NewMessageModal.test.jsx
@@ -7,6 +7,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 // For testing
 import { sendMessageTTL } from '@utils';
 import createMatchMedia from '../../helpers/createMatchMedia';
+import isAccessible from '../../utils/axe';
 
 const queryClient = new QueryClient();
 
@@ -15,6 +16,10 @@ const MockNewMessageModal = () => (
     <NewMessageModal showModal />
   </QueryClientProvider>
 );
+
+it('should be accessible', async () => {
+  await isAccessible(render(<MockNewMessageModal />));
+});
 
 it('renders button group flex-direction as row default', () => {
   const { getByRole } = render(<MockNewMessageModal />);

--- a/test/components/Modals/NewMessageModal.test.jsx
+++ b/test/components/Modals/NewMessageModal.test.jsx
@@ -17,8 +17,8 @@ const MockNewMessageModal = () => (
   </QueryClientProvider>
 );
 
-it('should be accessible', async () => {
-  await isAccessible(render(<MockNewMessageModal />));
+it('should be accessible', () => {
+  isAccessible(render(<MockNewMessageModal />));
 });
 
 it('renders button group flex-direction as row default', () => {

--- a/test/components/Modals/UploadButtonGroup.test.jsx
+++ b/test/components/Modals/UploadButtonGroup.test.jsx
@@ -3,8 +3,14 @@ import { expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 import UploadButtonGroup from '../../../src/components/Modals/UploadButtonGroup';
 import createMatchMedia from '../../helpers/createMatchMedia';
+import isAccessible from '../../utils/axe';
 
 const MockUploadButtonGroup = () => <UploadButtonGroup />;
+
+// TODO: Fix accessibility issues with this component
+it.skip('should be accessible', async () => {
+  await isAccessible(render(<MockUploadButtonGroup />));
+});
 
 it('renders only one button above 768px', () => {
   const { getAllByRole } = render(<MockUploadButtonGroup />);

--- a/test/components/Modals/UploadButtonGroup.test.jsx
+++ b/test/components/Modals/UploadButtonGroup.test.jsx
@@ -8,8 +8,8 @@ import isAccessible from '../../utils/axe';
 const MockUploadButtonGroup = () => <UploadButtonGroup />;
 
 // TODO: Fix accessibility issues with this component
-it.skip('should be accessible', async () => {
-  await isAccessible(render(<MockUploadButtonGroup />));
+it.skip('should be accessible', () => {
+  isAccessible(render(<MockUploadButtonGroup />));
 });
 
 it('renders only one button above 768px', () => {

--- a/test/components/Modals/UploadDocumentModal.test.jsx
+++ b/test/components/Modals/UploadDocumentModal.test.jsx
@@ -4,8 +4,13 @@ import { render } from '@testing-library/react';
 import { UploadDocumentModal } from '@components/Modals';
 import createMatchMedia from '../../helpers/createMatchMedia';
 import '@testing-library/jest-dom/extend-expect';
+import isAccessible from '../../utils/axe';
 
 const MockUploadDocumentModal = () => <UploadDocumentModal showModal />;
+
+it('should be accessible', async () => {
+  await isAccessible(render(<MockUploadDocumentModal />));
+});
 
 it('renders cancel/upload group as row default', () => {
   const { getByRole } = render(<MockUploadDocumentModal />);

--- a/test/components/Modals/UploadDocumentModal.test.jsx
+++ b/test/components/Modals/UploadDocumentModal.test.jsx
@@ -8,8 +8,8 @@ import isAccessible from '../../utils/axe';
 
 const MockUploadDocumentModal = () => <UploadDocumentModal showModal />;
 
-it('should be accessible', async () => {
-  await isAccessible(render(<MockUploadDocumentModal />));
+it('should be accessible', () => {
+  isAccessible(render(<MockUploadDocumentModal />));
 });
 
 it('renders cancel/upload group as row default', () => {

--- a/test/components/NavBar/NavBar.test.jsx
+++ b/test/components/NavBar/NavBar.test.jsx
@@ -6,6 +6,7 @@ import { SessionContext } from '@contexts';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import createMatchMedia from '../../helpers/createMatchMedia';
 import NavBar from '../../../src/components/NavBar/NavBar';
+import isAccessible from '../../utils/axe';
 
 // clear created dom after each test, to start fresh for next
 afterEach(() => {
@@ -13,6 +14,28 @@ afterEach(() => {
 });
 
 const queryClient = new QueryClient();
+
+describe('Accessibility', () => {
+  const renderExample = () =>
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SessionContext.Provider value={{ session: { info: { isLoggedIn: false } } }}>
+          <BrowserRouter>
+            <NavBar />
+          </BrowserRouter>
+        </SessionContext.Provider>
+      </QueryClientProvider>
+    );
+
+  it('should be accessible', async () => {
+    await isAccessible(renderExample());
+  });
+
+  it('should be accessible on mobile', async () => {
+    window.matchMedia = createMatchMedia(1200);
+    await isAccessible(renderExample());
+  });
+});
 
 describe('login tests', () => {
   it('renders NavbarLoggedOut when user is not logged in', () => {

--- a/test/components/NavBar/NavBar.test.jsx
+++ b/test/components/NavBar/NavBar.test.jsx
@@ -27,6 +27,9 @@ describe('Accessibility', () => {
       </QueryClientProvider>
     );
 
+  // These are set to async/await so that they don't conflict with each other.
+  // `axe` requires synchronous execution, so if multiple are running at once,
+  // it can give false positives.
   it('should be accessible', async () => {
     await isAccessible(renderExample());
   });

--- a/test/components/NavBar/NavBarSkipLink.test.jsx
+++ b/test/components/NavBar/NavBarSkipLink.test.jsx
@@ -4,8 +4,19 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { expect, describe, it } from 'vitest';
 import { NavBarSkipLink } from '@components/NavBar';
+import isAccessible from '../../utils/axe';
 
 describe('NavBarSkipLink', () => {
+  it('should be accessible', async () => {
+    await isAccessible(
+      render(
+        <BrowserRouter>
+          <NavBarSkipLink />
+        </BrowserRouter>
+      )
+    );
+  });
+
   it('renders', () => {
     render(
       <BrowserRouter>

--- a/test/components/NavBar/NavBarSkipLink.test.jsx
+++ b/test/components/NavBar/NavBarSkipLink.test.jsx
@@ -7,8 +7,8 @@ import { NavBarSkipLink } from '@components/NavBar';
 import isAccessible from '../../utils/axe';
 
 describe('NavBarSkipLink', () => {
-  it('should be accessible', async () => {
-    await isAccessible(
+  it('should be accessible', () => {
+    isAccessible(
       render(
         <BrowserRouter>
           <NavBarSkipLink />

--- a/test/components/NavBar/NavMenu.test.jsx
+++ b/test/components/NavBar/NavMenu.test.jsx
@@ -17,6 +17,9 @@ const MockNavMenu = () => (
   </QueryClientProvider>
 );
 
+// These are set to async/await so that they don't conflict with each other.
+// `axe` requires synchronous execution, so if multiple are running at once,
+// it can give false positives.
 it('should be accessible', async () => {
   await isAccessible(render(<MockNavMenu />));
 });

--- a/test/components/NavBar/NavMenu.test.jsx
+++ b/test/components/NavBar/NavMenu.test.jsx
@@ -5,6 +5,7 @@ import { NavMenu } from '@components/NavBar';
 import { render } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import createMatchMedia from '../../helpers/createMatchMedia';
+import isAccessible from '../../utils/axe';
 
 const queryClient = new QueryClient();
 
@@ -16,6 +17,10 @@ const MockNavMenu = () => (
   </QueryClientProvider>
 );
 
+it('should be accessible', async () => {
+  await isAccessible(render(<MockNavMenu />));
+});
+
 it('does not render contacts and civic profile links above 600px', () => {
   const { queryByText } = render(<MockNavMenu />);
 
@@ -24,6 +29,11 @@ it('does not render contacts and civic profile links above 600px', () => {
 
   expect(contactsLink).toBeNull();
   expect(civicProfileLink).toBeNull();
+});
+
+it('should be accessible on mobile', async () => {
+  window.matchMedia = createMatchMedia(599);
+  await isAccessible(render(<MockNavMenu />));
 });
 
 it('renders contacts and civic profile links below 600px', () => {

--- a/test/components/NavBar/NavbarDesktop.test.jsx
+++ b/test/components/NavBar/NavbarDesktop.test.jsx
@@ -9,8 +9,8 @@ import isAccessible from '../../utils/axe';
 const queryClient = new QueryClient();
 
 // TODO: Fix accessibility issues with this component
-it.skip('should be accessible', async () => {
-  await isAccessible(
+it.skip('should be accessible', () => {
+  isAccessible(
     render(
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>

--- a/test/components/NavBar/NavbarDesktop.test.jsx
+++ b/test/components/NavBar/NavbarDesktop.test.jsx
@@ -4,8 +4,22 @@ import { render } from '@testing-library/react';
 import { expect, it } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import NavbarDesktop from '../../../src/components/NavBar/NavbarDesktop';
+import isAccessible from '../../utils/axe';
 
 const queryClient = new QueryClient();
+
+// TODO: Fix accessibility issues with this component
+it.skip('should be accessible', async () => {
+  await isAccessible(
+    render(
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <NavbarDesktop />
+        </BrowserRouter>
+      </QueryClientProvider>
+    )
+  );
+});
 
 it('renders icon menu when on screen larger than mobile', () => {
   const { queryByRole } = render(

--- a/test/components/NavBar/NavbarLoggedOut.test.jsx
+++ b/test/components/NavBar/NavbarLoggedOut.test.jsx
@@ -1,11 +1,35 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import { NavbarLoggedOut } from '@components/NavBar';
 import theme from '../../../src/theme';
 import createMatchMedia from '../../helpers/createMatchMedia';
+import isAccessible from '../../utils/axe';
+
+describe('Accessibility', () => {
+  it('should be accessible', async () => {
+    await isAccessible(
+      render(
+        <BrowserRouter>
+          <NavbarLoggedOut />
+        </BrowserRouter>
+      )
+    );
+  });
+
+  it('should be accessible on mobile', async () => {
+    window.matchMedia = createMatchMedia(599);
+    await isAccessible(
+      render(
+        <BrowserRouter>
+          <NavbarLoggedOut />
+        </BrowserRouter>
+      )
+    );
+  });
+});
 
 it('renders login button when user is logged out', () => {
   const { queryByRole } = render(

--- a/test/components/NavBar/NavbarLoggedOut.test.jsx
+++ b/test/components/NavBar/NavbarLoggedOut.test.jsx
@@ -9,6 +9,9 @@ import createMatchMedia from '../../helpers/createMatchMedia';
 import isAccessible from '../../utils/axe';
 
 describe('Accessibility', () => {
+  // These are set to async/await so that they don't conflict with each other.
+  // `axe` requires synchronous execution, so if multiple are running at once,
+  // it can give false positives.
   it('should be accessible', async () => {
     await isAccessible(
       render(

--- a/test/components/NavBar/NavbarMobile.test.jsx
+++ b/test/components/NavBar/NavbarMobile.test.jsx
@@ -7,8 +7,8 @@ import createMatchMedia from '../../helpers/createMatchMedia';
 import isAccessible from '../../utils/axe';
 
 // TODO: Fix accessibility issues with this component
-it.skip('should be accessible', async () => {
-  await isAccessible(
+it.skip('should be accessible', () => {
+  isAccessible(
     render(
       <BrowserRouter>
         <NavbarMobile />

--- a/test/components/NavBar/NavbarMobile.test.jsx
+++ b/test/components/NavBar/NavbarMobile.test.jsx
@@ -4,6 +4,18 @@ import { render } from '@testing-library/react';
 import { expect, it } from 'vitest';
 import NavbarMobile from '../../../src/components/NavBar/NavbarMobile';
 import createMatchMedia from '../../helpers/createMatchMedia';
+import isAccessible from '../../utils/axe';
+
+// TODO: Fix accessibility issues with this component
+it.skip('should be accessible', async () => {
+  await isAccessible(
+    render(
+      <BrowserRouter>
+        <NavbarMobile />
+      </BrowserRouter>
+    )
+  );
+});
 
 it('renders hamburger menu when on mobile', () => {
   const { queryByRole } = render(

--- a/test/components/NavBar/OidcLoginComponent.test.jsx
+++ b/test/components/NavBar/OidcLoginComponent.test.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { expect, it, vi, afterEach } from 'vitest';
 import OidcLoginComponent from '../../../src/components/NavBar/OidcLoginComponent';
 import createMatchMedia from '../../helpers/createMatchMedia';
+import isAccessible from '../../utils/axe';
 
 vi.mock('@inrupt/solid-client-authn-browser');
 
@@ -24,6 +25,10 @@ vi.mock('../../../src/constants/', async () => {
         'http://testurl_1.com/, http://testurl_2.com/, http://testurl_3.com/'
     }
   };
+});
+
+it('should be accessible', async () => {
+  await isAccessible(render(<OidcLoginComponent />));
 });
 
 it('sets OIDC provider on login', async () => {
@@ -62,6 +67,11 @@ it('renders container items as row default', () => {
   const cssProperty = getComputedStyle(container);
 
   expect(cssProperty.flexDirection).toBe('row');
+});
+
+it('should be accessible on mobile', async () => {
+  window.matchMedia = createMatchMedia(599);
+  await isAccessible(render(<OidcLoginComponent />));
 });
 
 it('renders container items as column mobile', () => {

--- a/test/components/NavBar/OidcLoginComponent.test.jsx
+++ b/test/components/NavBar/OidcLoginComponent.test.jsx
@@ -27,8 +27,8 @@ vi.mock('../../../src/constants/', async () => {
   };
 });
 
-it('should be accessible', async () => {
-  await isAccessible(render(<OidcLoginComponent />));
+it('should be accessible', () => {
+  isAccessible(render(<OidcLoginComponent />));
 });
 
 it('sets OIDC provider on login', async () => {
@@ -69,9 +69,9 @@ it('renders container items as row default', () => {
   expect(cssProperty.flexDirection).toBe('row');
 });
 
-it('should be accessible on mobile', async () => {
+it('should be accessible on mobile', () => {
   window.matchMedia = createMatchMedia(599);
-  await isAccessible(render(<OidcLoginComponent />));
+  isAccessible(render(<OidcLoginComponent />));
 });
 
 it('renders container items as column mobile', () => {

--- a/test/components/Notification/BasicNotification.test.jsx
+++ b/test/components/Notification/BasicNotification.test.jsx
@@ -4,6 +4,19 @@ import { expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { act } from 'react-dom/test-utils';
 import BasicNotification from '../../../src/components/Notification/BasicNotification';
 import { NotificationContext } from '../../../src/contexts/NotificationContext';
+import isAccessible from '../../utils/axe';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+it('should be accessible', () => {
+  isAccessible(render(<BasicNotification severity="success" message="message" id={123456} />));
+});
 
 it('renders correctly', () => {
   const message = 'my test message';
@@ -13,14 +26,6 @@ it('renders correctly', () => {
 
   const notification = screen.getByRole('alert');
   expect(notification.textContent).toBe(message);
-});
-
-beforeEach(() => {
-  vi.useFakeTimers();
-});
-
-afterEach(() => {
-  vi.useRealTimers();
 });
 
 it('calls remove after 8 seconds', () => {

--- a/test/components/Notification/NotificationContainer.test.jsx
+++ b/test/components/Notification/NotificationContainer.test.jsx
@@ -3,12 +3,22 @@ import { render, screen } from '@testing-library/react';
 import { expect, it } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
 import { NotificationContainer } from '../../../src/components/Notification';
+import isAccessible from '../../utils/axe';
 
 const MockNotificationContainer = ({ notifications }) => (
   <BrowserRouter>
     <NotificationContainer notifications={notifications} />
   </BrowserRouter>
 );
+
+it('should be accessible', () => {
+  const notifications = [
+    { id: 34345, message: 'this is a success', severity: 'success' },
+    { id: 45555, message: 'this is and error test', severity: 'error' },
+    { id: 32235, message: 'this is an info test', severity: 'info' }
+  ];
+  isAccessible(render(<MockNotificationContainer notifications={notifications} />));
+});
 
 it('renders all the notifications from notification context', () => {
   const notifications = [

--- a/test/components/Profile/ProfileComponent.test.jsx
+++ b/test/components/Profile/ProfileComponent.test.jsx
@@ -7,6 +7,7 @@ import { SignedInUserContext } from '@contexts';
 import * as profileHelper from '../../../src/model-helpers/Profile';
 import '@testing-library/jest-dom/extend-expect';
 import createMatchMedia from '../../helpers/createMatchMedia';
+import isAccessible from '../../utils/axe';
 
 const profileInfo = {
   profileName: null,
@@ -31,6 +32,20 @@ const mockSignedInUserContextMemo = {
 
 describe('ProfileComponent', () => {
   afterEach(() => cleanup());
+
+  // These are set to async/await so that they don't conflict with each other.
+  // `axe` requires synchronous execution, so if multiple are running at once,
+  // it can give false positives.
+  // TODO: Fix accessibility issues with this component
+  it.skip('should be accessible', async () => {
+    await isAccessible(
+      render(
+        <SignedInUserContext.Provider value={mockSignedInUserContextMemo}>
+          <ProfileComponent contactProfile={null} />
+        </SignedInUserContext.Provider>
+      )
+    );
+  });
 
   it('renders cancel and update buttons after clicking on edit button from initial render', async () => {
     const { queryByRole } = render(
@@ -104,6 +119,18 @@ it('renders profile component as row default', () => {
   const cssProperty = getComputedStyle(container);
 
   expect(cssProperty.flexDirection).toBe('row');
+});
+
+// TODO: Fix accessibility issues with this component
+it.skip('should be accessible on mobile', async () => {
+  window.matchMedia = createMatchMedia(599);
+  await isAccessible(
+    render(
+      <SignedInUserContext.Provider value={mockSignedInUserContextMemo}>
+        <ProfileComponent contactProfile={null} />
+      </SignedInUserContext.Provider>
+    )
+  );
 });
 
 it('renders profile component as column mobile', () => {

--- a/test/components/Profile/ProfileImageField.test.jsx
+++ b/test/components/Profile/ProfileImageField.test.jsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { ProfileImageField } from '../../../src/components/Profile';
 import '@testing-library/jest-dom/extend-expect';
+import isAccessible from '../../utils/axe';
 
 const MockProfileComponent = ({ noUserImage, mockContactProfile }) => {
   if (!noUserImage) {
@@ -12,6 +13,11 @@ const MockProfileComponent = ({ noUserImage, mockContactProfile }) => {
 };
 
 describe('ProfileImageField', () => {
+  // TODO: Fix accessibility issues with this component
+  it.skip('should be accessible', () => {
+    isAccessible(render(<MockProfileComponent noUserImage mockContactProfile={null} />));
+  });
+
   it('renders Choose Img button and PersonIcon if contactProfile is null and user has no profile img', () => {
     const { queryByRole, queryByTestId } = render(
       <MockProfileComponent noUserImage mockContactProfile={null} />

--- a/test/components/Profile/ProfileInputField.test.jsx
+++ b/test/components/Profile/ProfileInputField.test.jsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { ProfileInputField } from '../../../src/components/Profile';
 import '@testing-library/jest-dom/extend-expect';
+import isAccessible from '../../utils/axe';
 
 const MockProfileComponent = ({ name }) => {
   const mockInputName = 'Name';
@@ -20,6 +21,10 @@ const MockProfileComponent = ({ name }) => {
 };
 
 describe('ProfileInputField', () => {
+  it('should be accessible', () => {
+    isAccessible(render(<MockProfileComponent name="mockInputValue" />));
+  });
+
   it('renders ProfileInputField with name Alice', () => {
     const mockInputValue = 'Alice';
     const { queryByRole } = render(<MockProfileComponent name={mockInputValue} />);

--- a/test/components/Signup/PodRegistrationForm.test.jsx
+++ b/test/components/Signup/PodRegistrationForm.test.jsx
@@ -8,8 +8,19 @@ import { expect, it, describe } from 'vitest';
 
 // Component being tested
 import { PodRegistrationForm } from '@components/Signup';
+import isAccessible from '../../utils/axe';
 
 describe('PodRegistrationForm', () => {
+  it('should be accessible', () => {
+    isAccessible(
+      render(
+        <Router>
+          <PodRegistrationForm />
+        </Router>
+      )
+    );
+  });
+
   it('renders', () => {
     render(
       <Router>

--- a/test/components/Signup/ShowNewPod.test.jsx
+++ b/test/components/Signup/ShowNewPod.test.jsx
@@ -4,6 +4,7 @@ import { expect, it, describe, vi } from 'vitest';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ShowNewPod } from '@components/Signup';
+import isAccessible from '../../utils/axe';
 
 vi.mock('@inrupt/solid-client');
 
@@ -19,6 +20,18 @@ vi.mock('react-router-dom', async () => {
 const queryClient = new QueryClient();
 
 describe('ShowNewPod', () => {
+  it('should be accessible', () => {
+    isAccessible(
+      render(
+        <QueryClientProvider client={queryClient}>
+          <Router>
+            <ShowNewPod oidcIssuer="oidIssuer" />
+          </Router>
+        </QueryClientProvider>
+      )
+    );
+  });
+
   it('renders', () => {
     render(
       <QueryClientProvider client={queryClient}>

--- a/test/helpers/test-setup.js
+++ b/test/helpers/test-setup.js
@@ -1,0 +1,4 @@
+import * as matchers from 'vitest-axe/matchers';
+import { expect } from 'vitest';
+
+expect.extend(matchers);

--- a/test/layouts/Breadcrumbs.test.jsx
+++ b/test/layouts/Breadcrumbs.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import Breadcrumbs from '../../src/layouts/Breadcrumbs';
+import isAccessible from '../utils/axe';
 
 vi.mock('react-router-dom', async () => {
   const actual = vi.importActual('react-router-dom');
@@ -12,6 +13,10 @@ vi.mock('react-router-dom', async () => {
     }),
     Link: vi.fn().mockImplementation(({ to, children }) => <a href={to}>{children}</a>)
   };
+});
+
+it('should be accessible', () => {
+  isAccessible(render(<Breadcrumbs />));
 });
 
 it('Renders correct routes and links', () => {

--- a/test/layouts/Layout.test.jsx
+++ b/test/layouts/Layout.test.jsx
@@ -9,6 +9,7 @@ import { NavBar } from '@components/NavBar';
 import Layout from '../../src/layouts/Layout';
 import theme from '../../src/theme';
 import createMatchMedia from '../helpers/createMatchMedia';
+import isAccessible from '../utils/axe';
 
 const MockLayout = () => (
   <ThemeProvider theme={theme}>
@@ -21,6 +22,29 @@ const MockLayout = () => (
 );
 
 describe('Desktop view', () => {
+  // TODO: Fix accessibility issues with this component
+  it.skip('should be accessible', () => {
+    vi.spyOn(hooks, 'useNotification').mockReturnValue({
+      state: { notifications: [] }
+    });
+    isAccessible(
+      render(
+        <SessionContext.Provider
+          value={{
+            session: {
+              info: {
+                isLoggedIn: true,
+                webId: 'https://example.com/pod/profile/card#me'
+              }
+            }
+          }}
+        >
+          <MockLayout />
+        </SessionContext.Provider>
+      )
+    );
+  });
+
   it('Renders breadcrumb when logged in, layout grid-template-rows as 64px 64px 1fr 280px', () => {
     vi.spyOn(hooks, 'useNotification').mockReturnValue({
       state: { notifications: [] }

--- a/test/layouts/Main.test.jsx
+++ b/test/layouts/Main.test.jsx
@@ -2,8 +2,13 @@ import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 import Main from '../../src/layouts/Main';
+import isAccessible from '../utils/axe';
 
 describe('Main Component', () => {
+  it('should be accessible', () => {
+    isAccessible(render(<Main>Text</Main>));
+  });
+
   it('renders', () => {
     render(<Main />);
   });

--- a/test/pages/CivicProfile.test.jsx
+++ b/test/pages/CivicProfile.test.jsx
@@ -4,6 +4,18 @@ import { render } from '@testing-library/react';
 import { expect, it } from 'vitest';
 import { CivicProfile } from '@pages';
 import createMatchMedia from '../helpers/createMatchMedia';
+import isAccessible from '../utils/axe';
+
+// TODO: Fix accessibility issues with this component
+it.skip('should be accessible', () => {
+  isAccessible(
+    render(
+      <BrowserRouter>
+        <CivicProfile />
+      </BrowserRouter>
+    )
+  );
+});
 
 it('renders page container flex direction as row and nav container width as 25% by default', () => {
   const component = render(

--- a/test/pages/Contacts.test.jsx
+++ b/test/pages/Contacts.test.jsx
@@ -5,6 +5,7 @@ import { render } from '@testing-library/react';
 import { useContactsList } from '@hooks';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import isAccessible from '../utils/axe';
 
 vi.mock('@hooks', async () => {
   const actual = await vi.importActual('@hooks');
@@ -20,6 +21,32 @@ const queryClient = new QueryClient();
 describe('Contacts Page', () => {
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  // TODO: Fix accessibility issues with this component
+  it.skip('should be accessible', () => {
+    const firstContact = {
+      person: 'Peter Parker',
+      familyName: 'Parker',
+      givenName: 'Peter',
+      webId: 'http://peter.com'
+    };
+    const secondContact = {
+      person: 'Batman',
+      familyName: 'Batman',
+      givenName: 'Batman',
+      webId: 'http://batman.com'
+    };
+    useContactsList.mockReturnValue({ data: [firstContact, secondContact] });
+    isAccessible(
+      render(
+        <QueryClientProvider client={queryClient}>
+          <BrowserRouter>
+            <Contacts />
+          </BrowserRouter>
+        </QueryClientProvider>
+      )
+    );
   });
 
   it('displays Loading message while loading', () => {

--- a/test/pages/Home.test.jsx
+++ b/test/pages/Home.test.jsx
@@ -3,9 +3,14 @@ import { render, cleanup, screen } from '@testing-library/react';
 import { expect, describe, it, afterEach } from 'vitest';
 import { Home } from '@pages';
 import createMatchMedia from '../helpers/createMatchMedia';
+import isAccessible from '../utils/axe';
 
 describe('Home Page', () => {
   afterEach(cleanup);
+
+  it('should be accessible', () => {
+    isAccessible(render(<Home />));
+  });
 
   it('renders with correct order of logoSection on mobile', () => {
     window.matchMedia = createMatchMedia(599);

--- a/test/pages/PersonalProfile.test.jsx
+++ b/test/pages/PersonalProfile.test.jsx
@@ -4,9 +4,21 @@ import { BrowserRouter } from 'react-router-dom';
 import { expect, it, describe } from 'vitest';
 import { CivicProfile } from '@pages';
 import { CIVIC_FORM_LIST } from '@components/CivicProfileForms';
+import isAccessible from '../utils/axe';
 
 describe('Civic Profile', () => {
   const numLinks = CIVIC_FORM_LIST.length;
+
+  // TODO: Fix accessibility issues with this component
+  it.skip('should be accessible', () => {
+    isAccessible(
+      render(
+        <BrowserRouter>
+          <CivicProfile />
+        </BrowserRouter>
+      )
+    );
+  });
 
   it('renders buttons for all forms in CIVIC_FORM_LIST', () => {
     const { getByRole, getAllByRole } = render(

--- a/test/pages/Signup.test.jsx
+++ b/test/pages/Signup.test.jsx
@@ -6,6 +6,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { Signup } from '@pages';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SessionContext } from '@contexts';
+import isAccessible from '../utils/axe';
 
 vi.mock('@inrupt/solid-client');
 
@@ -37,6 +38,21 @@ const MockSignupContexts = ({ session }) => (
 );
 
 describe('Signup Page', () => {
+  it('should be accessible', () => {
+    const sessionObj = {
+      login: vi.fn(),
+      fetch: vi.fn(),
+      podUrl: 'https://example.com',
+      session: {
+        info: {
+          webId: 'https://example.com/profile/',
+          isLoggedIn: false
+        }
+      }
+    };
+    isAccessible(render(<MockSignupContexts session={sessionObj} />));
+  });
+
   it('renders', () => {
     const sessionObj = {
       login: vi.fn(),

--- a/test/utils/axe.js
+++ b/test/utils/axe.js
@@ -1,0 +1,10 @@
+import { axe } from 'vitest-axe';
+import { render } from '@testing-library/react';
+import { expect } from 'vitest';
+
+const isAccessible = async (jsx) => {
+  const { container } = render(jsx);
+  expect(await axe(container)).toHaveNoViolations();
+};
+
+export default isAccessible;

--- a/test/utils/axe.js
+++ b/test/utils/axe.js
@@ -1,10 +1,8 @@
 import { axe } from 'vitest-axe';
-import { render } from '@testing-library/react';
 import { expect } from 'vitest';
 
-const isAccessible = async (jsx) => {
-  const { container } = render(jsx);
-  expect(await axe(container)).toHaveNoViolations();
+const isAccessible = async (renderResult) => {
+  expect(await axe(renderResult.container)).toHaveNoViolations();
 };
 
 export default isAccessible;

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,12 +1,18 @@
 // vitest.config.ts
-import {mergeConfig} from 'vite'
-import {defineConfig} from 'vitest/config'
-import viteConfig from './vite.config'
+/* eslint-disable import/no-extraneous-dependencies */
+import { mergeConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
+/* eslint-enable import/no-extraneous-dependencies */
+import viteConfig from './vite.config';
 
-export default mergeConfig(viteConfig, defineConfig({
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    globalSetup: './test/helpers/test-globals.js'
-  },
-}))
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: './test/helpers/test-setup.js',
+      globalSetup: './test/helpers/test-globals.js'
+    }
+  })
+);


### PR DESCRIPTION
This PR resolves #567 
 
**1.** Add `vitest-axe` and create an accessibility helper utility that uses it.
**2.** Add accessibility tests to all applicable tests (components, pages, etc.).
**3.** Skip tests that are failing, adding a TODO where necessary.

This touches a ton of files, but the majority are just adding accessibility tests to test files.

## Future Steps/PRs Needed to Finish This Work (optional):

Don't want to leave TODO's in the code without next steps, but considering how many there are here, next steps might be going through each of these failing tests, documenting the failures, and creating issues for each of them. 

TL;DR: create tickets for TODO's