### PR TITLE
Enhancement 534: Updated node to v18 and npm modules

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-16.20.2
+lts/Hydrogen

--- a/config/solid-server/solid-config.json
+++ b/config/solid-server/solid-config.json
@@ -10,6 +10,7 @@
     "css:CommunitySolidServer/config/http/notifications/base/storage.json",
     "css:CommunitySolidServer/config/http/server-factory/https.json",
     "css:CommunitySolidServer/config/http/static/default.json",
+    "css:CommunitySolidServer/config/identity/oidc/default.json",
     "css:CommunitySolidServer/config/identity/access/public.json",
     "css:CommunitySolidServer/config/identity/email/default.json",
     "css:CommunitySolidServer/config/identity/handler/default.json",

--- a/config/solid-server/solid-config.json
+++ b/config/solid-server/solid-config.json
@@ -1,13 +1,13 @@
 {
-  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^6.0.0/components/context.jsonld",
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
   "import": [
-    "css:CommunitySolidServer/config/app/init/default.json",
+    "css:CommunitySolidServer/config/app/init/static-root.json",
+    "css:CommunitySolidServer/config/app/init/initialize-root-pod.json",
     "css:CommunitySolidServer/config/app/main/default.json",
-    "css:CommunitySolidServer/config/app/setup/disabled.json",
     "css:CommunitySolidServer/config/app/variables/default.json",
     "css:CommunitySolidServer/config/http/handler/default.json",
     "css:CommunitySolidServer/config/http/middleware/default.json",
-    "css:CommunitySolidServer/config/http/notifications/websockets.json",
+    "css:CommunitySolidServer/config/http/notifications/base/storage.json",
     "css:CommunitySolidServer/config/http/server-factory/https.json",
     "css:CommunitySolidServer/config/http/static/default.json",
     "css:CommunitySolidServer/config/identity/access/public.json",
@@ -15,16 +15,13 @@
     "css:CommunitySolidServer/config/identity/handler/default.json",
     "css:CommunitySolidServer/config/identity/ownership/unsafe-no-check.json",
     "css:CommunitySolidServer/config/identity/pod/static.json",
-    "css:CommunitySolidServer/config/identity/registration/enabled.json",
     "css:CommunitySolidServer/config/ldp/authentication/dpop-bearer.json",
     "css:CommunitySolidServer/config/ldp/authorization/allow-all.json",
     "css:CommunitySolidServer/config/ldp/handler/default.json",
     "css:CommunitySolidServer/config/ldp/metadata-parser/default.json",
     "css:CommunitySolidServer/config/ldp/metadata-writer/default.json",
     "css:CommunitySolidServer/config/ldp/modes/default.json",
-    "css:CommunitySolidServer/config/storage/backend/file.json",
-    "css:CommunitySolidServer/config/storage/key-value/resource-store.json",
-    "css:CommunitySolidServer/config/storage/middleware/default.json",
+    "css:CommunitySolidServer/config/storage/keyvalue/storages/storages.json",
     "css:CommunitySolidServer/config/util/auxiliary/empty.json",
     "css:CommunitySolidServer/config/util/identifiers/suffix.json",
     "css:CommunitySolidServer/config/util/index/default.json",
@@ -33,5 +30,5 @@
     "css:CommunitySolidServer/config/util/resource-locker/file.json",
     "css:CommunitySolidServer/config/util/variables/default.json"
   ],
-  "@graph": [],
+  "@graph": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.1.0",
-        "@solid/community-server": "^6.1.0",
+        "@solid/community-server": "^7.0.3",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -3313,15 +3313,31 @@
       }
     },
     "node_modules/@koa/cors": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-3.4.3.tgz",
-      "integrity": "sha512-WPXQUaAeAMVaLTEFpoq3T2O1C+FstkjJnDQqy95Ck1UdILajsRhu6mhJ8H2f4NFPRBoCNN+qywTJfq/gGki5mw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-5.0.0.tgz",
+      "integrity": "sha512-x/iUDjcS90W69PryLDIMgFyV21YLTnG9zOpPXS7Bkt2b8AsY3zZsIpOLBkYr9fBcF3HbkKaER5hOBZLfpLgYNw==",
       "dev": true,
       "dependencies": {
         "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@koa/router": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@koa/router/-/router-12.0.1.tgz",
+      "integrity": "sha512-ribfPYfHb+Uw3b27Eiw6NPqjhIhTpVFzEWLwyc/1Xp+DCdwRRyIlAUODX+9bPARF6aQtUu1+/PHzdNvRzcs/+Q==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "methods": "^1.1.2",
+        "path-to-regexp": "^6.2.1"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/@mui/base": {
@@ -3834,12 +3850,12 @@
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
@@ -3879,126 +3895,118 @@
       "license": "ISC"
     },
     "node_modules/@solid/community-server": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@solid/community-server/-/community-server-6.1.0.tgz",
-      "integrity": "sha512-aDYEh30K3bAuzoHOjMmEUCr9CHf1jG1DE33p34Pf1rrwDC6SAwQXumEprkcrJzUF/wmsVESSYoFxtykfHNGSbQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@solid/community-server/-/community-server-7.0.3.tgz",
+      "integrity": "sha512-YLmuE7yLjOjiGmpyuPJ+Q058dMGrmMTsduo1aXW6JlMS7pwDjNawBQ3Y029K2QCRUHJSZaNqVXqPdIiJqcKoFA==",
       "dev": true,
       "dependencies": {
-        "@comunica/context-entries": "^2.6.8",
-        "@comunica/query-sparql": "^2.6.9",
+        "@comunica/context-entries": "^2.8.2",
+        "@comunica/query-sparql": "^2.9.0",
         "@rdfjs/types": "^1.1.0",
         "@solid/access-control-policy": "^0.1.3",
         "@solid/access-token-verifier": "^2.0.5",
         "@types/async-lock": "^1.4.0",
-        "@types/bcryptjs": "^2.4.2",
-        "@types/cors": "^2.8.12",
-        "@types/ejs": "^3.1.2",
-        "@types/end-of-stream": "^1.4.1",
-        "@types/fs-extra": "^11.0.1",
+        "@types/bcryptjs": "^2.4.4",
+        "@types/cookie": "^0.5.2",
+        "@types/cors": "^2.8.14",
+        "@types/ejs": "^3.1.3",
+        "@types/end-of-stream": "^1.4.2",
+        "@types/fs-extra": "^11.0.2",
         "@types/lodash.orderby": "^4.6.7",
-        "@types/marked": "^4.0.8",
-        "@types/mime-types": "^2.1.1",
-        "@types/n3": "^1.10.4",
-        "@types/node": "^14.18.43",
-        "@types/nodemailer": "^6.4.7",
-        "@types/oidc-provider": "^7.11.1",
+        "@types/mime-types": "^2.1.2",
+        "@types/n3": "^1.16.3",
+        "@types/node": "^18.18.4",
+        "@types/nodemailer": "^6.4.11",
+        "@types/oidc-provider": "^8.4.0",
         "@types/proper-lockfile": "^4.1.2",
         "@types/pump": "^1.1.1",
         "@types/punycode": "^2.1.0",
-        "@types/rdf-validate-shacl": "^0.4.1",
-        "@types/sparqljs": "^3.1.4",
+        "@types/rdf-validate-shacl": "^0.4.4",
+        "@types/sparqljs": "^3.1.6",
         "@types/url-join": "^4.0.1",
-        "@types/uuid": "^9.0.1",
-        "@types/ws": "^8.5.4",
-        "@types/yargs": "^17.0.24",
+        "@types/uuid": "^9.0.5",
+        "@types/ws": "^8.5.7",
+        "@types/yargs": "^17.0.28",
         "arrayify-stream": "^2.0.1",
         "async-lock": "^1.4.0",
         "bcryptjs": "^2.4.3",
-        "componentsjs": "^5.3.2",
+        "componentsjs": "^5.4.2",
+        "cookie": "^0.5.0",
         "cors": "^2.8.5",
-        "cross-fetch": "^3.1.5",
+        "cross-fetch": "^4.0.0",
         "ejs": "^3.1.9",
         "end-of-stream": "^1.4.4",
         "escape-string-regexp": "^4.0.0",
-        "fetch-sparql-endpoint": "^3.2.1",
+        "fetch-sparql-endpoint": "^4.1.0",
         "fs-extra": "^11.1.1",
-        "handlebars": "^4.7.7",
+        "handlebars": "^4.7.8",
         "ioredis": "^5.3.2",
         "iso8601-duration": "^2.1.1",
-        "jose": "^4.14.1",
-        "jsonld-context-parser": "^2.3.0",
+        "jose": "^4.15.2",
+        "jsonld-context-parser": "^2.3.2",
         "lodash.orderby": "^4.6.0",
-        "marked": "^4.3.0",
+        "marked": "^9.1.0",
         "mime-types": "^2.1.35",
-        "n3": "^1.16.4",
-        "nodemailer": "^6.9.1",
-        "oidc-provider": "7.10.6",
+        "n3": "^1.17.1",
+        "nodemailer": "^6.9.6",
+        "oidc-provider": "^8.4.0",
         "proper-lockfile": "^4.1.2",
         "pump": "^3.0.0",
-        "punycode": "^2.1.1",
-        "rdf-dereference": "^2.1.0",
+        "punycode": "^2.3.0",
+        "rdf-dereference": "^2.2.0",
         "rdf-parse": "^2.3.2",
         "rdf-serialize": "^2.2.2",
         "rdf-string": "^1.6.3",
-        "rdf-terms": "^1.9.1",
+        "rdf-terms": "^1.11.0",
         "rdf-validate-shacl": "^0.4.5",
-        "sparqlalgebrajs": "^4.0.5",
-        "sparqljs": "^3.6.2",
+        "sparqlalgebrajs": "^4.3.0",
+        "sparqljs": "^3.7.1",
         "url-join": "^4.0.1",
-        "uuid": "^9.0.0",
-        "winston": "^3.8.2",
+        "uuid": "^9.0.1",
+        "winston": "^3.11.0",
         "winston-transport": "^4.5.0",
-        "ws": "^8.13.0",
-        "yargs": "^17.7.1"
+        "ws": "^8.14.2",
+        "yargs": "^17.7.2",
+        "yup": "^1.3.2"
       },
       "bin": {
         "community-solid-server": "bin/server.js"
       },
       "engines": {
-        "node": ">=14.14"
+        "node": ">=18.0"
       }
     },
-    "node_modules/@solid/community-server/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "dev": true
-    },
-    "node_modules/@solid/community-server/node_modules/fetch-sparql-endpoint": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-3.3.3.tgz",
-      "integrity": "sha512-5ZNesFhFMcsEiSaCyg36L5VU7YP7xMJogc5i0n00nFNFZzrfGJ4Cm8LGrzXI6eySkb7QmaRyNWJGk5btAOjniA==",
+    "node_modules/@solid/community-server/node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dev": true,
       "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/readable-stream": "^2.3.11",
-        "@types/sparqljs": "^3.1.3",
-        "abort-controller": "^3.0.0",
-        "cross-fetch": "^3.0.6",
-        "is-stream": "^2.0.0",
-        "minimist": "^1.2.0",
-        "n3": "^1.6.3",
-        "rdf-string": "^1.6.0",
-        "readable-web-to-node-stream": "^3.0.2",
-        "sparqljs": "^3.1.2",
-        "sparqljson-parse": "^2.2.0",
-        "sparqlxml-parse": "^2.1.1",
-        "stream-to-string": "^1.1.0"
-      },
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/@solid/community-server/node_modules/marked": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+      "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+      "dev": true,
       "bin": {
-        "fetch-sparql-endpoint": "bin/fetch-sparql-endpoint.js"
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
       "dev": true,
       "dependencies": {
-        "defer-to-connect": "^2.0.0"
+        "defer-to-connect": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -4193,18 +4201,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/cacheable-request": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-      "dev": true,
-      "dependencies": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "^3.1.4",
-        "@types/node": "*",
-        "@types/responselike": "^1.0.0"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "4.3.9",
       "dev": true,
@@ -4239,6 +4235,12 @@
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.8.tgz",
       "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg==",
+      "dev": true
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.4.tgz",
+      "integrity": "sha512-7z/eR6O859gyWIAjuvBWFzNURmf2oPBmJlfVWkwehU5nzIyjwBsTh7WMmEEV4JFnHuQ3ex4oyTvfKzcyJVDBNA==",
       "dev": true
     },
     "node_modules/@types/cookies": {
@@ -4410,15 +4412,6 @@
       "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
       "dev": true
     },
-    "node_modules/@types/keyv": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/koa": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.14.0.tgz",
@@ -4477,12 +4470,6 @@
         "@types/mdurl": "*"
       }
     },
-    "node_modules/@types/marked": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
-      "integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==",
-      "dev": true
-    },
     "node_modules/@types/mdurl": {
       "version": "1.0.4",
       "dev": true,
@@ -4529,12 +4516,13 @@
       }
     },
     "node_modules/@types/oidc-provider": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@types/oidc-provider/-/oidc-provider-7.14.0.tgz",
-      "integrity": "sha512-zIoedB25LuuiNb0tqRQYI3BzdHXVCsZrCHm38apiLe1p6TmbZA7dCSv8rH3AR8xyBk7eNiE+iIBDEHlBx4UzPA==",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@types/oidc-provider/-/oidc-provider-8.4.3.tgz",
+      "integrity": "sha512-BtkZ7pi2mvlG0uORntefTGub6oxXKZnMPnRZN/b7Xda+m052uWEaeF6OCRp7PO+kMbygyZmKQXY09cfiA22nMw==",
       "dev": true,
       "dependencies": {
-        "@types/koa": "*"
+        "@types/koa": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/parse-json": {
@@ -4632,15 +4620,6 @@
       "version": "1.20.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/responselike": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/retry": {
       "version": "0.12.4",
@@ -5519,45 +5498,30 @@
       }
     },
     "node_modules/cacheable-lookup": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz",
-      "integrity": "sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
       "dev": true,
       "engines": {
-        "node": ">=10.6.0"
+        "node": ">=14.16"
       }
     },
     "node_modules/cacheable-request": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "version": "10.2.14",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+      "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
       "dev": true,
       "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^6.0.1",
-        "responselike": "^2.0.0"
+        "@types/http-cache-semantics": "^4.0.2",
+        "get-stream": "^6.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "keyv": "^4.5.3",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.0.0",
+        "responselike": "^3.0.0"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=14.16"
       }
     },
     "node_modules/call-bind": {
@@ -5773,18 +5737,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/clone-response": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "dev": true,
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/clownface": {
@@ -6073,6 +6025,15 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cookies": {
       "version": "0.9.1",
@@ -8261,6 +8222,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eta": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-3.2.0.tgz",
+      "integrity": "sha512-Qzc3it7nLn49dbOb9+oHV9rwtt9qN8oShRztqkZ3gXPqQflF0VLin5qhWk0g/2ioibBwT4DU6OIMVft7tg/rVg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/eta-dev/eta?sponsor=1"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "license": "MIT",
@@ -8562,6 +8535,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/form-data-encoder": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.17"
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -8776,37 +8758,28 @@
       }
     },
     "node_modules/got": {
-      "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
+      "integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
       "dev": true,
       "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.2",
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.8",
         "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
       },
       "engines": {
-        "node": ">=10.19.0"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
-    "node_modules/got/node_modules/cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.6.0"
       }
     },
     "node_modules/graceful-fs": {
@@ -9017,13 +8990,16 @@
       "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
       "dev": true
     },
-    "node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-      "dev": true
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "node_modules/http-errors": {
+    "node_modules/http-assert/node_modules/http-errors": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
       "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
@@ -9039,13 +9015,35 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/http-errors/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+      "dev": true
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/http-link-header": {
@@ -9069,16 +9067,28 @@
       }
     },
     "node_modules/http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
       "dev": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
+        "resolve-alpn": "^1.2.0"
       },
       "engines": {
         "node": ">=10.19.0"
+      }
+    },
+    "node_modules/http2-wrapper/node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -10342,6 +10352,40 @@
         "node": ">= 10"
       }
     },
+    "node_modules/koa/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/http-errors/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/kuler": {
       "version": "2.0.0",
       "dev": true,
@@ -10595,12 +10639,15 @@
       }
     },
     "node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lru-cache": {
@@ -10733,6 +10780,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/microdata-rdf-streaming-parser": {
       "version": "2.0.1",
       "dev": true,
@@ -10806,12 +10862,15 @@
       }
     },
     "node_modules/mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -10991,12 +11050,12 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11040,9 +11099,9 @@
       }
     },
     "node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "dev": true,
       "engines": {
         "node": ">= 6"
@@ -11165,35 +11224,36 @@
       }
     },
     "node_modules/oidc-provider": {
-      "version": "7.10.6",
-      "resolved": "https://registry.npmjs.org/oidc-provider/-/oidc-provider-7.10.6.tgz",
-      "integrity": "sha512-7fbnormUyTLP34dmR5WXoJtTWtfj6MsFNzIMKVRKv21e18NIXggn14EBUFC5rrMMtmeExb03+lJI/v+opD+0oQ==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/oidc-provider/-/oidc-provider-8.4.5.tgz",
+      "integrity": "sha512-2NsPrvIAX1W4ZR41cGbz2Lt2Ci8iXvECh+x+LcKcM115s/h8iB1pwnNlCdIrvAA2iBGM4/TkO75Xg7xb2FCzWA==",
       "dev": true,
       "dependencies": {
-        "@koa/cors": "^3.1.0",
-        "cacheable-lookup": "^6.0.1",
-        "debug": "^4.3.2",
-        "ejs": "^3.1.6",
-        "got": "^11.8.2",
-        "jose": "^4.1.4",
+        "@koa/cors": "^5.0.0",
+        "@koa/router": "^12.0.1",
+        "debug": "^4.3.4",
+        "eta": "^3.2.0",
+        "got": "^13.0.0",
+        "jose": "^5.1.3",
         "jsesc": "^3.0.2",
-        "koa": "^2.13.3",
-        "koa-compose": "^4.1.0",
-        "nanoid": "^3.1.28",
-        "object-hash": "^2.2.0",
-        "oidc-token-hash": "^5.0.1",
-        "paseto2": "npm:paseto@^2.1.3",
-        "quick-lru": "^5.1.1",
-        "raw-body": "^2.4.1"
-      },
-      "engines": {
-        "node": "^12.19.0 || ^14.15.0 || ^16.13.0"
+        "koa": "^2.14.2",
+        "nanoid": "^5.0.4",
+        "object-hash": "^3.0.0",
+        "oidc-token-hash": "^5.0.3",
+        "quick-lru": "^7.0.0",
+        "raw-body": "^2.5.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/panva"
-      },
-      "optionalDependencies": {
-        "paseto3": "npm:paseto@^3.0.0"
+      }
+    },
+    "node_modules/oidc-provider/node_modules/jose": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.0.tgz",
+      "integrity": "sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/oidc-provider/node_modules/jsesc": {
@@ -11206,6 +11266,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/oidc-provider/node_modules/nanoid": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.4.tgz",
+      "integrity": "sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     },
     "node_modules/oidc-token-hash": {
@@ -11306,12 +11384,12 @@
       }
     },
     "node_modules/p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12.20"
       }
     },
     "node_modules/p-limit": {
@@ -11388,33 +11466,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/paseto2": {
-      "name": "paseto",
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/paseto/-/paseto-2.1.3.tgz",
-      "integrity": "sha512-BNkbvr0ZFDbh3oV13QzT5jXIu8xpFc9r0o5mvWBhDU1GBkVt1IzHK1N6dcYmN7XImrUmPQ0HCUXmoe2WPo8xsg==",
-      "dev": true,
-      "engines": {
-        "node": "^12.19.0 || >=14.15.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/paseto3": {
-      "name": "paseto",
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/paseto/-/paseto-3.1.4.tgz",
-      "integrity": "sha512-BifaKKu+MS9b/vTgFMC6Q8uLUMqw8VtYgl4qODJWb6Jqt+dTKn8XH9EftJZx+6wxF4ELBbKdH33DZa4inMYVcg==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -11442,6 +11493,12 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -11634,6 +11691,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "dev": true
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "dev": true,
@@ -11681,12 +11744,12 @@
       "license": "MIT"
     },
     "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.0.0.tgz",
+      "integrity": "sha512-MX8gB7cVYTrYcFfAnfLlhRd0+Toyl8yX8uBx1MrX7K0jegiz9TumwOK27ldXrgDlHRdVi+MqU9Ssw6dr4BNreg==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11710,31 +11773,6 @@
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
-      "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -12367,12 +12405,15 @@
       }
     },
     "node_modules/responselike": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
       "dev": true,
       "dependencies": {
-        "lowercase-keys": "^2.0.0"
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12953,12 +12994,12 @@
       "license": "MIT"
     },
     "node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true,
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/std-env": {
@@ -13415,6 +13456,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "dev": true
+    },
     "node_modules/tinybench": {
       "version": "2.5.1",
       "dev": true,
@@ -13473,6 +13520,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "dev": true
     },
     "node_modules/tough-cookie": {
       "version": "4.1.3",
@@ -13862,9 +13915,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -14478,6 +14531,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.3.3.tgz",
+      "integrity": "sha512-v8QwZSsHH2K3/G9WSkp6mZKO+hugKT1EmnMqLNUcfu51HU9MDyhlETT/JgtzprnrnQHPWsjc6MUDMBp/l9fNnw==",
+      "dev": true,
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/yup/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -17175,12 +17252,25 @@
       }
     },
     "@koa/cors": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-3.4.3.tgz",
-      "integrity": "sha512-WPXQUaAeAMVaLTEFpoq3T2O1C+FstkjJnDQqy95Ck1UdILajsRhu6mhJ8H2f4NFPRBoCNN+qywTJfq/gGki5mw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-5.0.0.tgz",
+      "integrity": "sha512-x/iUDjcS90W69PryLDIMgFyV21YLTnG9zOpPXS7Bkt2b8AsY3zZsIpOLBkYr9fBcF3HbkKaER5hOBZLfpLgYNw==",
       "dev": true,
       "requires": {
         "vary": "^1.1.2"
+      }
+    },
+    "@koa/router": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@koa/router/-/router-12.0.1.tgz",
+      "integrity": "sha512-ribfPYfHb+Uw3b27Eiw6NPqjhIhTpVFzEWLwyc/1Xp+DCdwRRyIlAUODX+9bPARF6aQtUu1+/PHzdNvRzcs/+Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.4",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "methods": "^1.1.2",
+        "path-to-regexp": "^6.2.1"
       }
     },
     "@mui/base": {
@@ -17391,9 +17481,9 @@
       "dev": true
     },
     "@sindresorhus/is": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
       "dev": true
     },
     "@solid/access-control-policy": {
@@ -17425,116 +17515,105 @@
       }
     },
     "@solid/community-server": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@solid/community-server/-/community-server-6.1.0.tgz",
-      "integrity": "sha512-aDYEh30K3bAuzoHOjMmEUCr9CHf1jG1DE33p34Pf1rrwDC6SAwQXumEprkcrJzUF/wmsVESSYoFxtykfHNGSbQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@solid/community-server/-/community-server-7.0.3.tgz",
+      "integrity": "sha512-YLmuE7yLjOjiGmpyuPJ+Q058dMGrmMTsduo1aXW6JlMS7pwDjNawBQ3Y029K2QCRUHJSZaNqVXqPdIiJqcKoFA==",
       "dev": true,
       "requires": {
-        "@comunica/context-entries": "^2.6.8",
-        "@comunica/query-sparql": "^2.6.9",
+        "@comunica/context-entries": "^2.8.2",
+        "@comunica/query-sparql": "^2.9.0",
         "@rdfjs/types": "^1.1.0",
         "@solid/access-control-policy": "^0.1.3",
         "@solid/access-token-verifier": "^2.0.5",
         "@types/async-lock": "^1.4.0",
-        "@types/bcryptjs": "^2.4.2",
-        "@types/cors": "^2.8.12",
-        "@types/ejs": "^3.1.2",
-        "@types/end-of-stream": "^1.4.1",
-        "@types/fs-extra": "^11.0.1",
+        "@types/bcryptjs": "^2.4.4",
+        "@types/cookie": "^0.5.2",
+        "@types/cors": "^2.8.14",
+        "@types/ejs": "^3.1.3",
+        "@types/end-of-stream": "^1.4.2",
+        "@types/fs-extra": "^11.0.2",
         "@types/lodash.orderby": "^4.6.7",
-        "@types/marked": "^4.0.8",
-        "@types/mime-types": "^2.1.1",
-        "@types/n3": "^1.10.4",
-        "@types/node": "^14.18.43",
-        "@types/nodemailer": "^6.4.7",
-        "@types/oidc-provider": "^7.11.1",
+        "@types/mime-types": "^2.1.2",
+        "@types/n3": "^1.16.3",
+        "@types/node": "^18.18.4",
+        "@types/nodemailer": "^6.4.11",
+        "@types/oidc-provider": "^8.4.0",
         "@types/proper-lockfile": "^4.1.2",
         "@types/pump": "^1.1.1",
         "@types/punycode": "^2.1.0",
-        "@types/rdf-validate-shacl": "^0.4.1",
-        "@types/sparqljs": "^3.1.4",
+        "@types/rdf-validate-shacl": "^0.4.4",
+        "@types/sparqljs": "^3.1.6",
         "@types/url-join": "^4.0.1",
-        "@types/uuid": "^9.0.1",
-        "@types/ws": "^8.5.4",
-        "@types/yargs": "^17.0.24",
+        "@types/uuid": "^9.0.5",
+        "@types/ws": "^8.5.7",
+        "@types/yargs": "^17.0.28",
         "arrayify-stream": "^2.0.1",
         "async-lock": "^1.4.0",
         "bcryptjs": "^2.4.3",
-        "componentsjs": "^5.3.2",
+        "componentsjs": "^5.4.2",
+        "cookie": "^0.5.0",
         "cors": "^2.8.5",
-        "cross-fetch": "^3.1.5",
+        "cross-fetch": "^4.0.0",
         "ejs": "^3.1.9",
         "end-of-stream": "^1.4.4",
         "escape-string-regexp": "^4.0.0",
-        "fetch-sparql-endpoint": "^3.2.1",
+        "fetch-sparql-endpoint": "^4.1.0",
         "fs-extra": "^11.1.1",
-        "handlebars": "^4.7.7",
+        "handlebars": "^4.7.8",
         "ioredis": "^5.3.2",
         "iso8601-duration": "^2.1.1",
-        "jose": "^4.14.1",
-        "jsonld-context-parser": "^2.3.0",
+        "jose": "^4.15.2",
+        "jsonld-context-parser": "^2.3.2",
         "lodash.orderby": "^4.6.0",
-        "marked": "^4.3.0",
+        "marked": "^9.1.0",
         "mime-types": "^2.1.35",
-        "n3": "^1.16.4",
-        "nodemailer": "^6.9.1",
-        "oidc-provider": "7.10.6",
+        "n3": "^1.17.1",
+        "nodemailer": "^6.9.6",
+        "oidc-provider": "^8.4.0",
         "proper-lockfile": "^4.1.2",
         "pump": "^3.0.0",
-        "punycode": "^2.1.1",
-        "rdf-dereference": "^2.1.0",
+        "punycode": "^2.3.0",
+        "rdf-dereference": "^2.2.0",
         "rdf-parse": "^2.3.2",
         "rdf-serialize": "^2.2.2",
         "rdf-string": "^1.6.3",
-        "rdf-terms": "^1.9.1",
+        "rdf-terms": "^1.11.0",
         "rdf-validate-shacl": "^0.4.5",
-        "sparqlalgebrajs": "^4.0.5",
-        "sparqljs": "^3.6.2",
+        "sparqlalgebrajs": "^4.3.0",
+        "sparqljs": "^3.7.1",
         "url-join": "^4.0.1",
-        "uuid": "^9.0.0",
-        "winston": "^3.8.2",
+        "uuid": "^9.0.1",
+        "winston": "^3.11.0",
         "winston-transport": "^4.5.0",
-        "ws": "^8.13.0",
-        "yargs": "^17.7.1"
+        "ws": "^8.14.2",
+        "yargs": "^17.7.2",
+        "yup": "^1.3.2"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "14.18.63",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-          "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-          "dev": true
-        },
-        "fetch-sparql-endpoint": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-3.3.3.tgz",
-          "integrity": "sha512-5ZNesFhFMcsEiSaCyg36L5VU7YP7xMJogc5i0n00nFNFZzrfGJ4Cm8LGrzXI6eySkb7QmaRyNWJGk5btAOjniA==",
+        "cross-fetch": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+          "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
           "dev": true,
           "requires": {
-            "@rdfjs/types": "*",
-            "@types/readable-stream": "^2.3.11",
-            "@types/sparqljs": "^3.1.3",
-            "abort-controller": "^3.0.0",
-            "cross-fetch": "^3.0.6",
-            "is-stream": "^2.0.0",
-            "minimist": "^1.2.0",
-            "n3": "^1.6.3",
-            "rdf-string": "^1.6.0",
-            "readable-web-to-node-stream": "^3.0.2",
-            "sparqljs": "^3.1.2",
-            "sparqljson-parse": "^2.2.0",
-            "sparqlxml-parse": "^2.1.1",
-            "stream-to-string": "^1.1.0"
+            "node-fetch": "^2.6.12"
           }
+        },
+        "marked": {
+          "version": "9.1.6",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+          "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+          "dev": true
         }
       }
     },
     "@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
       "dev": true,
       "requires": {
-        "defer-to-connect": "^2.0.0"
+        "defer-to-connect": "^2.0.1"
       }
     },
     "@tanstack/query-core": {
@@ -17668,18 +17747,6 @@
         "@types/node": "*"
       }
     },
-    "@types/cacheable-request": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-      "dev": true,
-      "requires": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "^3.1.4",
-        "@types/node": "*",
-        "@types/responselike": "^1.0.0"
-      }
-    },
     "@types/chai": {
       "version": "4.3.9",
       "dev": true
@@ -17711,6 +17778,12 @@
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.8.tgz",
       "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg==",
+      "dev": true
+    },
+    "@types/cookie": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.4.tgz",
+      "integrity": "sha512-7z/eR6O859gyWIAjuvBWFzNURmf2oPBmJlfVWkwehU5nzIyjwBsTh7WMmEEV4JFnHuQ3ex4oyTvfKzcyJVDBNA==",
       "dev": true
     },
     "@types/cookies": {
@@ -17861,15 +17934,6 @@
       "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
       "dev": true
     },
-    "@types/keyv": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/koa": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.14.0.tgz",
@@ -17923,12 +17987,6 @@
         "@types/mdurl": "*"
       }
     },
-    "@types/marked": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
-      "integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==",
-      "dev": true
-    },
     "@types/mdurl": {
       "version": "1.0.4",
       "dev": true
@@ -17969,12 +18027,13 @@
       }
     },
     "@types/oidc-provider": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@types/oidc-provider/-/oidc-provider-7.14.0.tgz",
-      "integrity": "sha512-zIoedB25LuuiNb0tqRQYI3BzdHXVCsZrCHm38apiLe1p6TmbZA7dCSv8rH3AR8xyBk7eNiE+iIBDEHlBx4UzPA==",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@types/oidc-provider/-/oidc-provider-8.4.3.tgz",
+      "integrity": "sha512-BtkZ7pi2mvlG0uORntefTGub6oxXKZnMPnRZN/b7Xda+m052uWEaeF6OCRp7PO+kMbygyZmKQXY09cfiA22nMw==",
       "dev": true,
       "requires": {
-        "@types/koa": "*"
+        "@types/koa": "*",
+        "@types/node": "*"
       }
     },
     "@types/parse-json": {
@@ -18061,15 +18120,6 @@
     "@types/resolve": {
       "version": "1.20.2",
       "dev": true
-    },
-    "@types/responselike": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/retry": {
       "version": "0.12.4",
@@ -18635,35 +18685,24 @@
       }
     },
     "cacheable-lookup": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz",
-      "integrity": "sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
       "dev": true
     },
     "cacheable-request": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "version": "10.2.14",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+      "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
       "dev": true,
       "requires": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^6.0.1",
-        "responselike": "^2.0.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        }
+        "@types/http-cache-semantics": "^4.0.2",
+        "get-stream": "^6.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "keyv": "^4.5.3",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.0.0",
+        "responselike": "^3.0.0"
       }
     },
     "call-bind": {
@@ -18785,15 +18824,6 @@
             "strip-ansi": "^6.0.0"
           }
         }
-      }
-    },
-    "clone-response": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^1.0.0"
       }
     },
     "clownface": {
@@ -18992,6 +19022,12 @@
     },
     "convert-source-map": {
       "version": "1.9.0"
+    },
+    "cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "dev": true
     },
     "cookies": {
       "version": "0.9.1",
@@ -20441,6 +20477,12 @@
       "version": "2.0.3",
       "dev": true
     },
+    "eta": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-3.2.0.tgz",
+      "integrity": "sha512-Qzc3it7nLn49dbOb9+oHV9rwtt9qN8oShRztqkZ3gXPqQflF0VLin5qhWk0g/2ioibBwT4DU6OIMVft7tg/rVg==",
+      "dev": true
+    },
     "event-target-shim": {
       "version": "5.0.1"
     },
@@ -20661,6 +20703,12 @@
         "mime-types": "^2.1.12"
       }
     },
+    "form-data-encoder": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "dev": true
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -20784,30 +20832,22 @@
       }
     },
     "got": {
-      "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
+      "integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.2",
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.8",
         "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
-      },
-      "dependencies": {
-        "cacheable-lookup": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-          "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-          "dev": true
-        }
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
       }
     },
     "graceful-fs": {
@@ -20942,6 +20982,31 @@
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
           "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
           "dev": true
+        },
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.1"
+          }
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+          "dev": true
         }
       }
     },
@@ -20952,24 +21017,16 @@
       "dev": true
     },
     "http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "dev": true,
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "2.0.1",
         "toidentifier": "1.0.1"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-          "dev": true
-        }
       }
     },
     "http-link-header": {
@@ -20985,13 +21042,21 @@
       }
     },
     "http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
       "dev": true,
       "requires": {
         "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
+        "resolve-alpn": "^1.2.0"
+      },
+      "dependencies": {
+        "quick-lru": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+          "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+          "dev": true
+        }
       }
     },
     "https-proxy-agent": {
@@ -21764,6 +21829,35 @@
         "statuses": "^1.5.0",
         "type-is": "^1.6.16",
         "vary": "^1.1.2"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.1"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+              "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+              "dev": true
+            }
+          }
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+          "dev": true
+        }
       }
     },
     "koa-compose": {
@@ -21940,9 +22034,9 @@
       }
     },
     "lowercase-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true
     },
     "lru-cache": {
@@ -22024,6 +22118,12 @@
       "version": "1.4.1",
       "dev": true
     },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true
+    },
     "microdata-rdf-streaming-parser": {
       "version": "2.0.1",
       "dev": true,
@@ -22071,9 +22171,9 @@
       "dev": true
     },
     "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "dev": true
     },
     "min-indent": {
@@ -22184,9 +22284,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
       "dev": true
     },
     "npm-run-path": {
@@ -22210,9 +22310,9 @@
       "version": "4.1.1"
     },
     "object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "dev": true
     },
     "object-inspect": {
@@ -22287,33 +22387,42 @@
       }
     },
     "oidc-provider": {
-      "version": "7.10.6",
-      "resolved": "https://registry.npmjs.org/oidc-provider/-/oidc-provider-7.10.6.tgz",
-      "integrity": "sha512-7fbnormUyTLP34dmR5WXoJtTWtfj6MsFNzIMKVRKv21e18NIXggn14EBUFC5rrMMtmeExb03+lJI/v+opD+0oQ==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/oidc-provider/-/oidc-provider-8.4.5.tgz",
+      "integrity": "sha512-2NsPrvIAX1W4ZR41cGbz2Lt2Ci8iXvECh+x+LcKcM115s/h8iB1pwnNlCdIrvAA2iBGM4/TkO75Xg7xb2FCzWA==",
       "dev": true,
       "requires": {
-        "@koa/cors": "^3.1.0",
-        "cacheable-lookup": "^6.0.1",
-        "debug": "^4.3.2",
-        "ejs": "^3.1.6",
-        "got": "^11.8.2",
-        "jose": "^4.1.4",
+        "@koa/cors": "^5.0.0",
+        "@koa/router": "^12.0.1",
+        "debug": "^4.3.4",
+        "eta": "^3.2.0",
+        "got": "^13.0.0",
+        "jose": "^5.1.3",
         "jsesc": "^3.0.2",
-        "koa": "^2.13.3",
-        "koa-compose": "^4.1.0",
-        "nanoid": "^3.1.28",
-        "object-hash": "^2.2.0",
-        "oidc-token-hash": "^5.0.1",
-        "paseto2": "npm:paseto@^2.1.3",
-        "paseto3": "npm:paseto@^3.0.0",
-        "quick-lru": "^5.1.1",
-        "raw-body": "^2.4.1"
+        "koa": "^2.14.2",
+        "nanoid": "^5.0.4",
+        "object-hash": "^3.0.0",
+        "oidc-token-hash": "^5.0.3",
+        "quick-lru": "^7.0.0",
+        "raw-body": "^2.5.2"
       },
       "dependencies": {
+        "jose": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.0.tgz",
+          "integrity": "sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw==",
+          "dev": true
+        },
         "jsesc": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
           "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+          "dev": true
+        },
+        "nanoid": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.4.tgz",
+          "integrity": "sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==",
           "dev": true
         }
       }
@@ -22386,9 +22495,9 @@
       "dev": true
     },
     "p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
       "dev": true
     },
     "p-limit": {
@@ -22433,19 +22542,6 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
     },
-    "paseto2": {
-      "version": "npm:paseto@2.1.3",
-      "resolved": "https://registry.npmjs.org/paseto/-/paseto-2.1.3.tgz",
-      "integrity": "sha512-BNkbvr0ZFDbh3oV13QzT5jXIu8xpFc9r0o5mvWBhDU1GBkVt1IzHK1N6dcYmN7XImrUmPQ0HCUXmoe2WPo8xsg==",
-      "dev": true
-    },
-    "paseto3": {
-      "version": "npm:paseto@3.1.4",
-      "resolved": "https://registry.npmjs.org/paseto/-/paseto-3.1.4.tgz",
-      "integrity": "sha512-BifaKKu+MS9b/vTgFMC6Q8uLUMqw8VtYgl4qODJWb6Jqt+dTKn8XH9EftJZx+6wxF4ELBbKdH33DZa4inMYVcg==",
-      "dev": true,
-      "optional": true
-    },
     "path-exists": {
       "version": "4.0.0",
       "dev": true
@@ -22460,6 +22556,12 @@
     },
     "path-parse": {
       "version": "1.0.7"
+    },
+    "path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
     },
     "path-type": {
       "version": "4.0.0"
@@ -22570,6 +22672,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "dev": true
+    },
     "psl": {
       "version": "1.9.0",
       "dev": true
@@ -22596,9 +22704,9 @@
       "version": "1.2.3"
     },
     "quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.0.0.tgz",
+      "integrity": "sha512-MX8gB7cVYTrYcFfAnfLlhRd0+Toyl8yX8uBx1MrX7K0jegiz9TumwOK27ldXrgDlHRdVi+MqU9Ssw6dr4BNreg==",
       "dev": true
     },
     "randombytes": {
@@ -22617,27 +22725,6 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "http-errors": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-          "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-          "dev": true,
-          "requires": {
-            "depd": "2.0.0",
-            "inherits": "2.0.4",
-            "setprototypeof": "1.2.0",
-            "statuses": "2.0.1",
-            "toidentifier": "1.0.1"
-          }
-        },
-        "statuses": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-          "dev": true
-        }
       }
     },
     "rdf-data-factory": {
@@ -23095,12 +23182,12 @@
       "dev": true
     },
     "responselike": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
       "dev": true,
       "requires": {
-        "lowercase-keys": "^2.0.0"
+        "lowercase-keys": "^3.0.0"
       }
     },
     "restore-cursor": {
@@ -23472,9 +23559,9 @@
       "dev": true
     },
     "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true
     },
     "std-env": {
@@ -23759,6 +23846,12 @@
       "version": "2.3.8",
       "dev": true
     },
+    "tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "dev": true
+    },
     "tinybench": {
       "version": "2.5.1",
       "dev": true
@@ -23792,6 +23885,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true
+    },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
       "dev": true
     },
     "tough-cookie": {
@@ -24041,9 +24140,9 @@
       "dev": true
     },
     "vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "requires": {
         "esbuild": "^0.18.10",
@@ -24389,6 +24488,26 @@
     "yocto-queue": {
       "version": "0.1.0",
       "dev": true
+    },
+    "yup": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.3.3.tgz",
+      "integrity": "sha512-v8QwZSsHH2K3/G9WSkp6mZKO+hugKT1EmnMqLNUcfu51HU9MDyhlETT/JgtzprnrnQHPWsjc6MUDMBp/l9fNnw==",
+      "dev": true,
+      "requires": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+          "dev": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.1.0",
-    "@solid/community-server": "^6.1.0",
+    "@solid/community-server": "^7.0.3",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",


### PR DESCRIPTION
## This PR:
Resolves #534
 
**1.**  Make sure you run `nvm use` before testing this PR.
## Screenshots (if applicable):
NA

## Additional Context (optional):

- This branch was updated to the latest LTS version of node v18.
- `npm audit fix --force` was used to update npm modules
- Followed [these release notes](https://github.com/CommunitySolidServer/CommunitySolidServer/blob/v7.0.0/RELEASE_NOTES.md) for updating CSS `solid-config.json` to work with v7.x.

## Future Steps/PRs Needed to Finish This Work (optional):
Believe everything is functional for review.

## Issues needing discussion/feedback (optional):
**1.** Verify the CCS config is working as expected.   
