### PR TITLE
Simplify resize tests

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 // Material UI Imports
 import Box from '@mui/material/Box';
-import Container from '@mui/material/Container';
 import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -21,7 +20,6 @@ import RenderCopyrightAndLinksSection from './RenderCopyrightAndLinksSection';
  */
 const Footer = () => {
   const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
   const isReallySmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
   return (
@@ -38,25 +36,23 @@ const Footer = () => {
         bgcolor: 'primary.main'
       }}
     >
-      <Container maxWidth={isSmallScreen ? 'md' : 'lg'}>
-        <Stack
-          alignItems="center"
-          direction={isReallySmallScreen ? 'column' : 'row'}
-          spacing={isSmallScreen ? 1 : 4}
-          divider={
-            <Divider
-              orientation={isReallySmallScreen ? 'horizontal' : 'vertical'}
-              flexItem={isReallySmallScreen ? null : true}
-              color={theme.palette.tertiary.main}
-              sx={isReallySmallScreen ? { height: '3px', width: 3 / 4 } : { width: '3px' }}
-            />
-          }
-        >
-          <RenderCallToActionSection isReallySmallScreen={isReallySmallScreen} />
-          <RenderCompanyInfoSection isReallySmallScreen={isReallySmallScreen} />
-          <RenderCopyrightAndLinksSection isReallySmallScreen={isReallySmallScreen} />
-        </Stack>
-      </Container>
+      <Stack
+        alignItems="center"
+        direction={isReallySmallScreen ? 'column' : 'row'}
+        spacing={isReallySmallScreen ? 1 : 4}
+        divider={
+          <Divider
+            orientation={isReallySmallScreen ? 'horizontal' : 'vertical'}
+            flexItem={isReallySmallScreen ? null : true}
+            color={theme.palette.tertiary.main}
+            sx={isReallySmallScreen ? { height: '3px', width: 3 / 4 } : { width: '3px' }}
+          />
+        }
+      >
+        <RenderCallToActionSection isReallySmallScreen={isReallySmallScreen} />
+        <RenderCompanyInfoSection isReallySmallScreen={isReallySmallScreen} />
+        <RenderCopyrightAndLinksSection isReallySmallScreen={isReallySmallScreen} />
+      </Stack>
     </Box>
   );
 };

--- a/src/components/Form/FormSection.jsx
+++ b/src/components/Form/FormSection.jsx
@@ -3,8 +3,6 @@ import React from 'react';
 // Material UI Imports
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { useTheme } from '@mui/material/styles';
 
 /**
  * FormSection Component - Component that wraps section with title and MUI Box
@@ -19,29 +17,24 @@ import { useTheme } from '@mui/material/styles';
  * @param {React.ReactElement} Props.children - JSX Element of the wrapped form
  * @returns {React.JSX.Element} - The FormSection Component
  */
-const FormSection = ({ title, headingId, children }) => {
-  const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
-
-  return (
-    <Box
-      sx={{
-        marginTop: 1,
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        alignItems: 'center',
-        mx: '3px',
-        padding: isSmallScreen ? '10px' : '20px',
-        minWidth: '50%'
-      }}
-    >
-      <Typography variant="h2" align="center" mb={2} sx={{ fontSize: '20px' }} id={headingId}>
-        {title}
-      </Typography>
-      {children}
-    </Box>
-  );
-};
+const FormSection = ({ title, headingId, children }) => (
+  <Box
+    sx={{
+      marginTop: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      alignItems: 'center',
+      mx: '3px',
+      padding: '16px',
+      minWidth: '50%'
+    }}
+  >
+    <Typography variant="h2" align="center" mb={2} sx={{ fontSize: '20px' }} id={headingId}>
+      {title}
+    </Typography>
+    {children}
+  </Box>
+);
 
 export default FormSection;

--- a/src/components/Home/HomeSection.jsx
+++ b/src/components/Home/HomeSection.jsx
@@ -19,7 +19,6 @@ import Typography from '@mui/material/Typography';
  * @param {string} Props.button - section button
  * @param {string} Props.href - section button href
  * @param {string} Props.label - section button aria-label
- * @param {boolean} Props.isReallySmallScreen - screen size
  * @param {boolean} Props.hasMargin - gives marginBottom
  * @returns {React.JSX.Element} - the home section component
  */
@@ -31,7 +30,6 @@ const HomeSection = ({
   button,
   href,
   label,
-  isReallySmallScreen,
   hasMargin
 }) => (
   <Stack mb={hasMargin ? 8 : null} alignItems="center">
@@ -40,7 +38,7 @@ const HomeSection = ({
       src={componentImageSrc}
       alt={componentImageAlt}
       sx={{
-        width: isReallySmallScreen ? '80%' : '300px'
+        width: '300px'
       }}
     />
     <Typography
@@ -58,7 +56,7 @@ const HomeSection = ({
         data-testid="testDescription"
         sx={{
           color: 'primary.dark',
-          width: isReallySmallScreen ? '100%' : '85%',
+          width: '100%',
           marginBottom: '24px'
         }}
       >
@@ -72,8 +70,7 @@ const HomeSection = ({
         aria-label={label}
         sx={{
           my: '1rem',
-          backgroundColor: 'primary.light',
-          width: isReallySmallScreen ? 1 : 1 / 4
+          backgroundColor: 'primary.light'
         }}
       >
         {button}

--- a/src/components/Home/KeyFeatures.jsx
+++ b/src/components/Home/KeyFeatures.jsx
@@ -14,10 +14,9 @@ import Typography from '@mui/material/Typography';
  * @param {string} Props.icon - icon
  * @param {string} Props.title - key feature title
  * @param {string} Props.description - key feature description
- * @param {boolean} Props.isReallySmallScreen - screen size
  * @returns {React.JSX.Element} the KeyFeatures section component
  */
-const KeyFeatures = ({ icon, title, description, isReallySmallScreen }) => (
+const KeyFeatures = ({ icon, title, description }) => (
   <Stack alignItems="center">
     <Box
       sx={{
@@ -44,7 +43,6 @@ const KeyFeatures = ({ icon, title, description, isReallySmallScreen }) => (
     <Typography
       variant="body1"
       sx={{
-        width: isReallySmallScreen ? 1 : '85%',
         textAlign: 'center',
         color: 'primary.dark',
         marginBottom: '50px'

--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -4,8 +4,6 @@ import React from 'react';
 import { useSession, useNotification } from '@hooks';
 // Material UI Imports
 import Box from '@mui/material/Box';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { useTheme } from '@mui/system';
 // Component Imports
 import { NavBar, NavBarSkipLink } from '@components/NavBar';
 import { InactivityMessage, NotificationContainer } from '@components/Notification';
@@ -16,21 +14,12 @@ import Main from './Main';
 const Layout = ({ ariaLabel, children }) => {
   const { session } = useSession();
   const { state } = useNotification();
-  const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
-
-  const isLoggedInSmallScreen = () =>
-    session.info.isLoggedIn ? '64px 64px 1fr 560px' : '64px 1fr 560px';
-
-  const isLoggedInDesktop = () =>
-    session.info.isLoggedIn ? '64px 64px 1fr 280px' : '64px 1fr 280px';
 
   return (
     <Box
       aria-label={ariaLabel}
       sx={{
         display: 'grid',
-        gridTemplateRows: isSmallScreen ? isLoggedInSmallScreen() : isLoggedInDesktop(),
         minHeight: '100vh'
       }}
     >

--- a/test/components/Footer/Footer.test.jsx
+++ b/test/components/Footer/Footer.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { render, cleanup, screen } from '@testing-library/react';
-import { expect, it, afterEach, describe } from 'vitest';
+import { expect, it, afterEach, describe, vi } from 'vitest';
 import { SessionContext } from '@contexts';
 import { ThemeProvider } from '@mui/material/styles';
 import theme from '../../../src/theme';
@@ -11,6 +11,11 @@ import Footer from '../../../src/components/Footer/Footer';
 afterEach(() => {
   cleanup();
 });
+
+vi.mock('@mui/material/useMediaQuery', async (importOriginal) => ({
+  ...importOriginal,
+  default: () => true
+}));
 
 describe('Footer', () => {
   it('renders `h2` elements for headings', () => {
@@ -27,5 +32,19 @@ describe('Footer', () => {
     const headings = screen.getAllByRole('heading', { level: 2 });
 
     expect(headings.length).toBe(2);
+  });
+
+  it('renders column when screen is small', () => {
+    const { getAllByRole } = render(
+      <SessionContext.Provider value={{ session: { info: { isLoggedIn: false } } }}>
+        <ThemeProvider theme={theme}>
+          <BrowserRouter>
+            <Footer />
+          </BrowserRouter>
+        </ThemeProvider>
+      </SessionContext.Provider>
+    );
+
+    expect(getAllByRole('separator').length).not.toBe(0);
   });
 });

--- a/test/components/Form/FormSection.test.jsx
+++ b/test/components/Form/FormSection.test.jsx
@@ -2,28 +2,16 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { expect, it } from 'vitest';
 import { FormSection } from '@components/Form';
-import createMatchMedia from '../../helpers/createMatchMedia';
 
 const MockChildrenComponent = () => <div />;
 
 const MockFormSection = () => (
-  <FormSection title="Example Title">
+  <FormSection title="Example Title" headingId="test">
     <MockChildrenComponent />
   </FormSection>
 );
 
-it('renders 20px padding by default', () => {
+it('renders', () => {
   const component = render(<MockFormSection />);
-  const adjustableBox = getComputedStyle(component.container.firstChild);
-
-  expect(adjustableBox.padding).toBe('20px');
-});
-
-it("renders 10px padding after MUI breakpoint 'sm' is triggered", () => {
-  window.matchMedia = createMatchMedia(599);
-
-  const component = render(<MockFormSection />);
-  const adjustableBox = getComputedStyle(component.container.firstChild);
-
-  expect(adjustableBox.padding).toBe('10px');
+  expect(component.getByText('Example Title')).not.toBeNull();
 });

--- a/test/components/Home/HomeSection.test.jsx
+++ b/test/components/Home/HomeSection.test.jsx
@@ -2,15 +2,10 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { expect, it, describe } from 'vitest';
 import { HomeSection } from '@components/Home';
-import createMatchMedia from '../../helpers/createMatchMedia';
 
 const MockSection = () => <HomeSection />;
-const MockSectionDescription = () => <HomeSection description="Example Text" />;
-const MockSectionDescriptionMobile = () => (
-  <HomeSection isReallySmallScreen description="Example Text" />
-);
 const MockSectionButton = () => <HomeSection button="button" />;
-const MockSectionButtonMobile = () => <HomeSection isReallySmallScreen button="button" />;
+const MockSectionDescription = () => <HomeSection description="Example Text" />;
 
 describe('Button rendering', () => {
   it('renders no button', () => {
@@ -28,16 +23,6 @@ describe('Button rendering', () => {
     expect(button).not.toBeNull();
     expect(buttonStyles.width).not.toBe('100%');
   });
-
-  it('renders button mobile', () => {
-    window.matchMedia = createMatchMedia(599);
-    const { queryByRole } = render(<MockSectionButtonMobile />);
-    const button = queryByRole('button');
-    const buttonStyles = getComputedStyle(button);
-
-    expect(button).not.toBeNull();
-    expect(buttonStyles.width).toBe('100%');
-  });
 });
 
 describe('Description rendering', () => {
@@ -51,34 +36,14 @@ describe('Description rendering', () => {
   it('renders description', () => {
     const { queryByText } = render(<MockSectionDescription />);
     const description = queryByText('Example Text');
-    const descriptionStyles = getComputedStyle(description);
-
-    expect(descriptionStyles.width).not.toBe('100%');
-  });
-
-  it('renders description mobile', () => {
-    window.matchMedia = createMatchMedia(599);
-    const { queryByText } = render(<MockSectionDescriptionMobile />);
-    const description = queryByText('Example Text');
-    const descriptionStyles = getComputedStyle(description);
-
-    expect(descriptionStyles.width).toBe('100%');
+    expect(description).not.toBeNull();
   });
 });
 
 describe('Image rendering', () => {
   it('renders image at 300px width on desktop', () => {
     const { queryByRole } = render(<MockSectionDescription />);
-    const image = getComputedStyle(queryByRole('img'));
-
-    expect(image.width).toBe('300px');
-  });
-
-  it('renders image at 80% width on mobile', () => {
-    window.matchMedia = createMatchMedia(599);
-    const { queryByRole } = render(<MockSectionDescriptionMobile />);
-    const image = getComputedStyle(queryByRole('img'));
-
-    expect(image.width).toBe('80%');
+    const image = queryByRole('img');
+    expect(image).not.toBeNull();
   });
 });

--- a/test/components/Home/KeyFeatures.test.jsx
+++ b/test/components/Home/KeyFeatures.test.jsx
@@ -2,24 +2,11 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { expect, it } from 'vitest';
 import { KeyFeatures } from '@components/Home';
-import createMatchMedia from '../../helpers/createMatchMedia';
 
 const MockKeyFeaturesDefault = () => <KeyFeatures description="Example Text" />;
-const MockKeyFeaturesMobile = () => <KeyFeatures isReallySmallScreen description="Example Text" />;
 
 it('renders less width by default', () => {
   const { getByText } = render(<MockKeyFeaturesDefault />);
   const description = getByText('Example Text');
-  const descriptionStyles = getComputedStyle(description);
-
-  expect(descriptionStyles.width).not.toBe('100%');
-});
-
-it('renders 100% width mobile', () => {
-  window.matchMedia = createMatchMedia(599);
-  const { getByText } = render(<MockKeyFeaturesMobile />);
-  const description = getByText('Example Text');
-  const descriptionStyles = getComputedStyle(description);
-
-  expect(descriptionStyles.width).toBe('100%');
+  expect(description).not.toBeNull();
 });

--- a/test/layouts/Layout.test.jsx
+++ b/test/layouts/Layout.test.jsx
@@ -8,7 +8,6 @@ import { ThemeProvider } from '@mui/material/styles';
 import { NavBar } from '@components/NavBar';
 import Layout from '../../src/layouts/Layout';
 import theme from '../../src/theme';
-import createMatchMedia from '../helpers/createMatchMedia';
 
 const MockLayout = () => (
   <ThemeProvider theme={theme}>
@@ -45,9 +44,8 @@ describe('Desktop view', () => {
     expect(breadcrumb).not.toBeNull();
 
     const test = queryByLabelText('test');
-    const cssProperty = getComputedStyle(test);
 
-    expect(cssProperty['grid-template-rows']).toBe('64px 64px 1fr 280px');
+    expect(test).not.toBeNull();
   });
 
   it('renders no breadcrumbs, layout grid-template-rows as 64px 1fr 280px when logged out', () => {
@@ -61,57 +59,7 @@ describe('Desktop view', () => {
     expect(breadcrumb).toBeNull();
 
     const test = queryByLabelText('test');
-    const cssProperty = getComputedStyle(test);
 
-    expect(cssProperty['grid-template-rows']).toBe('64px 1fr 280px');
-  });
-});
-
-describe('Mobile view below 600px', () => {
-  it('Renders breadcrumb when logged in, layout grid-template-rows as 64px 64px 1fr 560px', () => {
-    window.matchMedia = createMatchMedia(599);
-    vi.spyOn(hooks, 'useNotification').mockReturnValue({
-      state: { notifications: [] }
-    });
-    const { queryByLabelText } = render(
-      <SessionContext.Provider
-        value={{
-          session: {
-            info: {
-              isLoggedIn: true,
-              webId: 'https://example.com/pod/profile/card#me'
-            }
-          }
-        }}
-      >
-        <MockLayout />
-      </SessionContext.Provider>
-    );
-
-    const breadcrumb = queryByLabelText('breadcrumb');
-
-    expect(breadcrumb).not.toBeNull();
-
-    const test = queryByLabelText('test');
-    const cssProperty = getComputedStyle(test);
-
-    expect(cssProperty['grid-template-rows']).toBe('64px 64px 1fr 560px');
-  });
-
-  it('renders no breadcrumbs, layout grid-template-rows as 64px 1fr 560px when logged out', () => {
-    window.matchMedia = createMatchMedia(599);
-    vi.spyOn(hooks, 'useNotification').mockReturnValue({
-      state: { notifications: [] }
-    });
-    const { queryByLabelText } = render(<MockLayout />);
-
-    const breadcrumb = queryByLabelText('breadcrumb');
-
-    expect(breadcrumb).toBeNull();
-
-    const test = queryByLabelText('test');
-    const cssProperty = getComputedStyle(test);
-
-    expect(cssProperty['grid-template-rows']).toBe('64px 1fr 560px');
+    expect(test).not.toBeNull();
   });
 });


### PR DESCRIPTION
This PR removes a lot of unnecessary code around resizing, and some now unneeded test cases.

In general, I think we should be able to mock `useMediaQuery` instead of modifying the window object in future tests.