### PR TITLE
[ no issue ] UI tweaks to Profile page

### DIFF
--- a/src/components/Modals/AddContactModal.jsx
+++ b/src/components/Modals/AddContactModal.jsx
@@ -146,7 +146,6 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
             autoComplete="username"
             value={username}
             onChange={(e) => wrappedSetUsername(e.target.value)}
-            required
             fullWidth
           />
           <TextField

--- a/src/components/Profile/ProfileComponent.jsx
+++ b/src/components/Profile/ProfileComponent.jsx
@@ -124,7 +124,22 @@ const ProfileComponent = ({ contactProfile, webId }) => {
             setInputValue={setNickname}
             edit={edit}
           />
-          <ProfileInputField inputName="WebId" inputValue={webId} />
+          <ProfileInputField
+            inputName="WebId"
+            inputValue={webId}
+            endAdornment={
+              <IconButton
+                aria-label="Copy WebId"
+                edge="end"
+                onClick={() => {
+                  navigator.clipboard.writeText(webId);
+                  addNotification('success', 'webId copied to clipboard');
+                }}
+              >
+                <ContentCopyIcon />
+              </IconButton>
+            }
+          />
         </Box>
         {!contactProfile && (
           <Box sx={{ display: 'flex', flexDirection: 'row', gap: '10px' }}>

--- a/src/components/Profile/ProfileComponent.jsx
+++ b/src/components/Profile/ProfileComponent.jsx
@@ -21,10 +21,11 @@ import ProfileEditButtonGroup from './ProfileEditButtonGroup';
  * @name ProfileComponent
  * @param {object} Props - Props for ClientProfile component
  * @param {object} [Props.contactProfile] - Contact object with data from profile
+ * @param {string} [Props.webId] - The webId of the contact
  * or null if user profile is selected
  * @returns {React.JSX.Element} The UserProfile Component
  */
-const ProfileComponent = ({ contactProfile }) => {
+const ProfileComponent = ({ contactProfile, webId }) => {
   const { session } = useSession();
   const { updateProfileInfo, setProfileData, profileData, fetchProfileInfo } =
     useContext(SignedInUserContext);
@@ -116,6 +117,7 @@ const ProfileComponent = ({ contactProfile }) => {
             setInputValue={setNickname}
             edit={edit}
           />
+          <ProfileInputField inputName="WebId" inputValue={webId} />
         </Box>
         {!contactProfile && (
           <ProfileEditButtonGroup

--- a/src/components/Profile/ProfileComponent.jsx
+++ b/src/components/Profile/ProfileComponent.jsx
@@ -137,13 +137,15 @@ const ProfileComponent = ({ contactProfile, webId }) => {
               <a href={signupLink} rel="noopener noreferrer" target="_blank">
                 Your Invite Link
               </a>
-              <IconButton aria-label="Copy Invite Link" edge="end">
-                <ContentCopyIcon
-                  onClick={() => {
-                    navigator.clipboard.writeText(signupLink);
-                    addNotification('success', 'Invite link copied to clipboard');
-                  }}
-                />
+              <IconButton
+                aria-label="Copy Invite Link"
+                edge="end"
+                onClick={() => {
+                  navigator.clipboard.writeText(signupLink);
+                  addNotification('success', 'Invite link copied to clipboard');
+                }}
+              >
+                <ContentCopyIcon />
               </IconButton>
             </Typography>
           </Box>

--- a/src/components/Profile/ProfileComponent.jsx
+++ b/src/components/Profile/ProfileComponent.jsx
@@ -1,9 +1,12 @@
 // React Imports
 import React, { useContext, useEffect, useState } from 'react';
 // Custom Hook Imports
-import { useSession } from '@hooks';
+import { useNotification, useSession } from '@hooks';
 // Material UI Imports
 import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 // Context Imports
@@ -27,6 +30,7 @@ import ProfileEditButtonGroup from './ProfileEditButtonGroup';
  */
 const ProfileComponent = ({ contactProfile, webId }) => {
   const { session } = useSession();
+  const { addNotification } = useNotification();
   const { updateProfileInfo, setProfileData, profileData, fetchProfileInfo } =
     useContext(SignedInUserContext);
 
@@ -73,6 +77,9 @@ const ProfileComponent = ({ contactProfile, webId }) => {
 
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+  const signupLink = `${window.location.origin}/signup?webId=${encodeURIComponent(
+    session.info.webId
+  )}`;
 
   return (
     <Box
@@ -120,11 +127,26 @@ const ProfileComponent = ({ contactProfile, webId }) => {
           <ProfileInputField inputName="WebId" inputValue={webId} />
         </Box>
         {!contactProfile && (
-          <ProfileEditButtonGroup
-            edit={edit}
-            handleCancelEdit={handleCancelEdit}
-            handleEditInput={handleEditInput}
-          />
+          <Box sx={{ display: 'flex', flexDirection: 'row', gap: '10px' }}>
+            <ProfileEditButtonGroup
+              edit={edit}
+              handleCancelEdit={handleCancelEdit}
+              handleEditInput={handleEditInput}
+            />
+            <Typography sx={{ marginTop: '8px' }}>
+              <a href={signupLink} rel="noopener noreferrer" target="_blank">
+                Your Invite Link
+              </a>
+              <IconButton aria-label="Copy Invite Link" edge="end">
+                <ContentCopyIcon
+                  onClick={() => {
+                    navigator.clipboard.writeText(signupLink);
+                    addNotification('success', 'Invite link copied to clipboard');
+                  }}
+                />
+              </IconButton>
+            </Typography>
+          </Box>
         )}
       </form>
     </Box>

--- a/src/components/Profile/ProfileImageField.jsx
+++ b/src/components/Profile/ProfileImageField.jsx
@@ -8,7 +8,6 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import HideImageIcon from '@mui/icons-material/HideImage';
 import ImageIcon from '@mui/icons-material/Image';
-import Typography from '@mui/material/Typography';
 // Contexts Imports
 import { SignedInUserContext } from '@contexts';
 import useNotification from '../../hooks/useNotification';
@@ -69,7 +68,6 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
         gap: '10px'
       }}
     >
-      <Typography color="black">Profile Image: </Typography>
       <Avatar
         src={contactProfile ? contactProfile.profileImage : profileImg}
         alt="PASS profile"

--- a/src/components/Profile/ProfileInputField.jsx
+++ b/src/components/Profile/ProfileInputField.jsx
@@ -17,9 +17,10 @@ import InputLabel from '@mui/material/InputLabel';
  * @param {(value: React.SetStateAction<string|null>) => void} Props.setInputValue
  * - Set function for inputValue
  * @param {boolean} Props.edit - Boolean used to toggle edit inputs
+ * @param {React.JSX.Element} Props.endAdornment - optional end adornment for input
  * @returns {React.JSX.Element} React component for NewMessage
  */
-const ProfileInputField = ({ inputName, inputValue, setInputValue, edit }) => (
+const ProfileInputField = ({ inputName, inputValue, setInputValue, edit, endAdornment }) => (
   <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
     <InputLabel htmlFor={`input-${inputName}`} sx={{ color: 'black' }}>
       {inputName}:
@@ -30,6 +31,7 @@ const ProfileInputField = ({ inputName, inputValue, setInputValue, edit }) => (
       placeholder={inputValue || 'No value set'}
       disabled={!edit}
       onChange={(e) => setInputValue(e.target.value)}
+      endAdornment={endAdornment}
     />
   </Box>
 );

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -8,8 +8,6 @@ import AddIcon from '@mui/icons-material/Add';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
-import IconButton from '@mui/material/IconButton';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import Container from '@mui/material/Container';
 import ShareIcon from '@mui/icons-material/Share';
 import Typography from '@mui/material/Typography';
@@ -127,10 +125,6 @@ const Profile = () => {
     );
   }
 
-  const signupLink = `${window.location.origin}/signup?webId=${encodeURIComponent(
-    session.info.webId
-  )}`;
-
   return (
     <Container
       sx={{
@@ -142,21 +136,6 @@ const Profile = () => {
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '20px', alignItems: 'center' }}>
         <Typography sx={{ fontWeight: 'bold', fontSize: '18px' }}>Profile Information</Typography>
-        {!contact ? (
-          <Typography>
-            <a href={signupLink} rel="noopener noreferrer" target="_blank">
-              Your Invite Link
-            </a>
-            <IconButton aria-label="Copy Invite Link" edge="end">
-              <ContentCopyIcon
-                onClick={() => {
-                  navigator.clipboard.writeText(signupLink);
-                  addNotification('success', 'Invite link copied to clipboard');
-                }}
-              />
-            </IconButton>
-          </Typography>
-        ) : null}
         <Box
           sx={{
             display: 'flex',

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,6 +1,6 @@
 // React Imports
 import React, { useContext, useEffect, useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 // Custom Hook Imports
 import { useNotification, useSession } from '@hooks';
 // Material UI Imports
@@ -143,7 +143,7 @@ const Profile = () => {
         {!contact ? (
           <Typography>
             <a href={signupLink} rel="noopener noreferrer" target="_blank">
-              Your Signup Link
+              Your Invite Link
             </a>
           </Typography>
         ) : null}
@@ -155,24 +155,8 @@ const Profile = () => {
             justifyContent: 'center',
             flexDirection: isSmallScreen ? 'column' : 'row'
           }}
-        >
-          <Typography>User WebId: </Typography>
-          <Link
-            to={webIdUrl}
-            target="_blank"
-            rel="noreferrer"
-            style={{
-              maxWidth: isSmallScreen ? '240px' : 'none',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis'
-            }}
-          >
-            {webIdUrl}
-          </Link>
-        </Box>
-
-        <ProfileComponent contactProfile={contactProfile} />
+        />
+        <ProfileComponent contactProfile={contactProfile} webId={webIdUrl} />
 
         <Container
           sx={{

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -8,6 +8,8 @@ import AddIcon from '@mui/icons-material/Add';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import Container from '@mui/material/Container';
 import ShareIcon from '@mui/icons-material/Share';
 import Typography from '@mui/material/Typography';
@@ -145,6 +147,14 @@ const Profile = () => {
             <a href={signupLink} rel="noopener noreferrer" target="_blank">
               Your Invite Link
             </a>
+            <IconButton aria-label="Copy Invite Link" edge="end">
+              <ContentCopyIcon
+                onClick={() => {
+                  navigator.clipboard.writeText(signupLink);
+                  addNotification('success', 'Invite link copied to clipboard');
+                }}
+              />
+            </IconButton>
           </Typography>
         ) : null}
         <Box


### PR DESCRIPTION
Small tweaks to the profile page to make it look a little cleaner. We had a few links floating at the top just to have a place to put them. Now they're better integrated into the design.
 
- Moved the "web ID" field and the "signup link" field into the profile card itself.
- Renamed "signup link" to "invite link" to better describe its intended purpose
- added a copy button that copies the invite link to the system clipboard
- Removed some redundant text
- Removed the required field requirement from username in the contacts modal

Before:
![image](https://github.com/codeforpdx/PASS/assets/37914436/c5051587-0dde-4b9d-8fa6-ff3d67a9c166)

After:
![image](https://github.com/codeforpdx/PASS/assets/37914436/dd9519ce-ca1f-4e4b-aa0a-68a2e4b16d3f)
