### PR TITLE
[ no issue ] Remove unused buttons from navbar

### DIFF
--- a/src/components/NavBar/NavMenu.jsx
+++ b/src/components/NavBar/NavMenu.jsx
@@ -13,8 +13,6 @@ import LogoutIcon from '@mui/icons-material/Logout';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import MenuList from '@mui/material/MenuList';
-import NotificationsIcon from '@mui/icons-material/Notifications';
-import SettingsIcon from '@mui/icons-material/Settings';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 // Context Imports
@@ -35,7 +33,6 @@ import { useMessageList } from '@hooks';
  * @param {React.Dispatch<any>} Props.setAnchorEl - The set function for anchorEl
  * @param {React.Dispatch<React.SetStateAction<boolean>>} Props.setShowConfirmation
  * - The set function for showConfirmationModal
- * @param {(event) => void} Props.handleNotificationsMenu - Handler function for
  * Notification Menu
  * @param {string} Props.profileImg - String for profile image
  * @returns {React.JSX.Element} - The NavMenu Component
@@ -47,7 +44,6 @@ const NavMenu = ({
   anchorEl,
   setAnchorEl,
   setShowConfirmation,
-  handleNotificationsMenu,
   profileImg
 }) => {
   const theme = useTheme();
@@ -147,20 +143,6 @@ const NavMenu = ({
             Messages
           </MenuItem>
         </Link>
-        {/* notifications */}
-        <MenuItem
-          component={Button}
-          startIcon={<NotificationsIcon sx={{ height: '24px', width: '24px' }} />}
-          onClick={handleNotificationsMenu}
-          sx={{
-            display: { md: 'none' },
-            color: theme.palette.primary.main,
-            width: '100%',
-            minHeight: '36px'
-          }}
-        >
-          Notifications
-        </MenuItem>
         {/* profile */}
         <Link
           to="/profile"
@@ -189,14 +171,6 @@ const NavMenu = ({
           </MenuItem>
         </Link>
         <Divider sx={{ marginY: '5px' }} />
-        {/* settings */}
-        <MenuItem
-          component={Button}
-          startIcon={<SettingsIcon sx={{ height: '24px', width: '24px' }} />}
-          sx={{ color: theme.palette.primary.main, width: '100%', minHeight: '36px' }}
-        >
-          Settings
-        </MenuItem>
         {/* logout */}
         <MenuItem
           component={Button}

--- a/src/components/NavBar/NavbarDesktop.jsx
+++ b/src/components/NavBar/NavbarDesktop.jsx
@@ -9,11 +9,7 @@ import Badge from '@mui/material/Badge';
 import Box from '@mui/material/Box';
 import EmailIcon from '@mui/icons-material/Email';
 import IconButton from '@mui/material/IconButton';
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
-import NotificationsIcon from '@mui/icons-material/Notifications';
 import Toolbar from '@mui/material/Toolbar';
-import { useTheme } from '@mui/material/styles';
 // Custom Hook Imports
 import { useMessageList } from '@hooks';
 // Component Imports
@@ -33,24 +29,14 @@ import NavMenu from './NavMenu';
  * @returns {React.JSX.Element} - The Desktop version of Navbar Component
  */
 const NavbarDesktop = ({ setShowConfirmation }) => {
-  const theme = useTheme();
   const { data } = useMessageList('Inbox');
 
   const numUnreadMessages = data?.reduce((a, m) => (!m.readStatus ? a + 1 : a), 0);
 
   // states for NavMenu component
   const [anchorEl, setAnchorEl] = useState(null);
-  const [anchorElNotifications, setAnchorElNotifications] = useState(null);
   const [openMenu, setOpenMenu] = useState(false);
   const menuId = 'primary-search-account-menu';
-
-  const handleNotificationsMenu = (event) => {
-    setAnchorElNotifications(event.currentTarget);
-  };
-
-  const handleNotificationsClose = () => {
-    setAnchorElNotifications(null);
-  };
 
   const handleOpenMenu = (event) => {
     setAnchorEl(event.currentTarget);
@@ -88,49 +74,6 @@ const NavbarDesktop = ({ setShowConfirmation }) => {
                 <EmailIcon />
               </Badge>
             </IconButton>
-            {/* notifications icon */}
-            <IconButton
-              size="large"
-              aria-label="Show notifications"
-              color="inherit"
-              onClick={handleNotificationsMenu}
-              edge="start"
-            >
-              <Badge color="error">
-                <NotificationsIcon />
-              </Badge>
-            </IconButton>
-            {/* notifications menu */}
-            <Menu
-              id="menu-appbar-notifications"
-              anchorEl={anchorElNotifications}
-              anchorOrigin={{
-                vertical: 'bottom',
-                horizontal: 'right'
-              }}
-              keepMounted
-              transformOrigin={{
-                vertical: 'top',
-                horizontal: 'right'
-              }}
-              open={Boolean(anchorElNotifications)}
-              onClose={handleNotificationsClose}
-              slotProps={{
-                paper: {
-                  style: {
-                    marginTop: '10px'
-                  }
-                }
-              }}
-              sx={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
-            >
-              <MenuItem onClick={handleNotificationsClose}>
-                <p style={{ color: theme.palette.primary.main }}>Notification 1</p>
-              </MenuItem>
-              <MenuItem onClick={handleNotificationsClose}>
-                <p style={{ color: theme.palette.primary.main }}>Notification 2</p>
-              </MenuItem>
-            </Menu>
             {/* profile icon */}
             <IconButton
               size="large"
@@ -157,7 +100,6 @@ const NavbarDesktop = ({ setShowConfirmation }) => {
               anchorEl={anchorEl}
               setAnchorEl={setAnchorEl}
               setShowConfirmation={setShowConfirmation}
-              handleNotificationsMenu={handleNotificationsMenu}
               profileImg={profileImg}
             />
           )}


### PR DESCRIPTION
Remove unused buttons from navbar. 

They're placeholders for features we were considering at one point. However, it's not clear with the current feature set if these buttons would ever be used (the notifications bell doesn't match with current UX trends).

It also makes onboarding more difficult because new users can't tell if the button isn't supposed to work, or if they're doing something wrong.

Before:

![image](https://github.com/codeforpdx/PASS/assets/37914436/3ae9001b-ce1d-4200-b8f2-592c6377fa78)
 ---
![image](https://github.com/codeforpdx/PASS/assets/37914436/f6d8dc56-8e87-47a3-ab67-e3849c94cf25)


After:
![image](https://github.com/codeforpdx/PASS/assets/37914436/e005e60c-5f85-43bd-900f-ce93affc2ca0)
---
![image](https://github.com/codeforpdx/PASS/assets/37914436/ee44f252-7b4b-4926-8e57-ca04a2971599)
