### PR TITLE
[no issue] Update inrupt libraries to version 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@emotion/react": "^11.10.8",
         "@emotion/styled": "^11.10.8",
-        "@inrupt/solid-client": "^1.24.0",
-        "@inrupt/solid-client-authn-browser": "1.15.0",
+        "@inrupt/solid-client": "^2.0.0",
+        "@inrupt/solid-client-authn-browser": "^2.0.0",
         "@inrupt/vocab-common-rdf": "^1.0.5",
         "@mui/base": "^5.0.0-beta.0",
         "@mui/icons-material": "^5.11.16",
@@ -3025,13 +3025,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@floating-ui/core": {
       "version": "1.5.0",
       "license": "MIT",
@@ -3094,7 +3087,8 @@
     },
     "node_modules/@inrupt/oidc-client": {
       "version": "1.11.6",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client/-/oidc-client-1.11.6.tgz",
+      "integrity": "sha512-1rCTk1T6pdm/7gKozutZutk7jwmYBADlnkGGoI5ypke099NOCa5KFXjkQpbjsps0PRkKZ+0EaR70XN5+xqmViA==",
       "dependencies": {
         "acorn": "^7.4.1",
         "base64-js": "^1.5.1",
@@ -3104,64 +3098,82 @@
       }
     },
     "node_modules/@inrupt/oidc-client-ext": {
-      "version": "1.17.3",
-      "license": "MIT",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-2.0.0.tgz",
+      "integrity": "sha512-SYkesE26mXXIyNInq1XwEZd97yfk0nj3xXbreEmPX8pqbOi6fHhACKrg33KHTVTMuZIe1D+xJs5QA0GhxLf+eg==",
       "dependencies": {
         "@inrupt/oidc-client": "^1.11.6",
-        "@inrupt/solid-client-authn-core": "^1.17.3",
-        "@inrupt/universal-fetch": "^1.0.1",
-        "jose": "^4.14.6",
+        "@inrupt/solid-client-authn-core": "^2.0.0",
+        "jose": "^5.1.3",
         "uuid": "^9.0.1"
+      }
+    },
+    "node_modules/@inrupt/oidc-client-ext/node_modules/jose": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.2.tgz",
+      "integrity": "sha512-/WByRr4jDcsKlvMd1dRJnPfS1GVO3WuKyaurJ/vvXcOaUQO8rnNObCQMlv/5uCceVQIq5Q4WLF44ohsdiTohdg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@inrupt/solid-client": {
-      "version": "1.30.2",
-      "license": "MIT",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-2.0.0.tgz",
+      "integrity": "sha512-3ojzIb7zks8T7uvEEW346vOw9RGi61IEHjaIoRCoORUkx6ZsYuoUKv3XyLTfYPVl8Q9Tl2avBe+1U60nHxl16A==",
       "dependencies": {
-        "@inrupt/universal-fetch": "^1.0.1",
-        "@rdfjs/dataset": "^1.1.0",
-        "@types/rdfjs__dataset": "^1.0.4",
         "buffer": "^6.0.3",
-        "http-link-header": "^1.1.0",
-        "jsonld-context-parser": "^2.3.0",
-        "jsonld-streaming-parser": "^3.2.0",
-        "n3": "^1.10.0",
-        "uuid": "^9.0.0"
-      },
-      "engines": {
-        "node": "^16.0.0 || ^18.0.0 || ^20.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/@inrupt/solid-client-authn-browser": {
-      "version": "1.15.0",
-      "license": "MIT",
-      "dependencies": {
-        "@inrupt/oidc-client-ext": "^1.15.0",
-        "@inrupt/solid-client-authn-core": "^1.15.0",
-        "@inrupt/universal-fetch": "^1.0.1",
-        "@types/lodash.clonedeep": "^4.5.6",
-        "@types/node": "^18.0.3",
-        "@types/uuid": "^9.0.1",
-        "events": "^3.3.0",
-        "jose": "^4.3.7",
-        "lodash.clonedeep": "^4.5.0",
-        "uuid": "^9.0.0"
-      }
-    },
-    "node_modules/@inrupt/solid-client-authn-core": {
-      "version": "1.17.3",
-      "license": "MIT",
-      "dependencies": {
-        "@inrupt/universal-fetch": "^1.0.1",
-        "events": "^3.3.0",
-        "jose": "^4.14.6",
+        "http-link-header": "^1.1.1",
+        "jsonld-context-parser": "^2.4.0",
+        "jsonld-streaming-parser": "^3.3.0",
+        "n3": "^1.17.2",
         "uuid": "^9.0.1"
       },
       "engines": {
-        "node": "^16.0.0 || ^18.0.0 || ^20.0.0"
+        "node": "^18.0.0 || ^20.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/@inrupt/solid-client-authn-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-2.0.0.tgz",
+      "integrity": "sha512-Y+BczY8T2Xpfp2Obd3IAvlF91UCEgQMed2+9LM6FCBkVkk03CqbFL80ebO7mYd6woVVlIeC+8IB2UrRlNHqlkA==",
+      "dependencies": {
+        "@inrupt/oidc-client-ext": "^2.0.0",
+        "@inrupt/solid-client-authn-core": "^2.0.0",
+        "events": "^3.3.0",
+        "jose": "^5.1.3",
+        "uuid": "^9.0.1"
+      }
+    },
+    "node_modules/@inrupt/solid-client-authn-browser/node_modules/jose": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.2.tgz",
+      "integrity": "sha512-/WByRr4jDcsKlvMd1dRJnPfS1GVO3WuKyaurJ/vvXcOaUQO8rnNObCQMlv/5uCceVQIq5Q4WLF44ohsdiTohdg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@inrupt/solid-client-authn-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-2.0.0.tgz",
+      "integrity": "sha512-qM+E9I5u2DFlsfyoXossx8w0vKv8p+rXH98K9RUauJImpygQ3I3Ra6hSB2bwA1PdPQd5ttNg236oKe1sTT6Hqw==",
+      "dependencies": {
+        "events": "^3.3.0",
+        "jose": "^5.1.3",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0"
+      }
+    },
+    "node_modules/@inrupt/solid-client-authn-core/node_modules/jose": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.2.tgz",
+      "integrity": "sha512-/WByRr4jDcsKlvMd1dRJnPfS1GVO3WuKyaurJ/vvXcOaUQO8rnNObCQMlv/5uCceVQIq5Q4WLF44ohsdiTohdg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@inrupt/solid-client/node_modules/buffer": {
@@ -3184,17 +3196,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/@inrupt/universal-fetch": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.7",
-        "undici": "^5.19.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.0.0 || ^18.0.0 || ^20.0.0"
       }
     },
     "node_modules/@inrupt/vocab-common-rdf": {
@@ -3732,6 +3733,7 @@
     },
     "node_modules/@rdfjs/data-model": {
       "version": "1.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": ">=1.0.1"
@@ -3742,6 +3744,7 @@
     },
     "node_modules/@rdfjs/dataset": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/data-model": "^1.2.0"
@@ -4444,14 +4447,8 @@
     },
     "node_modules/@types/lodash": {
       "version": "4.14.200",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.8",
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/lodash.orderby": {
       "version": "4.6.8",
@@ -4577,13 +4574,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/rdfjs__dataset": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "rdf-js": "^4.0.2"
-      }
-    },
     "node_modules/@types/react": {
       "version": "18.2.34",
       "license": "MIT",
@@ -4699,6 +4689,7 @@
     },
     "node_modules/@types/uuid": {
       "version": "9.0.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -6049,9 +6040,10 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.33.2",
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.36.0.tgz",
+      "integrity": "sha512-mt7+TUBbTFg5+GngsAxeKBTl5/VS0guFeJacYge9OmHb+m058UwwIm41SE9T4Den7ClatV57B6TYTuJ0CX1MAw==",
       "hasInstallScript": true,
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -6105,7 +6097,8 @@
     },
     "node_modules/crypto-js": {
       "version": "4.2.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/css-color-keywords": {
       "version": "1.0.0",
@@ -9988,6 +9981,7 @@
     },
     "node_modules/jose": {
       "version": "4.15.4",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -10162,12 +10156,12 @@
       }
     },
     "node_modules/jsonld-context-parser": {
-      "version": "2.3.3",
-      "license": "MIT",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.4.0.tgz",
+      "integrity": "sha512-ZYOfvh525SdPd9ReYY58dxB3E2RUEU4DJ6ZibO8AitcowPeBH4L5rCAitE2om5G1P+HMEgYEYEr4EZKbVN4tpA==",
       "dependencies": {
         "@types/http-link-header": "^1.0.1",
         "@types/node": "^18.0.0",
-        "canonicalize": "^1.0.1",
         "cross-fetch": "^3.0.6",
         "http-link-header": "^1.0.2",
         "relative-to-absolute-iri": "^1.0.5"
@@ -10176,13 +10170,10 @@
         "jsonld-context-parse": "bin/jsonld-context-parse.js"
       }
     },
-    "node_modules/jsonld-context-parser/node_modules/canonicalize": {
-      "version": "1.0.8",
-      "license": "Apache-2.0"
-    },
     "node_modules/jsonld-streaming-parser": {
-      "version": "3.2.1",
-      "license": "MIT",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.3.0.tgz",
+      "integrity": "sha512-6aWiAsWGZioTB/vNQ3KenREz9ddEOliZoEETi+jLrlL7+vkgMeHjnxyFlGe4UOCU7SVUNPhz/lgLGZjnxgVYtA==",
       "dependencies": {
         "@bergos/jsonparse": "^1.4.0",
         "@rdfjs/types": "*",
@@ -10191,7 +10182,7 @@
         "buffer": "^6.0.3",
         "canonicalize": "^1.0.1",
         "http-link-header": "^1.0.2",
-        "jsonld-context-parser": "^2.3.0",
+        "jsonld-context-parser": "^2.4.0",
         "rdf-data-factory": "^1.1.0",
         "readable-stream": "^4.0.0"
       }
@@ -10535,10 +10526,6 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "license": "MIT"
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -11758,7 +11745,8 @@
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -11840,6 +11828,7 @@
     },
     "node_modules/rdf-js": {
       "version": "4.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "*"
@@ -12661,7 +12650,8 @@
     },
     "node_modules/serialize-javascript": {
       "version": "4.0.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -13770,16 +13760,6 @@
       "version": "1.13.6",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/undici": {
-      "version": "5.27.2",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
@@ -17059,9 +17039,6 @@
       "version": "8.53.0",
       "dev": true
     },
-    "@fastify/busboy": {
-      "version": "2.0.0"
-    },
     "@floating-ui/core": {
       "version": "1.5.0",
       "requires": {
@@ -17103,6 +17080,8 @@
     },
     "@inrupt/oidc-client": {
       "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client/-/oidc-client-1.11.6.tgz",
+      "integrity": "sha512-1rCTk1T6pdm/7gKozutZutk7jwmYBADlnkGGoI5ypke099NOCa5KFXjkQpbjsps0PRkKZ+0EaR70XN5+xqmViA==",
       "requires": {
         "acorn": "^7.4.1",
         "base64-js": "^1.5.1",
@@ -17112,28 +17091,35 @@
       }
     },
     "@inrupt/oidc-client-ext": {
-      "version": "1.17.3",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-2.0.0.tgz",
+      "integrity": "sha512-SYkesE26mXXIyNInq1XwEZd97yfk0nj3xXbreEmPX8pqbOi6fHhACKrg33KHTVTMuZIe1D+xJs5QA0GhxLf+eg==",
       "requires": {
         "@inrupt/oidc-client": "^1.11.6",
-        "@inrupt/solid-client-authn-core": "^1.17.3",
-        "@inrupt/universal-fetch": "^1.0.1",
-        "jose": "^4.14.6",
+        "@inrupt/solid-client-authn-core": "^2.0.0",
+        "jose": "^5.1.3",
         "uuid": "^9.0.1"
+      },
+      "dependencies": {
+        "jose": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.2.tgz",
+          "integrity": "sha512-/WByRr4jDcsKlvMd1dRJnPfS1GVO3WuKyaurJ/vvXcOaUQO8rnNObCQMlv/5uCceVQIq5Q4WLF44ohsdiTohdg=="
+        }
       }
     },
     "@inrupt/solid-client": {
-      "version": "1.30.2",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-2.0.0.tgz",
+      "integrity": "sha512-3ojzIb7zks8T7uvEEW346vOw9RGi61IEHjaIoRCoORUkx6ZsYuoUKv3XyLTfYPVl8Q9Tl2avBe+1U60nHxl16A==",
       "requires": {
-        "@inrupt/universal-fetch": "^1.0.1",
-        "@rdfjs/dataset": "^1.1.0",
-        "@types/rdfjs__dataset": "^1.0.4",
         "buffer": "^6.0.3",
-        "fsevents": "^2.3.2",
-        "http-link-header": "^1.1.0",
-        "jsonld-context-parser": "^2.3.0",
-        "jsonld-streaming-parser": "^3.2.0",
-        "n3": "^1.10.0",
-        "uuid": "^9.0.0"
+        "fsevents": "^2.3.3",
+        "http-link-header": "^1.1.1",
+        "jsonld-context-parser": "^2.4.0",
+        "jsonld-streaming-parser": "^3.3.0",
+        "n3": "^1.17.2",
+        "uuid": "^9.0.1"
       },
       "dependencies": {
         "buffer": {
@@ -17146,34 +17132,39 @@
       }
     },
     "@inrupt/solid-client-authn-browser": {
-      "version": "1.15.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-2.0.0.tgz",
+      "integrity": "sha512-Y+BczY8T2Xpfp2Obd3IAvlF91UCEgQMed2+9LM6FCBkVkk03CqbFL80ebO7mYd6woVVlIeC+8IB2UrRlNHqlkA==",
       "requires": {
-        "@inrupt/oidc-client-ext": "^1.15.0",
-        "@inrupt/solid-client-authn-core": "^1.15.0",
-        "@inrupt/universal-fetch": "^1.0.1",
-        "@types/lodash.clonedeep": "^4.5.6",
-        "@types/node": "^18.0.3",
-        "@types/uuid": "^9.0.1",
+        "@inrupt/oidc-client-ext": "^2.0.0",
+        "@inrupt/solid-client-authn-core": "^2.0.0",
         "events": "^3.3.0",
-        "jose": "^4.3.7",
-        "lodash.clonedeep": "^4.5.0",
-        "uuid": "^9.0.0"
+        "jose": "^5.1.3",
+        "uuid": "^9.0.1"
+      },
+      "dependencies": {
+        "jose": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.2.tgz",
+          "integrity": "sha512-/WByRr4jDcsKlvMd1dRJnPfS1GVO3WuKyaurJ/vvXcOaUQO8rnNObCQMlv/5uCceVQIq5Q4WLF44ohsdiTohdg=="
+        }
       }
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "1.17.3",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-2.0.0.tgz",
+      "integrity": "sha512-qM+E9I5u2DFlsfyoXossx8w0vKv8p+rXH98K9RUauJImpygQ3I3Ra6hSB2bwA1PdPQd5ttNg236oKe1sTT6Hqw==",
       "requires": {
-        "@inrupt/universal-fetch": "^1.0.1",
         "events": "^3.3.0",
-        "jose": "^4.14.6",
+        "jose": "^5.1.3",
         "uuid": "^9.0.1"
-      }
-    },
-    "@inrupt/universal-fetch": {
-      "version": "1.0.3",
-      "requires": {
-        "node-fetch": "^2.6.7",
-        "undici": "^5.19.1"
+      },
+      "dependencies": {
+        "jose": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.2.tgz",
+          "integrity": "sha512-/WByRr4jDcsKlvMd1dRJnPfS1GVO3WuKyaurJ/vvXcOaUQO8rnNObCQMlv/5uCceVQIq5Q4WLF44ohsdiTohdg=="
+        }
       }
     },
     "@inrupt/vocab-common-rdf": {
@@ -17412,12 +17403,14 @@
     },
     "@rdfjs/data-model": {
       "version": "1.3.4",
+      "dev": true,
       "requires": {
         "@rdfjs/types": ">=1.0.1"
       }
     },
     "@rdfjs/dataset": {
       "version": "1.1.1",
+      "dev": true,
       "requires": {
         "@rdfjs/data-model": "^1.2.0"
       }
@@ -17965,13 +17958,8 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.200"
-    },
-    "@types/lodash.clonedeep": {
-      "version": "4.5.8",
-      "requires": {
-        "@types/lodash": "*"
-      }
+      "version": "4.14.200",
+      "dev": true
     },
     "@types/lodash.orderby": {
       "version": "4.6.8",
@@ -18084,12 +18072,6 @@
         "@types/node": "*"
       }
     },
-    "@types/rdfjs__dataset": {
-      "version": "1.0.5",
-      "requires": {
-        "rdf-js": "^4.0.2"
-      }
-    },
     "@types/react": {
       "version": "18.2.34",
       "requires": {
@@ -18189,7 +18171,8 @@
       "dev": true
     },
     "@types/uuid": {
-      "version": "9.0.6"
+      "version": "9.0.6",
+      "dev": true
     },
     "@types/ws": {
       "version": "8.5.8",
@@ -19041,7 +19024,9 @@
       }
     },
     "core-js": {
-      "version": "3.33.2"
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.36.0.tgz",
+      "integrity": "sha512-mt7+TUBbTFg5+GngsAxeKBTl5/VS0guFeJacYge9OmHb+m058UwwIm41SE9T4Den7ClatV57B6TYTuJ0CX1MAw=="
     },
     "cors": {
       "version": "2.8.5",
@@ -19077,7 +19062,9 @@
       }
     },
     "crypto-js": {
-      "version": "4.2.0"
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "css-color-keywords": {
       "version": "1.0.0"
@@ -21588,7 +21575,8 @@
       }
     },
     "jose": {
-      "version": "4.15.4"
+      "version": "4.15.4",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0"
@@ -21705,23 +21693,21 @@
       }
     },
     "jsonld-context-parser": {
-      "version": "2.3.3",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.4.0.tgz",
+      "integrity": "sha512-ZYOfvh525SdPd9ReYY58dxB3E2RUEU4DJ6ZibO8AitcowPeBH4L5rCAitE2om5G1P+HMEgYEYEr4EZKbVN4tpA==",
       "requires": {
         "@types/http-link-header": "^1.0.1",
         "@types/node": "^18.0.0",
-        "canonicalize": "^1.0.1",
         "cross-fetch": "^3.0.6",
         "http-link-header": "^1.0.2",
         "relative-to-absolute-iri": "^1.0.5"
-      },
-      "dependencies": {
-        "canonicalize": {
-          "version": "1.0.8"
-        }
       }
     },
     "jsonld-streaming-parser": {
-      "version": "3.2.1",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.3.0.tgz",
+      "integrity": "sha512-6aWiAsWGZioTB/vNQ3KenREz9ddEOliZoEETi+jLrlL7+vkgMeHjnxyFlGe4UOCU7SVUNPhz/lgLGZjnxgVYtA==",
       "requires": {
         "@bergos/jsonparse": "^1.4.0",
         "@rdfjs/types": "*",
@@ -21730,7 +21716,7 @@
         "buffer": "^6.0.3",
         "canonicalize": "^1.0.1",
         "http-link-header": "^1.0.2",
-        "jsonld-context-parser": "^2.3.0",
+        "jsonld-context-parser": "^2.4.0",
         "rdf-data-factory": "^1.1.0",
         "readable-stream": "^4.0.0"
       },
@@ -21965,9 +21951,6 @@
     },
     "lodash": {
       "version": "4.17.21"
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0"
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -22714,6 +22697,8 @@
     },
     "randombytes": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -22786,6 +22771,7 @@
     },
     "rdf-js": {
       "version": "4.0.2",
+      "dev": true,
       "requires": {
         "@rdfjs/types": "*"
       }
@@ -23326,6 +23312,8 @@
     },
     "serialize-javascript": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
       "requires": {
         "randombytes": "^2.1.0"
       }
@@ -24054,12 +24042,6 @@
     "underscore": {
       "version": "1.13.6",
       "dev": true
-    },
-    "undici": {
-      "version": "5.27.2",
-      "requires": {
-        "@fastify/busboy": "^2.0.0"
-      }
     },
     "undici-types": {
       "version": "5.26.5"

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@emotion/react": "^11.10.8",
     "@emotion/styled": "^11.10.8",
-    "@inrupt/solid-client": "^1.24.0",
-    "@inrupt/solid-client-authn-browser": "1.15.0",
+    "@inrupt/solid-client": "^2.0.0",
+    "@inrupt/solid-client-authn-browser": "^2.0.0",
     "@inrupt/vocab-common-rdf": "^1.0.5",
     "@mui/base": "^5.0.0-beta.0",
     "@mui/icons-material": "^5.11.16",

--- a/src/contexts/SessionContext.jsx
+++ b/src/contexts/SessionContext.jsx
@@ -27,7 +27,7 @@ import {
   logout,
   handleIncomingRedirect,
   getDefaultSession,
-  onSessionRestore as onSessionRestoreClient
+  EVENTS
 } from '@inrupt/solid-client-authn-browser';
 
 import { getProfileAll, getPodUrlAll } from '@inrupt/solid-client';
@@ -57,7 +57,7 @@ export const SessionProvider = ({
 
   useEffect(() => {
     if (onSessionRestore !== undefined) {
-      onSessionRestoreClient(onSessionRestore);
+      session.events.on(EVENTS.SESSION_RESTORED, onSessionRestore);
     }
   }, [onSessionRestore]);
 
@@ -109,7 +109,7 @@ export const SessionProvider = ({
         setSessionRequestInProgress(false);
       });
 
-    getDefaultSession().on('logout', () => {
+    getDefaultSession().events.on('logout', () => {
       setSession(getDefaultSession());
     });
   }, [session, sessionId, onError, currentLocation, restoreSession, skipLoadingProfile]);


### PR DESCRIPTION
Inrupt updated its libraries to version 2 a little while ago. It has, among other things, a way to log out of both the app and the pod server at the same time. Let's update, since the more advanced logout will be helpful. Also, the documentation has been updated to reflect the new version.

However, the documentation updates have been haphazard, so not all the tutorials have been moved to the new version.