### PR TITLE
Issue 463/add remove image modal

### DIFF
--- a/src/components/Profile/ProfileImageField.jsx
+++ b/src/components/Profile/ProfileImageField.jsx
@@ -45,7 +45,7 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
       const updatedProfileData = await fetchProfileInfo(session.info.webId);
       localStorage.setItem('profileImage', updatedProfileData.profileInfo.profileImage);
       setProfileImg(updatedProfileData.profileInfo.profileImage);
-
+      addNotification('success', `Profile image added.`);
       loadProfileData();
     }
   };

--- a/src/components/Profile/ProfileImageField.jsx
+++ b/src/components/Profile/ProfileImageField.jsx
@@ -11,6 +11,8 @@ import ImageIcon from '@mui/icons-material/Image';
 // Contexts Imports
 import { SignedInUserContext } from '@contexts';
 import useNotification from '../../hooks/useNotification';
+// Component Imports
+import ConfirmationModal from '../Modals/ConfirmationModal';
 
 /**
  * ProfileImageField Component - Component that creates the editable inputs fields
@@ -31,6 +33,8 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
   const { profileData, fetchProfileInfo, removeProfileImage, uploadProfileImage } =
     useContext(SignedInUserContext);
   const [profileImg, setProfileImg] = useState(localStorage.getItem('profileImage'));
+  const [processing, setProcessing] = useState(false);
+  const [showConfirmationModal, setShowConfirmationModal] = useState(false);
 
   const handleProfileImage = async (event) => {
     if (event.target.files[0].size > 1 * 1000 * 1024) {
@@ -47,13 +51,23 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
   };
 
   const handleRemoveProfileImg = async () => {
-    if (window.confirm("You're about to delete your profile image. Do you wish to continue?")) {
+    setProcessing(true);
+    try {
       await removeProfileImage(session, profileData);
-
       loadProfileData();
       localStorage.removeItem('profileImage');
       setProfileImg(null);
+      addNotification('success', `Profile image deleted from the pod.`);
+    } catch (e) {
+      addNotification('error', `Image deletion failed. Reason: ${e.message}`);
+    } finally {
+      setShowConfirmationModal(false);
+      setProcessing(false);
     }
+  };
+
+  const handleSelectRemoveProfileImg = async () => {
+    setShowConfirmationModal(true);
   };
 
   return (
@@ -79,7 +93,7 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
             variant="outlined"
             color="error"
             sx={{ width: '150px' }}
-            onClick={handleRemoveProfileImg}
+            onClick={handleSelectRemoveProfileImg}
             endIcon={<HideImageIcon />}
           >
             Remove Img
@@ -97,6 +111,15 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
             <input type="file" hidden accept=".gif, .png, .jpeg, .jpg, .webp" />
           </Button>
         ))}
+      <ConfirmationModal
+        showModal={showConfirmationModal}
+        setShowModal={setShowConfirmationModal}
+        title="Delete Image"
+        text={"You're about to delete your profile image. Do you wish to continue?"}
+        onConfirm={handleRemoveProfileImg}
+        confirmButtonText="Delete"
+        processing={processing}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
## This PR:
Resolves #463 

When clicking on the delete image button in the profile page, it uses the default Windows alert. This replaces it with Material UI using the `ConfirmationModal` component.

It also adds a notification upon successful uploading of a profile image and not only when there's an error. This makes it more consistent.

## Screenshots (if applicable):
<img width="1037" alt="2024-03-03" src="https://github.com/codeforpdx/PASS/assets/83156697/2697f17d-bee7-409e-9a6a-ac077b857156">

## Additional Context (optional):
Add any other context about the PR here.

## Future Steps/PRs Needed to Finish This Work (optional):
Anything I may have overlooked, ways to consolidate code, etc.

## Issues needing discussion/feedback (optional):
**1.** Adding the notification status for successful upload isn't strictly necessary, but I do think it helps maintain consistency and is useful if, for instance, the user has already moved away from the profile page.
