### PR TITLE
598 simplify add contact to use username

### DIFF
--- a/env.template
+++ b/env.template
@@ -1,4 +1,5 @@
 VITE_SOLID_IDENTITY_PROVIDER="http://localhost:3000/"
 VITE_SOLID_POD_SERVER="http://localhost:3000/"
 VITE_SUGGESTED_OIDC_OPTIONS="http://localhost:3000/, https://opencommons.net/, https://solidcommunity.net/, https://login.inrupt.com/, https://inrupt.net/"
+VITE_OIDC_WEBIDS = '{"http://localhost:3000/": "http://localhost:3000/user/profile/card#me", "https://opencommons.net/": "http://opencommons.net/user/profile/card#me", "https://solidcommunity.net/": "https://user.solidcommunity.net/profile/card#me", "https://login.inrupt.com/": "https://id.inrupt.com/user", "https://inrupt.net/": "https://id.inrupt.com/user"}'
 VITE_CLIENT_ID_DOC="http://localhost:3000/clientAppId.json"

--- a/src/components/Modals/AddContactModal.jsx
+++ b/src/components/Modals/AddContactModal.jsx
@@ -21,11 +21,10 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 // Custom Hook Imports
 import useNotification from '@hooks/useNotification';
-// Component Imports
-import { ENV } from '@constants';
-import { FormSection } from '../Form';
-
 // Constant Imports
+import { ENV } from '@constants';
+// Component Imports
+import { FormSection } from '../Form';
 
 // @memberof Modals
 // @name renderWebId
@@ -63,14 +62,6 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
   const [oidcProviders] = useState([...ENV.VITE_SUGGESTED_OIDC_OPTIONS.split(', '), 'Other']);
   const [Oidc, setOIDC] = useState('');
 
-  const oidcForm = {
-    'http://localhost:3000/': 'http://localhost:3000/user/profile/card#me',
-    'https://opencommons.net/': 'http://opencommons.net/user/profile/card#me',
-    'https://solidcommunity.net/': 'https://user.solidcommunity.net/profile/card#me.',
-    'https://login.inrupt.com/': 'https://id.inrupt.com/user',
-    'https://inrupt.net/': 'https://id.inrupt.com/user'
-  };
-
   const clearInputFields = () => {
     setUserGivenName('');
     setUserFamilyName('');
@@ -105,7 +96,7 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
       };
     } else {
       userObject = {
-        webId: oidcForm[Oidc].replace('user', userName.trim()).trim(),
+        webId: JSON.parse(ENV.VITE_OIDC_WEBIDS)[Oidc].replace('user', userName.trim()).trim(),
         ...(addUserGivenName.value && { givenName: addUserGivenName.value.trim() }),
         ...(addUserFamilyName.value && { familyName: addUserFamilyName.value.trim() })
       };

--- a/src/components/Modals/AddContactModal.jsx
+++ b/src/components/Modals/AddContactModal.jsx
@@ -55,10 +55,12 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
   const [userFamilyName, setUserFamilyName] = useState('');
   const [webId, setWebId] = useState('');
   const [invalidWebId, setInvalidWebId] = useState(false);
+  const [userName, setUserName] = useState('');
+  const [customWebID, setCustomWebID] = useState(false);
   const [processing, setProcessing] = useState(false);
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
-  const [oidcProviders] = useState(ENV.VITE_SUGGESTED_OIDC_OPTIONS.split(', '));
+  const [oidcProviders] = useState([...ENV.VITE_SUGGESTED_OIDC_OPTIONS.split(', '), 'Other']);
   const [Oidc, setOIDC] = React.useState('');
 
   const clearInputFields = () => {
@@ -70,6 +72,11 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
   };
 
   const handleOidcSelection = (e) => {
+    if (e.target.value === 'Other') {
+      setCustomWebID(true);
+    } else {
+      setCustomWebID(false);
+    }
     setOIDC(e.target.value);
   };
 
@@ -153,33 +160,48 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
               ))}
             </Select>
           </FormControl>
-          <TextField
-            margin="normal"
-            id="add-webId"
-            name="addWebId"
-            placeholder="WebId"
-            autoComplete="webid"
-            value={webId}
-            type="text"
-            onChange={(e) => {
-              setWebId(e.target.value);
-            }}
-            error={invalidWebId}
-            label={invalidWebId ? 'Error' : ''}
-            // helperText for invalidWebId === false is ' ' and not '' is to
-            // prevent the field from stretching when helperText disappears
-            helperText={invalidWebId ? 'Invalid WebId.' : ' '}
-            fullWidth
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton aria-label="Copy WebId" edge="end">
-                    <ContentCopyIcon />
-                  </IconButton>
-                </InputAdornment>
-              )
-            }}
-          />
+
+          <FormControl fullWidth>
+            <TextField
+              margin="normal"
+              id="add-user-name"
+              name="addUserName"
+              label="Username"
+              value={userName}
+              onChange={(e) => setUserName(e.target.value)}
+              fullWidth
+              autoFocus
+            />
+          </FormControl>
+          {customWebID && (
+            <TextField
+              margin="normal"
+              id="add-webId"
+              name="addWebId"
+              placeholder="WebId"
+              autoComplete="webid"
+              value={webId}
+              type="text"
+              onChange={(e) => {
+                setWebId(e.target.value);
+              }}
+              error={invalidWebId}
+              label={invalidWebId ? 'Error' : ''}
+              // helperText for invalidWebId === false is ' ' and not '' is to
+              // prevent the field from stretching when helperText disappears
+              helperText={invalidWebId ? 'Invalid WebId.' : ' '}
+              fullWidth
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton aria-label="Copy WebId" edge="end">
+                      <ContentCopyIcon />
+                    </IconButton>
+                  </InputAdornment>
+                )
+              }}
+            />
+          )}
           <DialogActions sx={{ width: '100%' }}>
             <Box
               sx={{

--- a/src/components/Modals/AddContactModal.jsx
+++ b/src/components/Modals/AddContactModal.jsx
@@ -19,6 +19,7 @@ import MenuItem from '@mui/material/MenuItem';
 import InputLabel from '@mui/material/InputLabel';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
+import Tooltip from '@mui/material/Tooltip';
 // Custom Hook Imports
 import useNotification from '@hooks/useNotification';
 // Constant Imports
@@ -151,67 +152,77 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
             onChange={(e) => setUserFamilyName(e.target.value)}
             fullWidth
           />
-          <FormControl fullWidth>
-            <InputLabel>OIDC Provider</InputLabel>
-            <Select
-              labelId="demo-multiple-name-label"
-              id="demo-multiple-name"
-              value={Oidc}
-              label="OIDC Provider"
-              data-testid="select-oidc"
-              onChange={handleOidcSelection}
-              fullWidth
-            >
-              {oidcProviders.map((oidc) => (
-                <MenuItem key={oidc} value={oidc}>
-                  {oidc}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
+          <Tooltip
+            title="Select the server/website where your pod is located"
+            arrow
+            placement="left"
+          >
+            <FormControl fullWidth>
+              <InputLabel>OIDC Provider</InputLabel>
+              <Select
+                labelId="demo-multiple-name-label"
+                id="demo-multiple-name"
+                value={Oidc}
+                label="OIDC Provider"
+                data-testid="select-oidc"
+                onChange={handleOidcSelection}
+                fullWidth
+              >
+                {oidcProviders.map((oidc) => (
+                  <MenuItem key={oidc} value={oidc}>
+                    {oidc}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Tooltip>
 
           {!customWebID && (
-            <FormControl fullWidth>
-              <TextField
-                margin="normal"
-                id="add-user-name"
-                name="addUserName"
-                label="Username"
-                value={userName}
-                onChange={(e) => setUserName(e.target.value)}
-                fullWidth
-                autoFocus
-              />
-            </FormControl>
+            <Tooltip title="Enter the username associated with your WebID" arrow placement="left">
+              <FormControl fullWidth>
+                <TextField
+                  margin="normal"
+                  id="add-user-name"
+                  name="addUserName"
+                  label="Username"
+                  value={userName}
+                  onChange={(e) => setUserName(e.target.value)}
+                  fullWidth
+                  autoFocus
+                />
+              </FormControl>
+            </Tooltip>
           )}
           {customWebID && (
-            <TextField
-              margin="normal"
-              id="add-webId"
-              name="addWebId"
-              placeholder="WebId"
-              autoComplete="webid"
-              value={webId}
-              type="text"
-              onChange={(e) => {
-                setWebId(e.target.value);
-              }}
-              error={invalidWebId}
-              label={invalidWebId ? 'Error' : ''}
-              // helperText for invalidWebId === false is ' ' and not '' is to
-              // prevent the field from stretching when helperText disappears
-              helperText={invalidWebId ? 'Invalid WebId.' : ' '}
-              fullWidth
-              InputProps={{
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <IconButton aria-label="Copy WebId" edge="end">
-                      <ContentCopyIcon />
-                    </IconButton>
-                  </InputAdornment>
-                )
-              }}
-            />
+            <Tooltip title="Enter your full WebID" arrow placement="left">
+              <TextField
+                margin="normal"
+                id="add-webId"
+                name="addWebId"
+                placeholder="WebId"
+                autoComplete="webid"
+                value={webId}
+                type="text"
+                onChange={(e) => {
+                  setWebId(e.target.value);
+                }}
+                error={invalidWebId}
+                label={invalidWebId ? 'Error' : ''}
+                // helperText for invalidWebId === false is ' ' and not '' is to
+                // prevent the field from stretching when helperText disappears
+                helperText={invalidWebId ? 'Invalid WebId.' : ' '}
+                fullWidth
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton aria-label="Copy WebId" edge="end">
+                        <ContentCopyIcon />
+                      </IconButton>
+                    </InputAdornment>
+                  )
+                }}
+              />
+            </Tooltip>
           )}
           <DialogActions sx={{ width: '100%' }}>
             <Box

--- a/src/components/Modals/AddContactModal.jsx
+++ b/src/components/Modals/AddContactModal.jsx
@@ -69,6 +69,7 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
     setWebId('');
     setInvalidWebId(false);
     setOIDC('');
+    setCustomWebID(false);
   };
 
   const handleOidcSelection = (e) => {
@@ -85,14 +86,21 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
     setProcessing(true);
 
     const { addUserGivenName, addUserFamilyName, addWebId } = event.target.elements;
+    let userObject;
 
-    const userObject = {
-      webId: addWebId.value.trim(),
-      ...(addUserGivenName.value && { givenName: addUserGivenName.value.trim() }),
-      ...(addUserFamilyName.value && { familyName: addUserFamilyName.value.trim() })
-    };
-
-    console.log(oidcProviders);
+    if (customWebID) {
+      userObject = {
+        webId: addWebId.value.trim(),
+        ...(addUserGivenName.value && { givenName: addUserGivenName.value.trim() }),
+        ...(addUserFamilyName.value && { familyName: addUserFamilyName.value.trim() })
+      };
+    } else {
+      userObject = {
+        webId: addWebId.value.trim(),
+        ...(addUserGivenName.value && { givenName: addUserGivenName.value.trim() }),
+        ...(addUserFamilyName.value && { familyName: addUserFamilyName.value.trim() })
+      };
+    }
 
     try {
       await getWebIdDataset(userObject.webId);
@@ -161,18 +169,20 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
             </Select>
           </FormControl>
 
-          <FormControl fullWidth>
-            <TextField
-              margin="normal"
-              id="add-user-name"
-              name="addUserName"
-              label="Username"
-              value={userName}
-              onChange={(e) => setUserName(e.target.value)}
-              fullWidth
-              autoFocus
-            />
-          </FormControl>
+          {!customWebID && (
+            <FormControl fullWidth>
+              <TextField
+                margin="normal"
+                id="add-user-name"
+                name="addUserName"
+                label="Username"
+                value={userName}
+                onChange={(e) => setUserName(e.target.value)}
+                fullWidth
+                autoFocus
+              />
+            </FormControl>
+          )}
           {customWebID && (
             <TextField
               margin="normal"

--- a/src/components/Modals/AddContactModal.jsx
+++ b/src/components/Modals/AddContactModal.jsx
@@ -14,12 +14,18 @@ import FormControl from '@mui/material/FormControl';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import TextField from '@mui/material/TextField';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import InputLabel from '@mui/material/InputLabel';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 // Custom Hook Imports
 import useNotification from '@hooks/useNotification';
 // Component Imports
+import { ENV } from '@constants';
 import { FormSection } from '../Form';
+
+// Constant Imports
 
 // @memberof Modals
 // @name renderWebId
@@ -52,12 +58,19 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
   const [processing, setProcessing] = useState(false);
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+  const [oidcProviders] = useState(ENV.VITE_SUGGESTED_OIDC_OPTIONS.split(', '));
+  const [Oidc, setOIDC] = React.useState('');
 
   const clearInputFields = () => {
     setUserGivenName('');
     setUserFamilyName('');
     setWebId('');
     setInvalidWebId(false);
+    setOIDC('');
+  };
+
+  const handleOidcSelection = (e) => {
+    setOIDC(e.target.value);
   };
 
   const handleAddContact = async (event) => {
@@ -71,6 +84,8 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
       ...(addUserGivenName.value && { givenName: addUserGivenName.value.trim() }),
       ...(addUserFamilyName.value && { familyName: addUserFamilyName.value.trim() })
     };
+
+    console.log(oidcProviders);
 
     try {
       await getWebIdDataset(userObject.webId);
@@ -121,7 +136,23 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
             onChange={(e) => setUserFamilyName(e.target.value)}
             fullWidth
           />
-
+          <FormControl fullWidth>
+            <InputLabel>OIDC Provider</InputLabel>
+            <Select
+              labelId="demo-multiple-name-label"
+              id="demo-multiple-name"
+              value={Oidc}
+              label="OIDC Provider"
+              onChange={handleOidcSelection}
+              fullWidth
+            >
+              {oidcProviders.map((oidc) => (
+                <MenuItem key={oidc} value={oidc}>
+                  {oidc}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
           <TextField
             margin="normal"
             id="add-webId"

--- a/src/components/Modals/AddContactModal.jsx
+++ b/src/components/Modals/AddContactModal.jsx
@@ -167,6 +167,7 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
               id="demo-multiple-name"
               value={Oidc}
               label="OIDC Provider"
+              data-testid="select-oidc"
               onChange={handleOidcSelection}
               fullWidth
             >

--- a/src/components/Modals/AddContactModal.jsx
+++ b/src/components/Modals/AddContactModal.jsx
@@ -61,7 +61,7 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
   const [oidcProviders] = useState([...ENV.VITE_SUGGESTED_OIDC_OPTIONS.split(', '), 'Other']);
-  const [Oidc, setOIDC] = React.useState('');
+  const [Oidc, setOIDC] = useState('');
 
   const oidcForm = {
     'http://localhost:3000/': 'http://localhost:3000/user/profile/card#me',

--- a/src/components/Modals/AddContactModal.jsx
+++ b/src/components/Modals/AddContactModal.jsx
@@ -63,6 +63,14 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
   const [oidcProviders] = useState([...ENV.VITE_SUGGESTED_OIDC_OPTIONS.split(', '), 'Other']);
   const [Oidc, setOIDC] = React.useState('');
 
+  const oidcForm = {
+    'http://localhost:3000/': 'http://localhost:3000/user/profile/card#me',
+    'https://opencommons.net/': 'http://opencommons.net/user/profile/card#me',
+    'https://solidcommunity.net/': 'https://user.solidcommunity.net/profile/card#me.',
+    'https://login.inrupt.com/': 'https://id.inrupt.com/user',
+    'https://inrupt.net/': 'https://id.inrupt.com/user'
+  };
+
   const clearInputFields = () => {
     setUserGivenName('');
     setUserFamilyName('');
@@ -70,6 +78,7 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
     setInvalidWebId(false);
     setOIDC('');
     setCustomWebID(false);
+    setUserName('');
   };
 
   const handleOidcSelection = (e) => {
@@ -96,7 +105,7 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
       };
     } else {
       userObject = {
-        webId: addWebId.value.trim(),
+        webId: oidcForm[Oidc].replace('user', userName.trim()).trim(),
         ...(addUserGivenName.value && { givenName: addUserGivenName.value.trim() }),
         ...(addUserFamilyName.value && { familyName: addUserFamilyName.value.trim() })
       };

--- a/test/components/Modals/AddContactModal.test.jsx
+++ b/test/components/Modals/AddContactModal.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, getByRole as testGetByRole } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { AddContactModal } from '@components/Modals';
@@ -60,6 +60,10 @@ describe('add contact', () => {
       <AddContactModal setShowAddContactModal={() => {}} showAddContactModal addContact={mockAdd} />
     );
 
+    await userEvent.click(testGetByRole(screen.getByTestId('select-oidc'), 'combobox'));
+
+    await userEvent.click(await screen.findByRole('option', { name: 'Other' }));
+
     const givenName = screen.getByRole('textbox', { name: 'First/given name (Optional)' });
     const familyName = screen.getByRole('textbox', { name: 'Last/family name (Optional)' });
     const webIdInput = screen.getByPlaceholderText('WebId');
@@ -86,6 +90,10 @@ describe('add contact', () => {
     render(
       <AddContactModal setShowAddContactModal={() => {}} showAddContactModal addContact={mockAdd} />
     );
+
+    await userEvent.click(testGetByRole(screen.getByTestId('select-oidc'), 'combobox'));
+
+    await userEvent.click(await screen.findByRole('option', { name: 'Other' }));
 
     const givenName = screen.getByRole('textbox', { name: 'First/given name (Optional)' });
     const familyName = screen.getByRole('textbox', { name: 'Last/family name (Optional)' });

--- a/test/components/Modals/AddContactModal.test.jsx
+++ b/test/components/Modals/AddContactModal.test.jsx
@@ -6,6 +6,18 @@ import { AddContactModal } from '@components/Modals';
 import * as solidClient from '@inrupt/solid-client';
 import createMatchMedia from '../../helpers/createMatchMedia';
 
+vi.mock('../../../src/constants/', async () => {
+  const actual = await vi.importActual('../../../src/constants/');
+  return {
+    ...actual,
+    ENV: {
+      VITE_SOLID_IDENTITY_PROVIDER: 'https://www.testurl.com/',
+      VITE_SUGGESTED_OIDC_OPTIONS:
+        'http://testurl_1.com/, http://testurl_2.com/, http://testurl_3.com/'
+    }
+  };
+});
+
 const MockAddContactModal = () => <AddContactModal showAddContactModal />;
 
 it('renders button container flex-direction row default', () => {

--- a/test/components/Modals/AddContactModal.test.jsx
+++ b/test/components/Modals/AddContactModal.test.jsx
@@ -6,18 +6,6 @@ import { AddContactModal } from '@components/Modals';
 import * as solidClient from '@inrupt/solid-client';
 import createMatchMedia from '../../helpers/createMatchMedia';
 
-vi.mock('../../../src/constants/', async () => {
-  const actual = await vi.importActual('../../../src/constants/');
-  return {
-    ...actual,
-    ENV: {
-      VITE_SOLID_IDENTITY_PROVIDER: 'https://www.testurl.com/',
-      VITE_SUGGESTED_OIDC_OPTIONS:
-        'http://testurl_1.com/, http://testurl_2.com/, http://testurl_3.com/'
-    }
-  };
-});
-
 const MockAddContactModal = () => <AddContactModal showAddContactModal />;
 
 it('renders button container flex-direction row default', () => {

--- a/test/helpers/setup-vitest.js
+++ b/test/helpers/setup-vitest.js
@@ -5,7 +5,8 @@ import createMatchMedia from './createMatchMedia';
 process.env.VITE_SOLID_IDENTITY_PROVIDER = 'https://solidcommunity.net';
 process.env.VITE_SUGGESTED_OIDC_OPTIONS =
   'http://testurl_1.com/, http://testurl_2.com/, http://testurl_3.com/';
-process.env.VITE_OIDC_WEBIDS = '{"http://testurl_1.com/": "http://testurl_1.com/user/profile/card#me", "http://testurl_2.com/": "http://testurl_2.com/user/profile/card#me", "http://testurl_3.com/": "http://testurl_3.com/user/profile/card#me"}'
+process.env.VITE_OIDC_WEBIDS =
+  '{"http://testurl_1.com/": "http://testurl_1.com/user/profile/card#me", "http://testurl_2.com/": "http://testurl_2.com/user/profile/card#me", "http://testurl_3.com/": "http://testurl_3.com/user/profile/card#me"}';
 
 afterEach(() => {
   window.matchMedia = createMatchMedia(1200);

--- a/test/helpers/setup-vitest.js
+++ b/test/helpers/setup-vitest.js
@@ -2,8 +2,8 @@
 import { afterEach } from 'vitest';
 import createMatchMedia from './createMatchMedia';
 
-// process.env.VITE_SOLID_IDENTITY_PROVIDER = 'https://solidcommunity.net',
-// process.env.VITE_SUGGESTED_OIDC_OPTIONS = 'http://testurl_1.com/, http://testurl_2.com/, http://testurl_3.com/'
+process.env.VITE_SOLID_IDENTITY_PROVIDER = 'https://solidcommunity.net',
+process.env.VITE_SUGGESTED_OIDC_OPTIONS = 'http://testurl_1.com/, http://testurl_2.com/, http://testurl_3.com/'
 
 afterEach(() => {
   window.matchMedia = createMatchMedia(1200);

--- a/test/helpers/setup-vitest.js
+++ b/test/helpers/setup-vitest.js
@@ -2,8 +2,9 @@
 import { afterEach } from 'vitest';
 import createMatchMedia from './createMatchMedia';
 
-process.env.VITE_SOLID_IDENTITY_PROVIDER = 'https://solidcommunity.net',
-process.env.VITE_SUGGESTED_OIDC_OPTIONS = 'http://testurl_1.com/, http://testurl_2.com/, http://testurl_3.com/'
+process.env.VITE_SOLID_IDENTITY_PROVIDER = 'https://solidcommunity.net';
+process.env.VITE_SUGGESTED_OIDC_OPTIONS =
+  'http://testurl_1.com/, http://testurl_2.com/, http://testurl_3.com/';
 
 afterEach(() => {
   window.matchMedia = createMatchMedia(1200);

--- a/test/helpers/setup-vitest.js
+++ b/test/helpers/setup-vitest.js
@@ -2,6 +2,9 @@
 import { afterEach } from 'vitest';
 import createMatchMedia from './createMatchMedia';
 
+// process.env.VITE_SOLID_IDENTITY_PROVIDER = 'https://solidcommunity.net',
+// process.env.VITE_SUGGESTED_OIDC_OPTIONS = 'http://testurl_1.com/, http://testurl_2.com/, http://testurl_3.com/'
+
 afterEach(() => {
   window.matchMedia = createMatchMedia(1200);
 });

--- a/test/helpers/setup-vitest.js
+++ b/test/helpers/setup-vitest.js
@@ -5,6 +5,7 @@ import createMatchMedia from './createMatchMedia';
 process.env.VITE_SOLID_IDENTITY_PROVIDER = 'https://solidcommunity.net';
 process.env.VITE_SUGGESTED_OIDC_OPTIONS =
   'http://testurl_1.com/, http://testurl_2.com/, http://testurl_3.com/';
+process.env.VITE_OIDC_WEBIDS = '{"http://testurl_1.com/": "http://testurl_1.com/user/profile/card#me", "http://testurl_2.com/": "http://testurl_2.com/user/profile/card#me", "http://testurl_3.com/": "http://testurl_3.com/user/profile/card#me"}'
 
 afterEach(() => {
   window.matchMedia = createMatchMedia(1200);


### PR DESCRIPTION
## This PR:
Resolves #598
 
In its current form PASS is still not very user friendly. You have to provide the whole web Id from the https to the #card to lookup the user. This is mainly for cases where the pod servers are different and URL needs to be changed to fit those pods.

This pull request replaces the WebID field with a username and OIDC provider dropdown to make the application more user friendly. The WebID can still be selected by clicking the ```Other``` dropdown for entering a custom WebID.

## Screenshots (if applicable):
![image](https://github.com/codeforpdx/PASS/assets/43707506/1e951441-e6d5-4219-bea9-34fa8d16f924)

Tooltip:
![image](https://github.com/codeforpdx/PASS/assets/43707506/4d1a22ab-e5af-4ac8-8d9e-142b1f71e04b)

![image](https://github.com/codeforpdx/PASS/assets/43707506/2b023bda-37bf-41da-8ac5-7aabfac0456c)

![image](https://github.com/codeforpdx/PASS/assets/43707506/699b16dd-18d6-4161-b808-1c8e7b8dfb5c)


## Additional Context (optional):
Add any other context about the PR here.

## Future Steps/PRs Needed to Finish This Work (optional):

## Issues needing discussion/feedback (optional):

