### PR TITLE
No Issue - Fix sharing of one document

### DIFF
--- a/src/components/Documents/DocumentTable.jsx
+++ b/src/components/Documents/DocumentTable.jsx
@@ -154,7 +154,7 @@ const DocumentTable = ({ handleAclPermissionsModal, handleSelectDeleteDoc }) => 
       getActions: (data) => [
         <GridActionsCellItem
           icon={<ShareIcon />}
-          onClick={() => handleAclPermissionsModal('documents', data.name, data.type)}
+          onClick={() => handleAclPermissionsModal('document', data.row.id, data.row.type)}
           label="Share"
         />
       ]

--- a/src/components/Modals/SetAclPermissionsModal.jsx
+++ b/src/components/Modals/SetAclPermissionsModal.jsx
@@ -75,7 +75,7 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
         case 'document':
           await setDocAclPermission(
             session,
-            dataset.docType,
+            dataset.docName,
             permissions,
             podUrl,
             webIdToSetPermsTo

--- a/src/utils/network/session-core.js
+++ b/src/utils/network/session-core.js
@@ -1,4 +1,4 @@
-import { getFile } from '@inrupt/solid-client';
+import { getFile, universalAccess } from '@inrupt/solid-client';
 import dayjs from 'dayjs';
 import { v4 as uuidv4 } from 'uuid';
 import {
@@ -32,24 +32,18 @@ import {
  * @memberof utils
  * @function setDocAclPermission
  * @param {Session} session - Solid's Session Object {@link Session}
- * @param {string} docType - Type of document
+ * @param {string} docName - Name of document to share
  * @param {Access} permissions - The Access object for setting ACL in Solid
  * @param {URL} podUrl - URL of the user's Pod
- * @param {string} webIdToSetPermsTo - URL of the other user's Pod to give/revoke permissions OR empty string
+ * @param {string} webId - The webId to share the document with
  * @returns {Promise} Promise - Sets permission for otherPodUsername for given
  * document type, if exists, or null
  */
-export const setDocAclPermission = async (
-  session,
-  docType,
-  permissions,
-  podUrl,
-  webIdToSetPermsTo
-) => {
+export const setDocAclPermission = async (session, docName, permissions, podUrl, webId) => {
   const containerUrl = `${podUrl}PASS/Documents/`;
-  const documentUrl = `${containerUrl}${docType.replace("'", '').replace(' ', '_')}/`;
+  const documentUrl = `${containerUrl}${docName.replace("'", '').replace(' ', '_')}`;
 
-  await setDocAclForUser(session, documentUrl, 'update', webIdToSetPermsTo, permissions);
+  await universalAccess.setAgentAccess(documentUrl, webId, permissions, { fetch: session.fetch });
 };
 
 /**
@@ -72,7 +66,7 @@ export const setDocContainerAclPermission = async (
 ) => {
   const containerUrl = `${podUrl}PASS/Documents/`;
 
-  await setDocAclForUser(session, containerUrl, 'update', webIdToSetPermsTo, permissions);
+  await setDocAclForUser(session, containerUrl, '', webIdToSetPermsTo, permissions);
 };
 
 /*

--- a/test/utils/session-core.test.js
+++ b/test/utils/session-core.test.js
@@ -39,7 +39,7 @@ describe('setDocContainerAclPermission', () => {
     expect(sessionHelpers.setDocAclForUser).toBeCalledWith(
       session,
       expectedContainerUrl,
-      'update',
+      '',
       expectedWebId,
       permissions
     );


### PR DESCRIPTION
The sharing of an individual document seems to have broken some time back in November. This PR fixes one document permission sharing.

Testing:

1. Upload a document to your pod (e.g. some_document.pdf)
2. share that document with another pod
3. Check that an ACL file has been properly generated for this file (some_document.pdf.acl)