### PR TITLE
Enhancement update document sharing modal to pull from contacts list (#573)

### DIFF
--- a/src/components/Form/FormSection.jsx
+++ b/src/components/Form/FormSection.jsx
@@ -28,7 +28,7 @@ const FormSection = ({ title, headingId, children }) => (
       mx: '3px',
       padding: '16px',
       minWidth: '50%',
-      maxWidth: '75vdw'
+      maxWidth: '75dvw'
     }}
   >
     <Typography variant="h2" align="center" mb={2} sx={{ fontSize: '20px' }} id={headingId}>

--- a/src/components/Form/FormSection.jsx
+++ b/src/components/Form/FormSection.jsx
@@ -27,7 +27,8 @@ const FormSection = ({ title, headingId, children }) => (
       alignItems: 'center',
       mx: '3px',
       padding: '16px',
-      minWidth: '50%'
+      minWidth: '50%',
+      maxWidth: '75vdw'
     }}
   >
     <Typography variant="h2" align="center" mb={2} sx={{ fontSize: '20px' }} id={headingId}>

--- a/src/components/Modals/SetAclPermissionsModal.jsx
+++ b/src/components/Modals/SetAclPermissionsModal.jsx
@@ -54,7 +54,7 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
     label: `${contact.person} ${contact.webId}`,
     id: contact.webId
   }));
-  const shareeName = data?.filter(
+  const shareName = data?.filter(
     (contact) => permissionState.webIdToSetPermsTo === contact.webId
   )[0];
 
@@ -124,7 +124,7 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
         }
       >
         <form onSubmit={handleAclPermission} autoComplete="off" style={{ width: '100%' }}>
-          <FormControl required fullWidth sx={{ maxWidth: '75vdw', marginBottom: '1rem' }}>
+          <FormControl required fullWidth sx={{ maxWidth: '75dvw', marginBottom: '1rem' }}>
             <InputLabel id="permissionType-label">Select One</InputLabel>
             <Select
               labelId="permissionType-label"
@@ -150,7 +150,7 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
             fullWidth
             required
             autoFocus
-            value={shareeName?.person ?? permissionState.webIdToSetPermsTo}
+            value={shareName?.person ?? permissionState.webIdToSetPermsTo}
             disablePortal
             autoSelect
             options={contactListOptions}

--- a/src/components/Modals/SetAclPermissionsModal.jsx
+++ b/src/components/Modals/SetAclPermissionsModal.jsx
@@ -123,8 +123,8 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
           dataset.modalType === 'container' ? 'Share All Documents' : `Share ${dataset.docName}`
         }
       >
-        <form onSubmit={handleAclPermission} autoComplete="off">
-          <FormControl required fullWidth sx={{ marginBottom: '1rem' }}>
+        <form onSubmit={handleAclPermission} autoComplete="off" style={{ width: '100%' }}>
+          <FormControl required fullWidth sx={{ maxWidth: '75vdw', marginBottom: '1rem' }}>
             <InputLabel id="permissionType-label">Select One</InputLabel>
             <Select
               labelId="permissionType-label"
@@ -145,6 +145,7 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
             id="set-acl-to"
             name="setAclTo"
             data-testid="newShareWith"
+            sx={{ marginBottom: '1rem' }}
             freeSolo
             fullWidth
             required

--- a/src/components/Modals/SetAclPermissionsModal.jsx
+++ b/src/components/Modals/SetAclPermissionsModal.jsx
@@ -40,25 +40,27 @@ import useNotification from '../../hooks/useNotification';
 const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
   const { session } = useSession();
   const { addNotification } = useNotification();
-  const { podUrl } = useContext(SignedInUserContext);
+
+  const { podUrl, webId } = useContext(SignedInUserContext);
+
   const [permissionState, setPermissionState] = useState({
-    podUrlToSetPermissionsTo: '',
+    webIdToSetPermsTo: '',
     permissionType: ''
   });
   const [processing, setProcessing] = useState(false);
 
   const { data } = useContactsList();
   const contactListOptions = data?.map((contact) => ({
-    label: `${contact.person} ${contact.podUrl}`,
-    id: contact.podUrl
+    label: `${contact.person} ${contact.webId}`,
+    id: contact.webId
   }));
   const shareeName = data?.filter(
-    (contact) => permissionState.podUrlToSetPermissionsTo === contact.podUrl
+    (contact) => permissionState.webIdToSetPermsTo === contact.webId
   )[0];
 
   const clearInputFields = () => {
     setPermissionState({
-      podUrlToSetPermissionsTo: '',
+      webIdToSetPermsTo: '',
       permissionType: ''
     });
     setProcessing(false);
@@ -75,12 +77,16 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
           append: event.target.setAclPerms.value === 'Share' && dataset.modalType === 'container'
         }
       : undefined;
-    const webIdToSetPermsTo = `${permissionState.podUrlToSetPermissionsTo}profile/card#me`;
 
     try {
       switch (dataset.modalType) {
         case 'container':
-          await setDocContainerAclPermission(session, permissions, podUrl, webIdToSetPermsTo);
+          await setDocContainerAclPermission(
+            session,
+            permissions,
+            podUrl,
+            permissionState.webIdToSetPermsTo
+          );
           break;
         case 'document':
           await setDocAclPermission(
@@ -88,7 +94,7 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
             dataset.docName,
             permissions,
             podUrl,
-            webIdToSetPermsTo
+            permissionState.webIdToSetPermsTo
           );
           break;
         default:
@@ -98,7 +104,7 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
       addNotification(
         'success',
         `${permissions.read ? 'Shared' : 'Unshared'} with ${
-          permissionState.podUrlToSetPermissionsTo
+          permissionState.webIdToSetPermsTo
         } for ${dataset.modalType === 'container' ? 'Documents Container' : dataset.docName}.`
       );
     } catch (error) {
@@ -143,24 +149,24 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
             fullWidth
             required
             autoFocus
-            value={shareeName?.person ?? permissionState.podUrlToSetPermissionsTo}
+            value={shareeName?.person ?? permissionState.webIdToSetPermsTo}
             disablePortal
             autoSelect
             options={contactListOptions}
             onChange={(event, newValue) => {
               setPermissionState({
                 ...permissionState,
-                podUrlToSetPermissionsTo: newValue.id ?? newValue
+                webIdToSetPermsTo: newValue.id ?? newValue
               });
             }}
             placeholder={permissionState.podUrlToSetPermissionsTo}
             error={permissionState.podUrlToSetPermissionsTo === podUrl}
             helperText={
-              permissionState.podUrlToSetPermissionsTo === podUrl
+              permissionState.webIdToSetPermsTo === webId
                 ? 'Cannot share to your own pod.'.toUpperCase()
                 : ''
             }
-            renderInput={(params) => <TextField {...params} label="PodURL to share with" />}
+            renderInput={(params) => <TextField {...params} label="WebID to share with" />}
           />
           <br />
           <FormControl fullWidth sx={{ display: 'flex', gap: 2, flexDirection: 'column' }}>
@@ -175,7 +181,7 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
             </Button>
             <Button
               variant="contained"
-              disabled={permissionState.podUrlToSetPermissionsTo === podUrl || processing}
+              disabled={permissionState.webIdToSetPermsTo === webId || processing}
               type="submit"
               color="primary"
               startIcon={<ShareIcon />}

--- a/src/components/Modals/SetAclPermissionsModal.jsx
+++ b/src/components/Modals/SetAclPermissionsModal.jsx
@@ -1,7 +1,7 @@
 // React Imports
 import React, { useContext, useState } from 'react';
 // Custom Hook Imports
-import { useSession } from '@hooks';
+import { useSession, useContactsList } from '@hooks';
 // Material UI Imports
 import Button from '@mui/material/Button';
 import ClearIcon from '@mui/icons-material/Clear';
@@ -12,6 +12,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import ShareIcon from '@mui/icons-material/Share';
 import TextField from '@mui/material/TextField';
+import Autocomplete from '@mui/material/Autocomplete';
 // Utility Imports
 import { setDocAclPermission, setDocContainerAclPermission } from '@utils';
 // Context Imports
@@ -45,6 +46,15 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
     permissionType: ''
   });
   const [processing, setProcessing] = useState(false);
+
+  const { data } = useContactsList();
+  const contactListOptions = data?.map((contact) => ({
+    label: `${contact.person} ${contact.podUrl}`,
+    id: contact.podUrl
+  }));
+  const shareeName = data?.filter(
+    (contact) => permissionState.podUrlToSetPermissionsTo === contact.podUrl
+  )[0];
 
   const clearInputFields = () => {
     setPermissionState({
@@ -125,28 +135,33 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
             </Select>
           </FormControl>
           <br />
-          <FormControl fullWidth sx={{ marginBottom: '1rem' }}>
-            <TextField
-              id="set-acl-to"
-              name="setAclTo"
-              value={permissionState.podUrlToSetPermissionsTo}
-              onChange={(e) =>
-                setPermissionState({
-                  ...permissionState,
-                  podUrlToSetPermissionsTo: e.target.value
-                })
-              }
-              placeholder={permissionState.podUrlToSetPermissionsTo}
-              label="Enter podURL"
-              required
-              error={permissionState.podUrlToSetPermissionsTo === podUrl}
-              helperText={
-                permissionState.podUrlToSetPermissionsTo === podUrl
-                  ? 'Cannot share to your own pod.'.toUpperCase()
-                  : ''
-              }
-            />
-          </FormControl>
+          <Autocomplete
+            id="set-acl-to"
+            name="setAclTo"
+            data-testid="newShareWith"
+            freeSolo
+            fullWidth
+            required
+            autoFocus
+            value={shareeName?.person ?? permissionState.podUrlToSetPermissionsTo}
+            disablePortal
+            autoSelect
+            options={contactListOptions}
+            onChange={(event, newValue) => {
+              setPermissionState({
+                ...permissionState,
+                podUrlToSetPermissionsTo: newValue.id ?? newValue
+              });
+            }}
+            placeholder={permissionState.podUrlToSetPermissionsTo}
+            error={permissionState.podUrlToSetPermissionsTo === podUrl}
+            helperText={
+              permissionState.podUrlToSetPermissionsTo === podUrl
+                ? 'Cannot share to your own pod.'.toUpperCase()
+                : ''
+            }
+            renderInput={(params) => <TextField {...params} label="PodURL to share with" />}
+          />
           <br />
           <FormControl fullWidth sx={{ display: 'flex', gap: 2, flexDirection: 'column' }}>
             <Button

--- a/src/components/Modals/SetAclPermissionsModal.jsx
+++ b/src/components/Modals/SetAclPermissionsModal.jsx
@@ -154,14 +154,14 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
             disablePortal
             autoSelect
             options={contactListOptions}
-            onChange={(event, newValue) => {
+            onChange={(_, newValue) => {
               setPermissionState({
                 ...permissionState,
                 webIdToSetPermsTo: newValue.id ?? newValue
               });
             }}
-            placeholder={permissionState.podUrlToSetPermissionsTo}
-            error={permissionState.podUrlToSetPermissionsTo === podUrl}
+            placeholder="WebID to share with"
+            error={permissionState.webIdToSetPermsTo === webId}
             helperText={
               permissionState.webIdToSetPermsTo === webId
                 ? 'Cannot share to your own pod.'.toUpperCase()


### PR DESCRIPTION
## This PR:
Resolves #573
 
**1.** Document sharing (SetAclPermissionsModal) uses Web ID instead of Pod URL   
**2.** Populates a dropdown of contacts and associated Web IDs
**3.** _Side improvement_: Header of FormSection no longer overflows

## Screenshots:

![image](https://github.com/codeforpdx/PASS/assets/139835244/63bb8438-2b24-42ba-885a-d4149add98e9)

![image](https://github.com/codeforpdx/PASS/assets/139835244/faa341fb-833a-4f5b-acda-980827493f39)

![image](https://github.com/codeforpdx/PASS/assets/139835244/050eccbe-389f-4b05-af23-64bb358ff4c3)

![image](https://github.com/codeforpdx/PASS/assets/139835244/e32e3a3d-8fa5-4208-8c67-beb3c472e9ef)

![image](https://github.com/codeforpdx/PASS/assets/139835244/3075b38b-acb0-4508-bf92-42c41a5092c6)