### PR TITLE
Issue #615 refetch if null

### DIFF
--- a/src/components/CivicProfileForms/HousingInfo.jsx
+++ b/src/components/CivicProfileForms/HousingInfo.jsx
@@ -14,7 +14,7 @@ import { useCivicProfile } from '@hooks';
  * @returns {React.JSX.Element} The HousingInfo Component
  */
 const HousingInfo = () => {
-  const { data, add, isSuccess } = useCivicProfile();
+  const { data, add, isSuccess, storedDataset, refetch } = useCivicProfile();
   const [formData, setFormData] = useState({
     lastPermanentStreet: '',
     lastPermanentCity: '',
@@ -27,16 +27,21 @@ const HousingInfo = () => {
       setFormData((prevFormData) => ({ ...prevFormData, ...data }));
     }
   }, [isSuccess, data]);
-
+  useEffect(() => {
+    if (!storedDataset) {
+      refetch();
+    }
+  }, [storedDataset]);
   const handleChange = (event) => {
     const { name, value } = event.target;
     setFormData((prevFormData) => ({ ...prevFormData, [name]: value }));
   };
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (!isSuccess) {
+    if (!isSuccess || !storedDataset) {
       return;
     }
+
     add(formData);
   };
 

--- a/src/components/Modals/SetAclPermissionsModal.jsx
+++ b/src/components/Modals/SetAclPermissionsModal.jsx
@@ -154,10 +154,10 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
             disablePortal
             autoSelect
             options={contactListOptions}
-            onChange={(_, newValue) => {
+            onChange={(_, value) => {
               setPermissionState({
                 ...permissionState,
-                webIdToSetPermsTo: newValue.id ?? newValue
+                webIdToSetPermsTo: value.id ?? value
               });
             }}
             placeholder="WebID to share with"

--- a/src/components/Modals/SetAclPermissionsModal.jsx
+++ b/src/components/Modals/SetAclPermissionsModal.jsx
@@ -154,10 +154,10 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
             disablePortal
             autoSelect
             options={contactListOptions}
-            onChange={(_, value) => {
+            onChange={(_, newValue) => {
               setPermissionState({
                 ...permissionState,
-                webIdToSetPermsTo: value.id ?? value
+                webIdToSetPermsTo: newValue.id ?? newValue
               });
             }}
             placeholder="WebID to share with"

--- a/src/hooks/useRdfCollection.js
+++ b/src/hooks/useRdfCollection.js
@@ -70,6 +70,7 @@ const useRdfCollection = (parse, serialize, fileUrl, fetchData) => {
   const addMutation = useMutation({
     mutationFn: async (item) => {
       if (!data) await fetchDocument();
+      // HERE
       const thing = serialize(item);
       const newDataset = setThing(storedDataset, thing);
       const savedDataset = await saveData(newDataset);

--- a/src/hooks/useRdfCollection.js
+++ b/src/hooks/useRdfCollection.js
@@ -70,7 +70,7 @@ const useRdfCollection = (parse, serialize, fileUrl, fetchData) => {
   const addMutation = useMutation({
     mutationFn: async (item) => {
       if (!data) await fetchDocument();
-      // HERE
+    
       const thing = serialize(item);
       const newDataset = setThing(storedDataset, thing);
       const savedDataset = await saveData(newDataset);

--- a/test/components/CivicProfileForms/HousingInfo.test.jsx
+++ b/test/components/CivicProfileForms/HousingInfo.test.jsx
@@ -16,7 +16,7 @@ vi.mock('@hooks', async () => {
 
 describe('Housing info form', () => {
   it('renders', () => {
-    useCivicProfile.mockReturnValue({ data: {}, isSuccess: true });
+    useCivicProfile.mockReturnValue({ data: {}, isSuccess: true, refetch: vi.fn() });
     const { getByRole } = render(<HousingInfo />);
     const cityField = getByRole('textbox', { name: 'City:' });
     expect(cityField).not.toBeNull();
@@ -31,7 +31,12 @@ describe('Housing info form', () => {
       lastPermanentState: 'Oregon',
       lastPermanentZIP: '97205'
     };
-    useCivicProfile.mockReturnValue({ add: mockAdd, isSuccess: true });
+    useCivicProfile.mockReturnValue({
+      add: mockAdd,
+      isSuccess: true,
+      storedDataset: {},
+      refetch: vi.fn()
+    });
     const { getByRole } = render(<HousingInfo />);
     const cityField = getByRole('textbox', { name: 'City:' });
     const streetField = getByRole('textbox', { name: 'Street:' });
@@ -44,5 +49,33 @@ describe('Housing info form', () => {
     await user.type(zipField, address.lastPermanentZIP);
     await user.click(submitButton);
     expect(mockAdd).toBeCalledWith(address);
+  });
+  it('does not submit when storedDataset is null', async () => {
+    const user = userEvent.setup();
+    const mockAdd = vi.fn();
+    const address = {
+      lastPermanentCity: 'Portland',
+      lastPermanentStreet: '20th ave',
+      lastPermanentState: 'Oregon',
+      lastPermanentZIP: '97205'
+    };
+    useCivicProfile.mockReturnValue({
+      add: mockAdd,
+      isSuccess: true,
+      storedDataset: null,
+      refetch: vi.fn()
+    });
+    const { getByRole } = render(<HousingInfo />);
+    const cityField = getByRole('textbox', { name: 'City:' });
+    const streetField = getByRole('textbox', { name: 'Street:' });
+    const stateField = getByRole('textbox', { name: 'State:' });
+    const zipField = getByRole('textbox', { name: 'ZIP Code:' });
+    const submitButton = getByRole('button');
+    await user.type(cityField, address.lastPermanentCity);
+    await user.type(streetField, address.lastPermanentStreet);
+    await user.type(stateField, address.lastPermanentState);
+    await user.type(zipField, address.lastPermanentZIP);
+    await user.click(submitButton);
+    expect(mockAdd).not.toBeCalled();
   });
 });


### PR DESCRIPTION
## This PR:
Resolves #615 

Issue seems to be that useRdfCollection's storedDocument is occasionally null when the mutation is called. My quick workaround is to add a useEffect that forces a refetch (and therefore a new state of storedDocument) if storedDocument is null. 
 
## Additional Context (optional):
This feels a little hacky to me but I'm not familiar enough with the codebase yet to figure out a different way. A new set of eyes/feedback is appreciated. 

