### PR TITLE
627/resolve failing basic info tests

### DIFF
--- a/src/components/CivicProfileForms/BasicInfo.jsx
+++ b/src/components/CivicProfileForms/BasicInfo.jsx
@@ -64,11 +64,7 @@ const BasicInfo = () => {
     if (!isSuccess || !storedDataset) {
       return;
     }
-    const formDataCopy = { ...formData };
-    if (formData.dateOfBirth === '') {
-      formDataCopy.dateOfBirth = null;
-    }
-    add(formDataCopy);
+    add(formData);
     addNotification('success', `Form submitted!`);
   };
 

--- a/src/components/CivicProfileForms/BasicInfo.jsx
+++ b/src/components/CivicProfileForms/BasicInfo.jsx
@@ -33,7 +33,7 @@ const BasicInfo = () => {
   const [formData, setFormData] = useState({
     firstName: '',
     lastName: '',
-    dateOfBirth: null,
+    dateOfBirth: '',
     gender: 9
   });
 
@@ -51,7 +51,7 @@ const BasicInfo = () => {
     if (e.$isDayjsObject) {
       setFormData((prevFormData) => ({
         ...prevFormData,
-        dateOfBirth: e.toDate()
+        dateOfBirth: dayjs(e).toDate()
       }));
     } else if (e.target) {
       const { name, value } = e.target;
@@ -73,7 +73,7 @@ const BasicInfo = () => {
       ...prevFormData,
       firstName: '',
       lastName: '',
-      dateOfBirth: null,
+      dateOfBirth: '',
       gender: 9
     }));
     addNotification('success', `Form cleared!`);

--- a/src/components/CivicProfileForms/BasicInfo.jsx
+++ b/src/components/CivicProfileForms/BasicInfo.jsx
@@ -33,7 +33,7 @@ const BasicInfo = () => {
   const [formData, setFormData] = useState({
     firstName: '',
     lastName: '',
-    dateOfBirth: '',
+    dateOfBirth: null,
     gender: 9
   });
 
@@ -64,7 +64,11 @@ const BasicInfo = () => {
     if (!isSuccess || !storedDataset) {
       return;
     }
-    add(formData);
+    const formDataCopy = { ...formData };
+    if (formData.dateOfBirth === '') {
+      formDataCopy.dateOfBirth = null;
+    }
+    add(formDataCopy);
     addNotification('success', `Form submitted!`);
   };
 
@@ -73,9 +77,10 @@ const BasicInfo = () => {
       ...prevFormData,
       firstName: '',
       lastName: '',
-      dateOfBirth: '',
+      dateOfBirth: null,
       gender: 9
     }));
+
     addNotification('success', `Form cleared!`);
   };
 

--- a/src/components/CivicProfileForms/BasicInfo.jsx
+++ b/src/components/CivicProfileForms/BasicInfo.jsx
@@ -51,7 +51,7 @@ const BasicInfo = () => {
     if (e.$isDayjsObject) {
       setFormData((prevFormData) => ({
         ...prevFormData,
-        dateOfBirth: dayjs(e).toDate()
+        dateOfBirth: e.toDate()
       }));
     } else if (e.target) {
       const { name, value } = e.target;

--- a/test/components/CivicProfileForms/BasicInfo.test.jsx
+++ b/test/components/CivicProfileForms/BasicInfo.test.jsx
@@ -1,83 +1,114 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { vi, expect, it, describe } from 'vitest';
 import { BasicInfo } from '@components/CivicProfileForms';
-import { useCivicProfile } from '@hooks';
+import { useCivicProfile, useNotification } from '@hooks';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import dayjs from 'dayjs';
 
 vi.mock('@hooks', async () => {
   const actual = await vi.importActual('@hooks');
 
   return {
     ...actual,
-    useCivicProfile: vi.fn()
+    useCivicProfile: vi.fn(),
+    useNotification: vi.fn()
   };
 });
 
 describe('Basic info form', () => {
   it('renders', () => {
     useCivicProfile.mockReturnValue({ data: {}, isSuccess: true, refetch: vi.fn() });
+    useNotification.mockReturnValue({ addNotification: vi.fn() });
+
     const { getByRole } = render(<BasicInfo />);
     const legalFirstName = getByRole('textbox', { name: 'Legal first name' });
     expect(legalFirstName).not.toBeNull();
   });
 
   // TODO: Resolve test not passing
-  // it('clears all input fields when you click the clear button', async () => {
-  //   const mockClear = vi.fn();
-  //   const basicInfoProfile = {
-  //     legalFirstName: 'Jane',
-  //     legalLastName: 'Doe',
-  //     legalDOB: '1980-12-15',
-  //     legalGender: 1
-  //   };
-  //   useCivicProfile.mockReturnValue({
-  //     add: mockClear,
-  //     isSuccess: true,
-  //     storedDataset: {},
-  //     refetch: vi.fn()
-  //   });
-  //   const { getByRole } = render(<BasicInfo />);
-  //   const legalFirstName = getByRole('textbox', { name: 'Legal first name' });
-  //   const legalLastName = getByRole('textbox', { name: 'Legal last name' });
-  //   const legalDOB = getByRole('textbox', { name: 'Choose date' });
-  //   const legalGender = getByRole('combobox', { name: 'Gender' });
-  //   const clearButton = getByRole('button', { name: 'Clear button' });
 
-  //   await userEvent.type(legalFirstName, basicInfoProfile.legalFirstName);
-  //   await userEvent.type(legalLastName, basicInfoProfile.legalLastName);
-  //   await userEvent.type(legalDOB, basicInfoProfile.legalDOB);
-  //   await userEvent.type(legalGender, `${basicInfoProfile.legalGender}{enter}`);
+  /* Likely related to the data types being entered into the form. Strings are processing as intended, 
+  but BasicInfo has date as well as a select input. The test must account for these as well.
+  See useCivicProfile.js for more info about the data that the Basic Info form uses as a hook. 
+  */
 
-  //   await userEvent.click(clearButton);
+  it('clears all input fields when you click the clear button', async () => {
+    const user = userEvent.setup();
+    const mockClear = vi.fn();
+    const basicInfoProfile = {
+      legalFirstName: 'Jane',
+      legalLastName: 'Doe',
+      legalDOB: '1980-12-15',
+      legalGender: 1
+    };
+    useCivicProfile.mockReturnValue({
+      add: mockClear,
+      isSuccess: true,
+      storedDataset: {},
+      refetch: vi.fn()
+    });
+    useNotification.mockReturnValue({ addNotification: vi.fn() });
 
-  //   expect(legalFirstName.value).toBe('');
-  //   expect(legalLastName.value).toBe('');
-  //   expect(legalDOB.value).toBe(null);
-  //   expect(legalGender.value).toBe('');
-  // });
+    const { getByRole } = render(<BasicInfo />);
+    const legalFirstName = getByRole('textbox', { name: 'Legal first name' });
+    const legalLastName = getByRole('textbox', { name: 'Legal last name' });
+    const legalDOB = getByRole('textbox', { name: 'Choose date' });
+    const legalGender = getByRole('combobox', { name: 'Gender' });
+    const clearButton = getByRole('button', { name: 'Clear button' });
+
+    await user.type(legalFirstName, basicInfoProfile.legalFirstName);
+    await user.type(legalLastName, basicInfoProfile.legalLastName);
+    await user.type(legalDOB, basicInfoProfile.legalDOB);
+    await user.click(legalGender);
+    const listBox = within(getByRole('listbox'));
+    user.click(listBox.getByText('Female'));
+    await user.click(clearButton);
+
+    expect(legalFirstName.value).toBe('');
+    expect(legalLastName.value).toBe('');
+    expect(legalDOB.value).toBe('');
+    expect(await screen.findByText(/Decline to answer/i)).toBeInTheDocument();
+  });
 
   // TODO: Resolve test not passing
-  // it('submits a basic info profile update when you click the submit button', async () => {
-  //   const user = userEvent.setup();
-  //   const mockAdd = vi.fn();
-  //   const basicInfoProfile = {
-  //     legalFirstName: 'Jane',
-  //     legalLastName: 'Doe',
-  //     legalDOB: '1980-12-15',
-  //     legalGender: 1
-  //   };
-  //   useCivicProfile.mockReturnValue({ add: mockAdd, isSuccess: true });
-  //   const { getByRole } = render(<BasicInfo />);
-  //   const legalFirstName = getByRole('textbox', { name: 'Legal first name' });
-  //   const legalLastName = getByRole('textbox', { name: 'Legal last name' });
-  //   const legalDOB = getByRole('textbox', { name: 'Choose date' });
-  //   const legalGender = getByRole('combobox', { name: 'Gender' });
-  //   const submitButton = getByRole('button', { name: 'Submit button' });
-  //   await user.type(legalFirstName, basicInfoProfile.legalFirstName);
-  //   await user.type(legalLastName, basicInfoProfile.legalLastName);
-  //   await user.type(legalDOB, basicInfoProfile.legalDOB);
-  //   await user.type(legalGender, `${basicInfoProfile.legalGender}{enter}`);
-  //   await user.click(submitButton);
-  //   expect(mockAdd).toBeCalledWith(basicInfoProfile);
-  // });
+  it('submits a basic info profile update when you click the submit button', async () => {
+    const user = userEvent.setup();
+    const mockAdd = vi.fn();
+    const basicInfoProfile = {
+      firstName: 'Jane',
+      lastName: 'Doe',
+      dateOfBirth: dayjs(Date.now()).toDate(),
+      gender: 1
+    };
+    const basicInfoTransformed = {
+      ...basicInfoProfile,
+      dateOfBirth: dayjs(basicInfoProfile.dateOfBirth).toDate()
+    };
+
+    useCivicProfile.mockReturnValue({
+      add: mockAdd,
+      isSuccess: true,
+      storedDataset: {},
+      refetch: vi.fn()
+    });
+    useNotification.mockReturnValue({ addNotification: vi.fn() });
+
+    const { getByRole } = render(<BasicInfo />);
+    const legalFirstName = getByRole('textbox', { name: 'Legal first name' });
+    const legalLastName = getByRole('textbox', { name: 'Legal last name' });
+    const legalDOB = getByRole('textbox', { name: 'Choose date' });
+    const legalGender = getByRole('combobox', { name: 'Gender' });
+    const submitButton = getByRole('button', { name: 'Submit button' });
+
+    await user.type(legalFirstName, basicInfoProfile.firstName);
+    await user.type(legalLastName, basicInfoProfile.lastName);
+    await user.type(legalDOB, `{enter}`);
+    await user.click(legalGender);
+    await user.click(screen.getByRole('option', { name: 'Male' }));
+    await user.click(submitButton);
+
+    expect(mockAdd).toBeCalledWith(basicInfoTransformed);
+  });
 });

--- a/test/components/CivicProfileForms/BasicInfo.test.jsx
+++ b/test/components/CivicProfileForms/BasicInfo.test.jsx
@@ -84,7 +84,11 @@ describe('Basic info form', () => {
     };
     const basicInfoTransformed = {
       ...basicInfoProfile,
-      dateOfBirth: dayjs(basicInfoProfile.dateOfBirth).toDate()
+      dateOfBirth: dayjs(
+        `${basicInfoProfile.dateOfBirth.getFullYear()}-${
+          basicInfoProfile.dateOfBirth.getMonth() + 1
+        }-${basicInfoProfile.dateOfBirth.getDate()}`
+      ).toDate()
     };
 
     useCivicProfile.mockReturnValue({

--- a/test/components/CivicProfileForms/BasicInfo.test.jsx
+++ b/test/components/CivicProfileForms/BasicInfo.test.jsx
@@ -29,11 +29,6 @@ describe('Basic info form', () => {
 
   // TODO: Resolve test not passing
 
-  /* Likely related to the data types being entered into the form. Strings are processing as intended, 
-  but BasicInfo has date as well as a select input. The test must account for these as well.
-  See useCivicProfile.js for more info about the data that the Basic Info form uses as a hook. 
-  */
-
   it('clears all input fields when you click the clear button', async () => {
     const user = userEvent.setup();
     const mockClear = vi.fn();

--- a/test/components/CivicProfileForms/BasicInfo.test.jsx
+++ b/test/components/CivicProfileForms/BasicInfo.test.jsx
@@ -27,15 +27,13 @@ describe('Basic info form', () => {
     expect(legalFirstName).not.toBeNull();
   });
 
-  // TODO: Resolve test not passing
-
   it('clears all input fields when you click the clear button', async () => {
     const user = userEvent.setup();
     const mockClear = vi.fn();
     const basicInfoProfile = {
       legalFirstName: 'Jane',
       legalLastName: 'Doe',
-      legalDOB: '1980-12-15',
+      legalDOB: Date.now(),
       legalGender: 1
     };
     useCivicProfile.mockReturnValue({
@@ -55,10 +53,11 @@ describe('Basic info form', () => {
 
     await user.type(legalFirstName, basicInfoProfile.legalFirstName);
     await user.type(legalLastName, basicInfoProfile.legalLastName);
-    await user.type(legalDOB, basicInfoProfile.legalDOB);
+    await user.type(legalDOB, `{enter}`);
     await user.click(legalGender);
     const listBox = within(getByRole('listbox'));
     user.click(listBox.getByText('Female'));
+
     await user.click(clearButton);
 
     expect(legalFirstName.value).toBe('');
@@ -67,7 +66,6 @@ describe('Basic info form', () => {
     expect(await screen.findByText(/Decline to answer/i)).toBeInTheDocument();
   });
 
-  // TODO: Resolve test not passing
   it('submits a basic info profile update when you click the submit button', async () => {
     const user = userEvent.setup();
     const mockAdd = vi.fn();


### PR DESCRIPTION
## This PR:
Resolves #627
 
Fixes 2 broken tests.

# Test 1: Clear all returns everything to default state.
The functionality was correct, the test was failing because it was not selecting the correct element to view if the new state is rendered properly. I decided to check that /Decline to answer/ was in the DOM rather than burrowing looking for the value of 9. Changed DOB reset value to empty string.

# Test 2: submits a basic info profile update when you click the submit button

This one was harder to test. You can't type any specific date into this MUI component using RTL because it automatically opens the calendar view. What I decided to do was press enter to automatically select the current date, as the current date will always be default highlighted in the component. There's some variation in how Date.now() and the DatePicker element format the current date, so I converted Date.now() to the raw formatted yyyy-mm-dd date, and back into a days object to compare to the DatePicker's value. 