### PR TITLE
[Bug Fix] - Issue 640/fix mui autocomplete errors

### DIFF
--- a/src/components/Modals/NewMessageModal.jsx
+++ b/src/components/Modals/NewMessageModal.jsx
@@ -144,13 +144,13 @@ const NewMessageModal = ({ showModal, setShowModal, oldMessage = '', toField = '
           >
             <Autocomplete
               data-testid="newMessageTo"
+              id="recipientPodUrl"
               freeSolo
               value={recipientName?.person ?? message.recipientPodUrl}
               disablePortal
               autoSelect
-              id="recipientPodUrl"
               options={contactListOptions}
-              onChange={(event, newValue) => {
+              onChange={(_event, newValue) => {
                 setMessage({
                   ...message,
                   // If user wants to use a custom webId instead of a contact option, set the recipient value to the typed input
@@ -158,11 +158,9 @@ const NewMessageModal = ({ showModal, setShowModal, oldMessage = '', toField = '
                 });
               }}
               fullWidth
-              required
-              autoFocus
               disabled={Boolean(toField) || Boolean(oldMessage)}
               renderInput={(params) => (
-                <TextField {...params} margin="normal" label="To" required />
+                <TextField {...params} autoFocus margin="normal" label="To" required />
               )}
             />
             <TextField

--- a/src/components/Modals/SetAclPermissionsModal.jsx
+++ b/src/components/Modals/SetAclPermissionsModal.jsx
@@ -125,13 +125,7 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
         }
       >
         <form onSubmit={handleAclPermission} autoComplete="off" style={{ width: '100%' }}>
-          <FormControl
-            required
-            fullWidth
-            sx={{
-              mb: '1rem'
-            }}
-          >
+          <FormControl required fullWidth sx={{ mb: '1rem' }}>
             <InputLabel id="permissionType-label">Select One</InputLabel>
             <Select
               labelId="permissionType-label"
@@ -149,6 +143,7 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
           </FormControl>
           <Autocomplete
             data-testid="newShareWith"
+            id="set-acl-to"
             sx={{ mb: '1rem' }}
             freeSolo
             fullWidth
@@ -166,7 +161,6 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
             renderInput={(params) => (
               <TextField
                 {...params}
-                id="set-acl-to"
                 name="setAclTo"
                 autoFocus
                 label="WebID to share with"

--- a/src/components/Modals/SetAclPermissionsModal.jsx
+++ b/src/components/Modals/SetAclPermissionsModal.jsx
@@ -58,8 +58,6 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
   const shareName = data?.filter(
     (contact) => permissionState.webIdToSetPermsTo === contact.webId
   )[0];
-  const isError = permissionState.webIdToSetPermsTo === webId;
-  const helperText = isError ? 'Cannot share to your own pod.' : '';
 
   const clearInputFields = () => {
     setPermissionState({
@@ -150,14 +148,11 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
             </Select>
           </FormControl>
           <Autocomplete
-            id="set-acl-to"
-            name="setAclTo"
             data-testid="newShareWith"
             sx={{ mb: '1rem' }}
             freeSolo
             fullWidth
             required
-            autoFocus
             value={shareName?.person ?? permissionState.webIdToSetPermsTo}
             disablePortal
             autoSelect
@@ -168,17 +163,18 @@ const SetAclPermissionsModal = ({ showModal, setShowModal, dataset }) => {
                 webIdToSetPermsTo: newValue.id ?? newValue
               });
             }}
-            placeholder="WebID to share with"
-            error={permissionState.webIdToSetPermsTo === webId}
-            helperText={
-              permissionState.webIdToSetPermsTo === webId ? 'Cannot share to your own pod.' : ''
-            }
             renderInput={(params) => (
               <TextField
                 {...params}
+                id="set-acl-to"
+                name="setAclTo"
+                autoFocus
                 label="WebID to share with"
-                error={isError}
-                helperText={helperText}
+                placeholder="WebID to share with"
+                error={permissionState.webIdToSetPermsTo === webId}
+                helperText={
+                  permissionState.webIdToSetPermsTo === webId ? 'Cannot share to your own pod.' : ''
+                }
               />
             )}
           />

--- a/src/components/NavBar/OidcLoginComponent.jsx
+++ b/src/components/NavBar/OidcLoginComponent.jsx
@@ -84,7 +84,7 @@ const OidcLoginComponent = ({ setShowSignInModal }) => {
         onInputChange={(_, newInputValue) => {
           setOidcIssuer(newInputValue);
         }}
-        ListboxProps={{ style: { maxHeight: '12rem' } }}
+        ListboxProps={{ sx: { maxHeight: '12rem' } }}
         renderInput={(renderParams) => (
           <TextField
             {...renderParams}

--- a/src/contexts/SignedInUserContext.jsx
+++ b/src/contexts/SignedInUserContext.jsx
@@ -36,9 +36,11 @@ export const SignedInUserContextProvider = ({ children }) => {
   const [loadingUserInfo, setLoadingUserInfo] = useState(true);
   const [podUrl, setPodUrl] = useState('');
   const [profileData, setProfileData] = useState(null);
+  const { webId } = session.info;
 
   const userInfoMemo = useMemo(
     () => ({
+      webId,
       podUrl,
       profileData,
       setProfileData: async (newProfileData) => setProfileData(newProfileData),
@@ -53,7 +55,6 @@ export const SignedInUserContextProvider = ({ children }) => {
   useEffect(() => {
     const loadUserInfo = async () => {
       try {
-        const { webId } = session.info;
         let fetchedPodUrl = (await getPodUrlAll(webId, { fetch: session.fetch }))[0];
         fetchedPodUrl = fetchedPodUrl || webId.split('profile')[0];
         setPodUrl(fetchedPodUrl);


### PR DESCRIPTION
## This PR:

Resolves #640 by moving props meant for TextField from the Autocomplete component and included webId as part of `SignedInUserContext`, which was not previously called.

The warning from MUI no longer appears and validation for Autocomplete is working again (see clip).

## Screenshots (if applicable):

https://github.com/codeforpdx/PASS/assets/14917816/b2f67f4c-1c44-49bb-a6f3-dc2f6e9482a4