### PR TITLE
Per Issue #646, switched order in `npm start` to run podserver first,…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.12.0",
   "description": "",
   "scripts": {
-    "start": "concurrently --kill-others \"npm run dev\" \"npm run podserver\"",
+    "start": "concurrently --kill-others \"npm run podserver\" \"npm run dev\"",
     "dev": "vite --host",
     "build": "vite build",
     "test": "vitest",


### PR DESCRIPTION
## This PR:
Resolves #646 
 
**1.** Switched order in `npm start` of package so podserver is first, then `npm run dev`. ran it — all still works fine. All tests still run with no errors. Ready for merge.

## Screenshots (if applicable):
<img width="985" alt="Screenshot 2024-06-06 at 04 49 56" src="https://github.com/codeforpdx/PASS/assets/398378/88867b27-eba8-40bf-86a7-6a203aab8c67">
<img width="568" alt="Screenshot 2024-06-06 at 04 51 39" src="https://github.com/codeforpdx/PASS/assets/398378/1a8b9743-4bd4-483d-938a-ed6ea3496f02">
<img width="1460" alt="Screenshot 2024-06-06 at 04 53 23" src="https://github.com/codeforpdx/PASS/assets/398378/f087e8ed-26cf-47d1-b2e6-21556fbeb64a">

## Additional Context (optional):
N/A

## Future Steps/PRs Needed to Finish This Work (optional):
N/A

## Issues needing discussion/feedback (optional):
**1.** None known.
