### PR TITLE
587: Restyle Sign In

### DIFF
--- a/src/components/Signup/ExistingPodForm.jsx
+++ b/src/components/Signup/ExistingPodForm.jsx
@@ -37,7 +37,7 @@ const ExistingPodForm = () => {
   };
 
   return (
-    <Box component="form" onSubmit={loginHandler} sx={formRowStyle}>
+    <Box component="form" onSubmit={loginHandler} sx={formRowStyle} textAlign="center">
       {/* TODO: Consider changing this to Autocomplete like the NavBar and SignInModal have */}
       <TextField
         sx={textFieldStyle}

--- a/src/components/Signup/ExistingPodForm.jsx
+++ b/src/components/Signup/ExistingPodForm.jsx
@@ -9,7 +9,12 @@ import TextField from '@mui/material/TextField';
 
 /* Styles */
 const formRowStyle = {
-  margin: '20px 0'
+  m: 1
+};
+
+const textFieldStyle = {
+  margin: '8px',
+  width: '27ch'
 };
 
 // TODO: Add JSDocs
@@ -32,29 +37,27 @@ const ExistingPodForm = () => {
   };
 
   return (
-    <Box>
-      <form onSubmit={loginHandler} style={formRowStyle}>
-        {/* TODO: Consider changing this to Autocomplete like the NavBar and SignInModal have */}
-        <TextField
-          sx={{ margin: '8px' }}
-          id="existing-pod-provider"
-          aria-label="Pod Provider"
-          label="Pod Provider"
-          variant="outlined"
-          onChange={(e) => setOidcIssuer(e.target.value)}
-          required
-        />
-        <br />
-        <Button
-          variant="contained"
-          color="primary"
-          size="large"
-          aria-label="Login to Pod Provider"
-          type="submit"
-        >
-          Login to Pod Provider
-        </Button>
-      </form>
+    <Box component="form" onSubmit={loginHandler} sx={formRowStyle}>
+      {/* TODO: Consider changing this to Autocomplete like the NavBar and SignInModal have */}
+      <TextField
+        sx={textFieldStyle}
+        id="existing-pod-provider"
+        label="Pod Provider"
+        variant="outlined"
+        onChange={(e) => setOidcIssuer(e.target.value)}
+        fullWidth
+        required
+      />
+      <br />
+      <Button
+        variant="contained"
+        color="primary"
+        size="large"
+        aria-label="Login to Pod Provider"
+        type="submit"
+      >
+        Login to Pod Provider
+      </Button>
     </Box>
   );
 };

--- a/src/components/Signup/ExistingPodForm.jsx
+++ b/src/components/Signup/ExistingPodForm.jsx
@@ -4,8 +4,7 @@ import React, { useState } from 'react';
 import { useSession } from '@hooks';
 // Material UI Imports
 import Button from '@mui/material/Button';
-import Card from '@mui/material/Card';
-import CardHeader from '@mui/material/CardHeader';
+import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 
 /* Styles */
@@ -33,14 +32,7 @@ const ExistingPodForm = () => {
   };
 
   return (
-    <Card
-      sx={{
-        padding: '8px',
-        margin: '8px',
-        boxShadow: '0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19)'
-      }}
-    >
-      <CardHeader title="Register with Existing Pod" />
+    <Box>
       <form onSubmit={loginHandler} style={formRowStyle}>
         {/* TODO: Consider changing this to Autocomplete like the NavBar and SignInModal have */}
         <TextField
@@ -63,7 +55,7 @@ const ExistingPodForm = () => {
           Login to Pod Provider
         </Button>
       </form>
-    </Card>
+    </Box>
   );
 };
 

--- a/src/components/Signup/PodRegistrationForm.jsx
+++ b/src/components/Signup/PodRegistrationForm.jsx
@@ -54,7 +54,13 @@ const PodRegistrationForm = ({ register, caseManagerName, previousInfo = null })
         <p>You will register with {caseManagerName ?? searchParams.get('webId')}</p>
       )}
 
-      <Box component="form" onSubmit={handleSubmit} sx={formRowStyle} autoComplete="off">
+      <Box
+        component="form"
+        onSubmit={handleSubmit}
+        sx={formRowStyle}
+        autoComplete="off"
+        textAlign="center"
+      >
         <TextField
           sx={textFieldStyle}
           id="email-form"

--- a/src/components/Signup/PodRegistrationForm.jsx
+++ b/src/components/Signup/PodRegistrationForm.jsx
@@ -7,8 +7,8 @@ import FilledInput from '@mui/material/FilledInput';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import InputLabel from '@mui/material/InputLabel';
+import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
-import { Box } from '@mui/material';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 
 const formRowStyle = {
@@ -37,12 +37,16 @@ const PodRegistrationForm = ({ register, caseManagerName, previousInfo = null })
     previousInfo ? previousInfo.confirmPassword : ''
   );
   const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const [searchParams] = useSearchParams();
   const handleSubmit = async (event) => {
     event.preventDefault();
     register(email, password, confirmPassword);
+  };
+
+  const handleClickShowPassword = () => setShowPassword((show) => !show);
+  const handleMouseDownPassword = (event) => {
+    event.preventDefault();
   };
 
   return (
@@ -68,9 +72,7 @@ const PodRegistrationForm = ({ register, caseManagerName, previousInfo = null })
           <FilledInput
             style={textFieldStyle}
             id="password-form"
-            inputProps={{
-              'aria-label': 'Password'
-            }}
+            aria-label="Password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             type={showPassword ? 'text' : 'password'}
@@ -78,7 +80,7 @@ const PodRegistrationForm = ({ register, caseManagerName, previousInfo = null })
               <InputAdornment position="end">
                 <IconButton
                   aria-label="toggle password visibility"
-                  onClick={() => setShowPassword(!showPassword)}
+                  onClick={handleClickShowPassword}
                   edge="end"
                 >
                   {showPassword ? <VisibilityOff /> : <Visibility />}
@@ -93,20 +95,19 @@ const PodRegistrationForm = ({ register, caseManagerName, previousInfo = null })
           <FilledInput
             style={textFieldStyle}
             id="confirm-password-form"
-            inputProps={{
-              'aria-label': 'Confirm Password'
-            }}
+            aria-label="Confirm Password"
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}
-            type={showConfirmPassword ? 'text' : 'password'}
+            type={showPassword ? 'text' : 'password'}
             endAdornment={
               <InputAdornment position="end">
                 <IconButton
-                  aria-label="toggle confirm password visibility"
-                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  aria-label="toggle password visibility"
+                  onClick={() => setShowPassword(!showPassword)}
+                  onMouseDown={handleMouseDownPassword}
                   edge="end"
                 >
-                  {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                  {showPassword ? <VisibilityOff /> : <Visibility />}
                 </IconButton>
               </InputAdornment>
             }

--- a/src/components/Signup/PodRegistrationForm.jsx
+++ b/src/components/Signup/PodRegistrationForm.jsx
@@ -3,22 +3,13 @@ import React, { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 // Material UI Imports
 import Button from '@mui/material/Button';
-import Card from '@mui/material/Card';
-import CardHeader from '@mui/material/CardHeader';
 import FilledInput from '@mui/material/FilledInput';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import InputLabel from '@mui/material/InputLabel';
 import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
+import { Box } from '@mui/material';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
-
-/* Styles for MUI components */
-const cardStyle = {
-  padding: '8px',
-  margin: '8px',
-  boxShadow: '0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19)'
-};
 
 const formRowStyle = {
   margin: '20px 0'
@@ -56,23 +47,11 @@ const PodRegistrationForm = ({ register, caseManagerName, previousInfo = null })
 
   return (
     <>
-      <Typography
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        mb={2}
-        variant="h5"
-        component="h3"
-      >
-        Register For PASS
-      </Typography>
       {searchParams.get('webId') && (
         <p>You will register with {caseManagerName ?? searchParams.get('webId')}</p>
       )}
 
-      <Card variant="outlined" sx={cardStyle}>
-        <CardHeader title="Set Up a New Pod" />
-
+      <Box>
         <form onSubmit={handleSubmit} style={formRowStyle} autoComplete="off">
           <TextField
             style={textFieldStyle}
@@ -145,7 +124,7 @@ const PodRegistrationForm = ({ register, caseManagerName, previousInfo = null })
             Set up your Pod
           </Button>
         </form>
-      </Card>
+      </Box>
     </>
   );
 };

--- a/src/components/Signup/PodRegistrationForm.jsx
+++ b/src/components/Signup/PodRegistrationForm.jsx
@@ -3,20 +3,19 @@ import React, { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 // Material UI Imports
 import Button from '@mui/material/Button';
-import FilledInput from '@mui/material/FilledInput';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
-import InputLabel from '@mui/material/InputLabel';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 
 const formRowStyle = {
-  margin: '20px 0'
+  m: 1
 };
 
 const textFieldStyle = {
-  margin: '8px'
+  margin: '8px',
+  width: '27ch'
 };
 
 /**
@@ -55,28 +54,30 @@ const PodRegistrationForm = ({ register, caseManagerName, previousInfo = null })
         <p>You will register with {caseManagerName ?? searchParams.get('webId')}</p>
       )}
 
-      <Box>
-        <form onSubmit={handleSubmit} style={formRowStyle} autoComplete="off">
-          <TextField
-            style={textFieldStyle}
-            id="email-form"
-            aria-label="Email"
-            label="Email"
-            variant="outlined"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-          />
-          <br />
-          <InputLabel htmlFor="password-form">Password</InputLabel>
-          <FilledInput
-            style={textFieldStyle}
-            id="password-form"
-            aria-label="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            type={showPassword ? 'text' : 'password'}
-            endAdornment={
+      <Box component="form" onSubmit={handleSubmit} sx={formRowStyle} autoComplete="off">
+        <TextField
+          sx={textFieldStyle}
+          id="email-form"
+          aria-label="Email"
+          label="Email"
+          variant="outlined"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          margin="normal"
+          required
+          fullWidth
+        />
+        <br />
+        <TextField
+          sx={textFieldStyle}
+          id="password-form"
+          margin="normal"
+          label="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          type={showPassword ? 'text' : 'password'}
+          InputProps={{
+            endAdornment: (
               <InputAdornment position="end">
                 <IconButton
                   aria-label="toggle password visibility"
@@ -86,20 +87,23 @@ const PodRegistrationForm = ({ register, caseManagerName, previousInfo = null })
                   {showPassword ? <VisibilityOff /> : <Visibility />}
                 </IconButton>
               </InputAdornment>
-            }
-            minLength="8"
-            required
-          />
-          <br />
-          <InputLabel htmlFor="confirm-password-form">Confirm Password</InputLabel>
-          <FilledInput
-            style={textFieldStyle}
-            id="confirm-password-form"
-            aria-label="Confirm Password"
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            type={showPassword ? 'text' : 'password'}
-            endAdornment={
+            )
+          }}
+          required
+          fullWidth
+          variant="outlined"
+          minLength="8"
+        />
+        <br />
+        <TextField
+          sx={textFieldStyle}
+          id="confirm-password-form"
+          label="Confirm Password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          type={showPassword ? 'text' : 'password'}
+          InputProps={{
+            endAdornment: (
               <InputAdornment position="end">
                 <IconButton
                   aria-label="toggle password visibility"
@@ -110,21 +114,23 @@ const PodRegistrationForm = ({ register, caseManagerName, previousInfo = null })
                   {showPassword ? <VisibilityOff /> : <Visibility />}
                 </IconButton>
               </InputAdornment>
-            }
-            minLength="8"
-            required
-          />
-          <br />
-          <Button
-            variant="contained"
-            color="primary"
-            size="large"
-            aria-label="Sign Up For a Pod"
-            type="submit"
-          >
-            Set up your Pod
-          </Button>
-        </form>
+            )
+          }}
+          variant="outlined"
+          minLength="8"
+          required
+          fullWidth
+        />
+        <br />
+        <Button
+          variant="contained"
+          color="primary"
+          size="large"
+          aria-label="Sign Up For a Pod"
+          type="submit"
+        >
+          Set up your Pod
+        </Button>
       </Box>
     </>
   );

--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -19,7 +19,6 @@ const Layout = ({ ariaLabel, children }) => {
     <Box
       aria-label={ariaLabel}
       sx={{
-        display: 'grid',
         minHeight: '100vh'
       }}
     >

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -10,7 +10,8 @@ import { FOAF } from '@inrupt/vocab-common-rdf';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
-import { Typography } from '@mui/material';
+
+import { Tab, Tabs, Typography } from '@mui/material';
 // Constant Imports
 import { ENV } from '@constants';
 // Signup Form Imports
@@ -22,6 +23,38 @@ import {
   ExistingPodForm
 } from '@components/Signup';
 
+const PassRegistrationTab = ({ register, caseManagerName, previousInfo }) => {
+  const [value, setValue] = useState('1');
+
+  const handleChange = (_event, newValue) => {
+    setValue(newValue);
+  };
+
+  return (
+    <Box>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Typography variant="h3" component="h1">
+          Register
+        </Typography>
+        <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
+          <Tab label="New Pod" value="1" />
+          <Tab label="Existing Pod" value="2" />
+        </Tabs>
+      </Box>
+      <Box hidden={value !== '1'}>
+        <PodRegistrationForm
+          register={register}
+          caseManagerName={caseManagerName}
+          previousInfo={previousInfo}
+        />
+      </Box>
+      <Box hidden={value !== '2'}>
+        <ExistingPodForm />
+      </Box>
+    </Box>
+  );
+};
+/**/
 /**
  * Signup - First screen in the user registration flow.
  * Allows users to either create a pod, or sign into an existing pod
@@ -100,13 +133,12 @@ const Signup = () => {
   }, [session.info.isLoggedIn, window.location.href]);
 
   return (
-    <Container>
+    <Container id="andrew">
       <Box
         sx={{
-          marginTop: 3,
           display: 'flex',
           flexDirection: 'column',
-          justifyContent: 'center',
+          justifyContent: 'flex-start',
           alignItems: 'center'
         }}
       >
@@ -116,19 +148,17 @@ const Signup = () => {
             display: 'inline-block',
             mx: '2px',
             padding: '20px',
-            minWidth: '400px',
+            minWidth: '280px',
+            margin: '24px',
             boxShadow: '0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19)'
           }}
         >
           {step === 'begin' && (
-            <>
-              <PodRegistrationForm
-                previousInfo={previousInfo}
-                register={registerAndInitialize}
-                caseManagerName={caseManagerName}
-              />
-              <ExistingPodForm />
-            </>
+            <PassRegistrationTab
+              previousInfo={previousInfo}
+              register={registerAndInitialize}
+              caseManagerName={caseManagerName}
+            />
           )}
           {step === 'loading' && <Typography>Creating Pod...</Typography>}
           {step === 'done' && (

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -33,10 +33,15 @@ const PassRegistrationTab = ({ register, caseManagerName, previousInfo }) => {
   return (
     <Box>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Typography variant="h4" component="h1">
+        <Typography variant="h4" component="h1" align="center">
           Sign Up
         </Typography>
-        <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
+        <Tabs
+          value={value}
+          onChange={handleChange}
+          aria-label="New or Existing Pod"
+          variant="fullWidth"
+        >
           <Tab label="New Pod" value="1" />
           <Tab label="Existing Pod" value="2" />
         </Tabs>

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -34,7 +34,7 @@ const PassRegistrationTab = ({ register, caseManagerName, previousInfo }) => {
     <Box>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
         <Typography variant="h4" component="h1">
-          Register
+          Sign Up
         </Typography>
         <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
           <Tab label="New Pod" value="1" />

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -33,7 +33,7 @@ const PassRegistrationTab = ({ register, caseManagerName, previousInfo }) => {
   return (
     <Box>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Typography variant="h3" component="h1">
+        <Typography variant="h4" component="h1">
           Register
         </Typography>
         <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
@@ -133,7 +133,7 @@ const Signup = () => {
   }, [session.info.isLoggedIn, window.location.href]);
 
   return (
-    <Container id="andrew">
+    <Container component="main" maxWidth="xs">
       <Box
         sx={{
           display: 'flex',
@@ -145,10 +145,8 @@ const Signup = () => {
         <Paper
           elevation={2}
           sx={{
-            display: 'inline-block',
             mx: '2px',
             padding: '20px',
-            minWidth: '280px',
             margin: '24px',
             boxShadow: '0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19)'
           }}


### PR DESCRIPTION
## This PR:
Resolves #587, #660
 
**1.** Updates the styling of the sign-in page to be visually simple. Separates new and existing pod sign-up into tabs (#587)
**2.** Changes the show password buttons to be connected (clicking either one shows both the password and confirm password)
**3.** Changes the display property of `Layout.jsx` from grid to the default (#660)

## Screenshots (if applicable):
[More screenshots here](https://github.com/codeforpdx/PASS/pull/653#issuecomment-2212597616)
### Before
![before_desktop](https://github.com/codeforpdx/PASS/assets/16945988/3047ec9e-53c6-429b-ace9-6631ee926439)
### After
![after_new_desktop](https://github.com/codeforpdx/PASS/assets/16945988/afede09e-67ee-4908-936f-edd2d40060c6)