### PR TITLE
Issue 651/reroute civic profile

### DIFF
--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -1,6 +1,6 @@
 // React Imports
 import React from 'react';
-import { Routes, Route, Navigate, Outlet } from 'react-router-dom';
+import { Routes, Route, Navigate, Outlet, useLocation } from 'react-router-dom';
 // Inrupt Imports
 import { useSession } from '@hooks';
 // Component Imports
@@ -23,6 +23,11 @@ const AppRoutes = () => {
   const restorePath = localStorage.getItem('restorePath');
   const loggedIn = session.info.isLoggedIn;
   const path = loggedIn ? restorePath || '/contacts' : '/';
+  const location = useLocation();
+
+  if (location.pathname === '/civic-profile') {
+    return <Navigate to="/civic-profile/basic-info" replace />;
+  }
 
   return (
     <Routes>
@@ -57,6 +62,7 @@ const AppRoutes = () => {
         <Route path="/civic-profile" element={<CivicProfile />}>
           {CIVIC_FORM_LIST.map((formProps) => (
             <Route
+              key={formProps.path}
               {...formProps}
               element={
                 <FormLayout>

--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -53,6 +53,7 @@ const AppRoutes = () => {
           ))}
         </Route>
         <Route path="/profile" element={<Profile />} />
+        {/* TODO: Remove blank Civic Profile page, ensure it directs Basic Information instead */}
         <Route path="/civic-profile" element={<CivicProfile />}>
           {CIVIC_FORM_LIST.map((formProps) => (
             <Route

--- a/src/components/CivicProfileForms/BasicInfo.jsx
+++ b/src/components/CivicProfileForms/BasicInfo.jsx
@@ -16,7 +16,7 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 // Dependency Imports
 import dayjs from 'dayjs';
-// Hooks Imports
+// Custom Hooks Imports
 import { useCivicProfile, useNotification } from '@hooks';
 // Component Imports
 import { FormSection } from '../Form';

--- a/src/components/CivicProfileForms/BasicInfo.jsx
+++ b/src/components/CivicProfileForms/BasicInfo.jsx
@@ -84,7 +84,7 @@ const BasicInfo = () => {
   return (
     <FormSection title="Basic Information">
       <form aria-labelledby="hmis-basic-info-form" onSubmit={handleSubmit} autoComplete="off">
-        <Grid container spacing={2}>
+        <Grid container spacing={2} mt={0} mb={2}>
           <Grid item xs={12} md={6}>
             <TextField
               id="hmis-basic-info-first-name"
@@ -147,7 +147,9 @@ const BasicInfo = () => {
               </Select>
             </FormControl>
           </Grid>
-          <Grid item xs={12} md={6}>
+        </Grid>
+        <Grid container spacing={1}>
+          <Grid item xs={12} sm={6}>
             <Button
               variant="outlined"
               type="button"
@@ -155,14 +157,13 @@ const BasicInfo = () => {
               color="error"
               startIcon={<ClearIcon />}
               fullWidth
-              sx={{ borderRadius: '20px' }}
               onClick={handleClear}
               aria-label="Clear button"
             >
               Clear
             </Button>
           </Grid>
-          <Grid item xs={12} md={6}>
+          <Grid item xs={12} sm={6}>
             <Button
               variant="contained"
               type="submit"
@@ -170,7 +171,6 @@ const BasicInfo = () => {
               color="primary"
               startIcon={<CheckIcon />}
               fullWidth
-              sx={{ borderRadius: '20px' }}
               disabled={!isSuccess}
               aria-label="Submit button"
             >

--- a/src/components/CivicProfileForms/FinancialInfo.jsx
+++ b/src/components/CivicProfileForms/FinancialInfo.jsx
@@ -1,13 +1,13 @@
-// React Imports
-import React from 'react';
-// Material UI Imports
-import Typography from '@mui/material/Typography';
-import { FormSection } from '../Form';
+// // React Imports
+// import React from 'react';
+// // Material UI Imports
+// import Typography from '@mui/material/Typography';
+// import { FormSection } from '../Form';
 
-const FinancialInfo = () => (
-  <FormSection title="Financial Information">
-    <Typography>To be completed</Typography>
-  </FormSection>
-);
+// const FinancialInfo = () => (
+//   <FormSection title="Financial Information">
+//     <Typography>To be completed</Typography>
+//   </FormSection>
+// );
 
-export default FinancialInfo;
+// export default FinancialInfo;

--- a/src/components/CivicProfileForms/FinancialInfo.jsx
+++ b/src/components/CivicProfileForms/FinancialInfo.jsx
@@ -2,7 +2,12 @@
 import React from 'react';
 // Material UI Imports
 import Typography from '@mui/material/Typography';
+import { FormSection } from '../Form';
 
-const FinancialInfo = () => <Typography>Financial Info</Typography>;
+const FinancialInfo = () => (
+  <FormSection title="Financial Information">
+    <Typography>To be completed</Typography>
+  </FormSection>
+);
 
 export default FinancialInfo;

--- a/src/components/CivicProfileForms/FormLayout.jsx
+++ b/src/components/CivicProfileForms/FormLayout.jsx
@@ -27,9 +27,15 @@ const FormLayout = ({ children }) => {
   const pageIdx = HMIS_FORM_LIST.findIndex((form) => form.path === path);
 
   return (
-    <Box sx={{ m: '8px' }}>
+    <Box>
       <Card>{children}</Card>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', my: 1 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          my: 1
+        }}
+      >
         {pageIdx > 0 ? (
           <Button
             variant="outlined"

--- a/src/components/CivicProfileForms/FormLayout.jsx
+++ b/src/components/CivicProfileForms/FormLayout.jsx
@@ -2,9 +2,11 @@
 import React from 'react';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
 // Material UI Imports
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
-import Link from '@mui/material/Link';
 // Other Imports
 import HMIS_FORM_LIST from './FormList';
 
@@ -25,20 +27,34 @@ const FormLayout = ({ children }) => {
   const pageIdx = HMIS_FORM_LIST.findIndex((form) => form.path === path);
 
   return (
-    <Box sx={{ margin: '8px' }}>
+    <Box sx={{ m: '8px' }}>
       <Card>{children}</Card>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', my: 1 }}>
         {pageIdx > 0 ? (
-          <Link component={RouterLink} to={`../${HMIS_FORM_LIST[pageIdx - 1].path}`}>
-            &lt; Prev
-          </Link>
+          <Button
+            variant="outlined"
+            component={RouterLink}
+            to={`../${HMIS_FORM_LIST[pageIdx - 1].path}`}
+            startIcon={<ArrowBackIcon />}
+            size="large"
+          >
+            Prev
+          </Button>
         ) : (
           <Box />
         )}
         {pageIdx < HMIS_FORM_LIST.length - 1 ? (
-          <Link component={RouterLink} to={`../${HMIS_FORM_LIST[pageIdx + 1].path}`}>
-            Next &gt;
-          </Link>
+          <Button
+            variant="outlined"
+            component={RouterLink}
+            to={`../${HMIS_FORM_LIST[pageIdx + 1].path}`}
+            endIcon={<ArrowForwardIcon />}
+            size="large"
+            // Disabled for incomplete Financial Information form
+            disabled={pageIdx === 1}
+          >
+            Next
+          </Button>
         ) : (
           <Box />
         )}

--- a/src/components/CivicProfileForms/FormLayout.jsx
+++ b/src/components/CivicProfileForms/FormLayout.jsx
@@ -7,7 +7,7 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
-// Other Imports
+// Component Imports
 import HMIS_FORM_LIST from './FormList';
 
 /**
@@ -27,12 +27,28 @@ const FormLayout = ({ children }) => {
   const pageIdx = HMIS_FORM_LIST.findIndex((form) => form.path === path);
 
   return (
-    <Box>
-      <Card>{children}</Card>
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        my: 1
+      }}
+    >
+      <Box
+        sx={{
+          width: '100%',
+          mb: 1
+        }}
+      >
+        <Card>{children}</Card>
+      </Box>
       <Box
         sx={{
           display: 'flex',
           justifyContent: 'space-between',
+          width: '100%',
           my: 1
         }}
       >

--- a/src/components/CivicProfileForms/FormList.js
+++ b/src/components/CivicProfileForms/FormList.js
@@ -1,16 +1,16 @@
 import BasicInfo from './BasicInfo';
-import FinancialInfo from './FinancialInfo';
+// import FinancialInfo from './FinancialInfo';
 import HousingInfo from './HousingInfo';
 
 const CIVIC_FORM_LIST = [
   { path: 'basic-info', label: 'Basic Information', element: BasicInfo, key: 'basic_info' },
-  { path: 'housing-info', label: 'Housing Information', element: HousingInfo, key: 'housing_info' },
-  {
-    path: 'financial-info',
-    label: 'Financial Information',
-    element: FinancialInfo,
-    key: 'financial_info'
-  }
+  { path: 'housing-info', label: 'Housing Information', element: HousingInfo, key: 'housing_info' }
+  // {
+  //   path: 'financial-info',
+  //   label: 'Financial Information',
+  //   element: FinancialInfo,
+  //   key: 'financial_info'
+  // }
 ];
 
 export default CIVIC_FORM_LIST;

--- a/src/components/CivicProfileForms/HousingInfo.jsx
+++ b/src/components/CivicProfileForms/HousingInfo.jsx
@@ -99,6 +99,7 @@ const HousingInfo = () => {
               label="Street:"
               onChange={handleChange}
               value={formData.lastPermanentStreet ?? ''}
+              autoComplete="street"
               fullWidth
               autoFocus
             />
@@ -110,6 +111,7 @@ const HousingInfo = () => {
               label="City:"
               onChange={handleChange}
               value={formData.lastPermanentCity ?? ''}
+              autoComplete="city"
               fullWidth
             />
           </Grid>
@@ -120,6 +122,7 @@ const HousingInfo = () => {
               label="State:"
               onChange={handleChange}
               value={formData.lastPermanentState ?? ''}
+              autoComplete="state"
               fullWidth
             />
           </Grid>
@@ -132,6 +135,7 @@ const HousingInfo = () => {
               value={formData.lastPermanentZIP ?? ''}
               error={zipError}
               helperText={zipError ? 'Invalid ZIP format. Expected: 12345 or 12345-6789' : ''}
+              autoComplete="postal-code"
               fullWidth
             />
           </Grid>

--- a/src/components/CivicProfileForms/HousingInfo.jsx
+++ b/src/components/CivicProfileForms/HousingInfo.jsx
@@ -22,7 +22,6 @@ import { FormSection } from '../Form';
  * @name HousingInfo
  * @returns {React.JSX.Element} The HousingInfo Component
  */
-
 const HousingInfo = () => {
   const { data, add, isSuccess, storedDataset, refetch } = useCivicProfile();
   const { addNotification } = useNotification();
@@ -92,14 +91,10 @@ const HousingInfo = () => {
   return (
     <FormSection title="Housing Information">
       <form aria-labelledby="hmis-basic-info-form" onSubmit={handleSubmit} autoComplete="off">
-        <Grid
-          container
-          spacing={2}
-          // columns={{ xs: 1, sm: 2 }}
-        >
+        <Grid container spacing={2} mt={0} mb={2}>
           <Grid item xs={12} md={6}>
             <TextField
-              id="street-input"
+              id="hmis-housing-info-last-street"
               name="lastPermanentStreet"
               label="Street:"
               onChange={handleChange}
@@ -110,7 +105,7 @@ const HousingInfo = () => {
           </Grid>
           <Grid item xs={12} md={6}>
             <TextField
-              id="city-input"
+              id="hmis-housing-info-last-city"
               name="lastPermanentCity"
               label="City:"
               onChange={handleChange}
@@ -120,7 +115,7 @@ const HousingInfo = () => {
           </Grid>
           <Grid item xs={12} md={6}>
             <TextField
-              id="state-input"
+              id="hmis-housing-info-last-state"
               name="lastPermanentState"
               label="State:"
               onChange={handleChange}
@@ -130,7 +125,7 @@ const HousingInfo = () => {
           </Grid>
           <Grid item xs={12} md={6}>
             <TextField
-              id="zip-input"
+              id="hmis-housing-info-last-zip"
               name="lastPermanentZIP"
               label="ZIP Code:"
               onChange={handleChange}
@@ -146,7 +141,7 @@ const HousingInfo = () => {
                 Months Houseless Past 3 Years:
               </InputLabel>
               <Select
-                id="months-homeless-input"
+                id="hmis-housing-info-months-homeless"
                 labelId="months-homeless-input-label"
                 name="monthsHomeless"
                 label="Months Houseless Past 3 Years:"
@@ -178,7 +173,7 @@ const HousingInfo = () => {
                 Number of Times Houseless Past 3 Years:
               </InputLabel>
               <Select
-                id="times-homeless-input"
+                id="hmis-housing-info-times-homeless"
                 labelId="times-homeless-input-label"
                 name="timesHomeless"
                 label="Number of Times Houseless Past 3 Years:"
@@ -201,7 +196,7 @@ const HousingInfo = () => {
                 Time Until Loss of Housing:
               </InputLabel>
               <Select
-                id="time-to-housing-loss-input"
+                id="hmis-housing-info-time-to-housing-loss"
                 labelId="time-to-housing-loss-input-label"
                 name="timeToHousingLoss"
                 label="Time Until Loss of Housing:"
@@ -217,8 +212,8 @@ const HousingInfo = () => {
             </FormControl>
           </Grid>
         </Grid>
-        <Grid container>
-          <Grid item xs={12} md={6}>
+        <Grid container spacing={1}>
+          <Grid item xs={12} sm={6}>
             <Button
               variant="outlined"
               type="button"
@@ -227,14 +222,13 @@ const HousingInfo = () => {
               color="error"
               startIcon={<ClearIcon />}
               fullWidth
-              // sx={{ borderRadius: '20px' }}
               onClick={handleClear}
               aria-label="Clear button"
             >
               Clear
             </Button>
           </Grid>
-          <Grid xs={12} md={6}>
+          <Grid item xs={12} sm={6}>
             <Button
               variant="contained"
               type="submit"
@@ -243,7 +237,6 @@ const HousingInfo = () => {
               color="primary"
               startIcon={<CheckIcon />}
               fullWidth
-              // sx={{ borderRadius: '20px' }}
               onClick={handleSubmit}
               disabled={!isSuccess}
               aria-label="Submit button"

--- a/src/components/CivicProfileForms/HousingInfo.jsx
+++ b/src/components/CivicProfileForms/HousingInfo.jsx
@@ -1,17 +1,18 @@
 // React Imports
-import React, { useState, useEffect } from 'react';
-// MUI Imports
-import FormControl from '@mui/material/FormControl';
-import Grid from '@mui/material/Grid';
-import TextField from '@mui/material/TextField';
-import Select from '@mui/material/Select';
-import InputLabel from '@mui/material/InputLabel';
-import MenuItem from '@mui/material/MenuItem';
+import React, { useEffect, useState } from 'react';
+// Material UI Imports
 import Button from '@mui/material/Button';
 import CheckIcon from '@mui/icons-material/Check';
 import ClearIcon from '@mui/icons-material/Clear';
+import FormControl from '@mui/material/FormControl';
+import Grid from '@mui/material/Grid';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import TextField from '@mui/material/TextField';
 // Custom Hooks Imports
 import { useCivicProfile, useNotification } from '@hooks';
+// Component Imports
 import { FormSection } from '../Form';
 
 /**
@@ -90,38 +91,44 @@ const HousingInfo = () => {
 
   return (
     <FormSection title="Housing Information">
-      <Grid container spacing={2}>
-        <Grid item xs={6}>
-          <FormControl
-            onSubmit={handleSubmit}
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '8px',
-              justifyContent: 'space-between'
-            }}
-          >
+      <form aria-labelledby="hmis-basic-info-form" onSubmit={handleSubmit} autoComplete="off">
+        <Grid
+          container
+          spacing={2}
+          // columns={{ xs: 1, sm: 2 }}
+        >
+          <Grid item xs={12} md={6}>
             <TextField
               id="street-input"
               name="lastPermanentStreet"
               label="Street:"
               onChange={handleChange}
               value={formData.lastPermanentStreet ?? ''}
+              fullWidth
+              autoFocus
             />
+          </Grid>
+          <Grid item xs={12} md={6}>
             <TextField
               id="city-input"
               name="lastPermanentCity"
               label="City:"
               onChange={handleChange}
               value={formData.lastPermanentCity ?? ''}
+              fullWidth
             />
+          </Grid>
+          <Grid item xs={12} md={6}>
             <TextField
               id="state-input"
               name="lastPermanentState"
               label="State:"
               onChange={handleChange}
               value={formData.lastPermanentState ?? ''}
+              fullWidth
             />
+          </Grid>
+          <Grid item xs={12} md={6}>
             <TextField
               id="zip-input"
               name="lastPermanentZIP"
@@ -130,81 +137,88 @@ const HousingInfo = () => {
               value={formData.lastPermanentZIP ?? ''}
               error={zipError}
               helperText={zipError ? 'Invalid ZIP format. Expected: 12345 or 12345-6789' : ''}
+              fullWidth
             />
-          </FormControl>
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <FormControl fullWidth>
+              <InputLabel id="months-homeless-input-label">
+                Months Houseless Past 3 Years:
+              </InputLabel>
+              <Select
+                id="months-homeless-input"
+                labelId="months-homeless-input-label"
+                name="monthsHomeless"
+                label="Months Houseless Past 3 Years:"
+                onChange={handleChange}
+                value={formData.monthsHomeless ?? ''}
+              >
+                <MenuItem value={101}>1 Month</MenuItem>
+                <MenuItem value={102}>2 Months</MenuItem>
+                <MenuItem value={103}>3 Months</MenuItem>
+                <MenuItem value={104}>4 Months</MenuItem>
+                <MenuItem value={105}>5 Months</MenuItem>
+                <MenuItem value={106}>6 Months</MenuItem>
+                <MenuItem value={107}>7 Months</MenuItem>
+                <MenuItem value={108}>8 Months</MenuItem>
+                <MenuItem value={109}>9 Months</MenuItem>
+                <MenuItem value={110}>10 Months</MenuItem>
+                <MenuItem value={111}>11 Months</MenuItem>
+                <MenuItem value={112}>12 Months</MenuItem>
+                <MenuItem value={113}>More than 12 Months</MenuItem>
+                <MenuItem value={8}>Client doesn’t know</MenuItem>
+                <MenuItem value={9}>Client refused</MenuItem>
+                <MenuItem value={99}>Data not collected</MenuItem>
+              </Select>
+            </FormControl>
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <FormControl fullWidth>
+              <InputLabel id="times-homeless-input-label">
+                Number of Times Houseless Past 3 Years:
+              </InputLabel>
+              <Select
+                id="times-homeless-input"
+                labelId="times-homeless-input-label"
+                name="timesHomeless"
+                label="Number of Times Houseless Past 3 Years:"
+                onChange={handleChange}
+                value={formData.timesHomeless ?? ''}
+              >
+                <MenuItem value={1}>One Time</MenuItem>
+                <MenuItem value={2}>Two Times</MenuItem>
+                <MenuItem value={3}>Three Times</MenuItem>
+                <MenuItem value={4}>Four or more Times</MenuItem>
+                <MenuItem value={8}>Client doesn’t know</MenuItem>
+                <MenuItem value={9}>Client refused</MenuItem>
+                <MenuItem value={99}>Data not collected</MenuItem>
+              </Select>
+            </FormControl>
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <FormControl fullWidth>
+              <InputLabel id="time-to-housing-loss-input-label">
+                Time Until Loss of Housing:
+              </InputLabel>
+              <Select
+                id="time-to-housing-loss-input"
+                labelId="time-to-housing-loss-input-label"
+                name="timeToHousingLoss"
+                label="Time Until Loss of Housing:"
+                onChange={handleChange}
+                value={formData.timeToHousingLoss ?? ''}
+              >
+                <MenuItem value={0}>0-6 Days</MenuItem>
+                <MenuItem value={1}>7-13 Days</MenuItem>
+                <MenuItem value={2}>14-21 Days</MenuItem>
+                <MenuItem value={3}>More than 21 days (0 points)</MenuItem>
+                <MenuItem value={99}>Data not collected</MenuItem>
+              </Select>
+            </FormControl>
+          </Grid>
         </Grid>
-        <Grid item xs={6} style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-          <FormControl onSubmit={handleSubmit}>
-            <InputLabel id="months-homeless-input-label">Months Houseless Past 3 Years:</InputLabel>
-            <Select
-              id="months-homeless-input"
-              labelId="months-homeless-input-label"
-              name="monthsHomeless"
-              label="Months Houseless Past 3 Years:"
-              onChange={handleChange}
-              value={formData.monthsHomeless ?? ''}
-            >
-              <MenuItem value={101}>1 Month</MenuItem>
-              <MenuItem value={102}>2 Months</MenuItem>
-              <MenuItem value={103}>3 Months</MenuItem>
-              <MenuItem value={104}>4 Months</MenuItem>
-              <MenuItem value={105}>5 Months</MenuItem>
-              <MenuItem value={106}>6 Months</MenuItem>
-              <MenuItem value={107}>7 Months</MenuItem>
-              <MenuItem value={108}>8 Months</MenuItem>
-              <MenuItem value={109}>9 Months</MenuItem>
-              <MenuItem value={110}>10 Months</MenuItem>
-              <MenuItem value={111}>11 Months</MenuItem>
-              <MenuItem value={112}>12 Months</MenuItem>
-              <MenuItem value={113}>More than 12 Months</MenuItem>
-              <MenuItem value={8}>Client doesn’t know</MenuItem>
-              <MenuItem value={9}>Client refused</MenuItem>
-              <MenuItem value={99}>Data not collected</MenuItem>
-            </Select>
-          </FormControl>
-          <FormControl onSubmit={handleSubmit}>
-            <InputLabel id="times-homeless-input-label">
-              Number of Times Houseless Past 3 Years:
-            </InputLabel>
-            <Select
-              id="times-homeless-input"
-              labelId="times-homeless-input-label"
-              name="timesHomeless"
-              label="Number of Times Houseless Past 3 Years:"
-              onChange={handleChange}
-              value={formData.timesHomeless ?? ''}
-            >
-              <MenuItem value={1}>One Time</MenuItem>
-              <MenuItem value={2}>Two Times</MenuItem>
-              <MenuItem value={3}>Three Times</MenuItem>
-              <MenuItem value={4}>Four or more Times</MenuItem>
-              <MenuItem value={8}>Client doesn’t know</MenuItem>
-              <MenuItem value={9}>Client refused</MenuItem>
-              <MenuItem value={99}>Data not collected</MenuItem>
-            </Select>
-          </FormControl>
-          <FormControl onSubmit={handleSubmit}>
-            <InputLabel id="time-to-housing-loss-input-label">
-              Time Until Loss of Housing:
-            </InputLabel>
-            <Select
-              id="time-to-housing-loss-input"
-              labelId="time-to-housing-loss-input-label"
-              name="timeToHousingLoss"
-              label="Time Until Loss of Housing:"
-              onChange={handleChange}
-              value={formData.timeToHousingLoss ?? ''}
-            >
-              <MenuItem value={0}>0-6 Days</MenuItem>
-              <MenuItem value={1}>7-13 Days</MenuItem>
-              <MenuItem value={2}>14-21 Days</MenuItem>
-              <MenuItem value={3}>More than 21 days (0 points)</MenuItem>
-              <MenuItem value={99}>Data not collected</MenuItem>
-            </Select>
-          </FormControl>
-        </Grid>
-        <Grid item xs={6}>
-          <FormControl style={{ display: 'flex' }}>
+        <Grid container>
+          <Grid item xs={12} md={6}>
             <Button
               variant="outlined"
               type="button"
@@ -213,16 +227,14 @@ const HousingInfo = () => {
               color="error"
               startIcon={<ClearIcon />}
               fullWidth
-              sx={{ borderRadius: '20px' }}
+              // sx={{ borderRadius: '20px' }}
               onClick={handleClear}
               aria-label="Clear button"
             >
               Clear
             </Button>
-          </FormControl>
-        </Grid>
-        <Grid item xs={6}>
-          <FormControl style={{ display: 'flex' }}>
+          </Grid>
+          <Grid xs={12} md={6}>
             <Button
               variant="contained"
               type="submit"
@@ -231,16 +243,16 @@ const HousingInfo = () => {
               color="primary"
               startIcon={<CheckIcon />}
               fullWidth
-              sx={{ borderRadius: '20px' }}
+              // sx={{ borderRadius: '20px' }}
               onClick={handleSubmit}
               disabled={!isSuccess}
               aria-label="Submit button"
             >
               Submit
             </Button>
-          </FormControl>
+          </Grid>
         </Grid>
-      </Grid>
+      </form>
     </FormSection>
   );
 };

--- a/src/components/CivicProfileForms/index.js
+++ b/src/components/CivicProfileForms/index.js
@@ -1,7 +1,13 @@
 import BasicInfo from './BasicInfo';
-import FinancialInfo from './FinancialInfo';
+// import FinancialInfo from './FinancialInfo';
 import HousingInfo from './HousingInfo';
 import FormLayout from './FormLayout';
 import CIVIC_FORM_LIST from './FormList';
 
-export { BasicInfo, FinancialInfo, HousingInfo, FormLayout, CIVIC_FORM_LIST };
+export {
+  BasicInfo,
+  // FinancialInfo,
+  HousingInfo,
+  FormLayout,
+  CIVIC_FORM_LIST
+};

--- a/src/components/Form/FormSection.jsx
+++ b/src/components/Form/FormSection.jsx
@@ -25,12 +25,7 @@ const FormSection = ({ title, headingId, children }) => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        alignItems: 'center',
-        padding: '20px',
-        width: '100%'
+        p: '20px'
       }}
     >
       <Typography

--- a/src/components/Modals/AddContactModal.jsx
+++ b/src/components/Modals/AddContactModal.jsx
@@ -153,20 +153,20 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
               autoComplete="given-name"
               value={userGivenName}
               onChange={(e) => setUserGivenName(e.target.value)}
-              fullWidth
               autoFocus
             />
           </FormControl>
-          <TextField
-            margin="normal"
-            id="add-user-family-name"
-            name="addUserFamilyName"
-            label="Last/family name (Optional)"
-            autoComplete="family-name"
-            value={userFamilyName}
-            onChange={(e) => setUserFamilyName(e.target.value)}
-            fullWidth
-          />
+          <FormControl fullWidth>
+            <TextField
+              margin="normal"
+              id="add-user-family-name"
+              name="addUserFamilyName"
+              label="Last/family name (Optional)"
+              autoComplete="family-name"
+              value={userFamilyName}
+              onChange={(e) => setUserFamilyName(e.target.value)}
+            />
+          </FormControl>
           <Tooltip
             title="Select the server/website where your pod is located"
             margin="normal"
@@ -182,7 +182,6 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
                 data-testid="select-oidc"
                 onChange={handleOidcSelection}
                 value={Oidc}
-                fullWidth
                 aria-required
               >
                 {oidcProviders.map((oidc) => (
@@ -210,7 +209,6 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
                   onChange={(e) => setUserName(e.target.value)}
                   required={!customWebID}
                   aria-required
-                  fullWidth
                   autoFocus
                 />
               </FormControl>
@@ -273,7 +271,6 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
                   setShowAddContactModal(false);
                 }}
                 fullWidth
-                sx={{ borderRadius: '20px' }}
               >
                 Cancel
               </Button>
@@ -284,7 +281,6 @@ const AddContactModal = ({ addContact, showAddContactModal, setShowAddContactMod
                 endIcon={<CheckIcon />}
                 type="submit"
                 fullWidth
-                sx={{ borderRadius: '20px' }}
               >
                 Add Contact
               </Button>

--- a/src/pages/CivicProfile.jsx
+++ b/src/pages/CivicProfile.jsx
@@ -4,8 +4,8 @@ import { Link, Outlet, useLocation } from 'react-router-dom';
 // Material UI Imports
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
-import MenuItem from '@mui/material/MenuItem';
-import MenuList from '@mui/material/MenuList';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/system';
 // Component Imports
@@ -27,18 +27,25 @@ const CivicProfile = () => {
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
   return (
-    <Container sx={{ display: 'flex', flexDirection: isSmallScreen ? 'column' : 'row' }}>
-      <Box sx={{ width: isSmallScreen ? '100%' : '25%', minWidth: '250px' }}>
+    <Container>
+      <Box>
         <nav>
-          <MenuList>
+          <Tabs
+            value={currentForm}
+            orientation={isSmallScreen ? 'vertical' : 'horizontal'}
+            aria-label="civic profile tabs"
+          >
             {CIVIC_FORM_LIST.map((form) => (
-              <Link to={form.path} style={{ textDecoration: 'none' }} key={form.path}>
-                <MenuItem divider selected={currentForm === form.path}>
-                  {form.label}
-                </MenuItem>
-              </Link>
+              <Tab
+                key={form.path}
+                component={Link}
+                to={form.path}
+                label={form.label}
+                value={form.path}
+                disabled={form.label === 'Financial Information'}
+              />
             ))}
-          </MenuList>
+          </Tabs>
         </nav>
       </Box>
       <Container>

--- a/src/pages/CivicProfile.jsx
+++ b/src/pages/CivicProfile.jsx
@@ -28,13 +28,18 @@ const CivicProfile = () => {
 
   return (
     <Container>
-      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center'
+        }}
+      >
         <nav>
           <Tabs
             value={currentForm}
-            // orientation={isSmallScreen ? 'vertical' : 'horizontal'}
             aria-label="civic profile tabs"
-            // centered
+            centered={isSmallScreen ? null : true}
             variant={isSmallScreen ? 'scrollable' : null}
           >
             {CIVIC_FORM_LIST.map((form) => (

--- a/src/pages/CivicProfile.jsx
+++ b/src/pages/CivicProfile.jsx
@@ -6,8 +6,6 @@ import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { useTheme } from '@mui/system';
 // Component Imports
 import { CIVIC_FORM_LIST } from '@components/CivicProfileForms';
 
@@ -23,8 +21,6 @@ const CivicProfile = () => {
 
   localStorage.setItem('restorePath', location.pathname);
   const currentForm = location.pathname.split('/').pop();
-  const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
   return (
     <Container>
@@ -36,11 +32,7 @@ const CivicProfile = () => {
         }}
       >
         <nav>
-          <Tabs
-            orientation={isSmallScreen ? 'vertical' : 'horizontal'}
-            value={currentForm}
-            aria-label="civic profile tabs"
-          >
+          <Tabs value={currentForm} aria-label="civic profile tabs">
             {CIVIC_FORM_LIST.map((form) => (
               <Tab
                 key={form.path}
@@ -48,8 +40,6 @@ const CivicProfile = () => {
                 to={form.path}
                 label={form.label}
                 value={form.path}
-                // Disabled for incomplete Financial Information form
-                disabled={form.label === 'Financial Information'}
               />
             ))}
           </Tabs>

--- a/src/pages/CivicProfile.jsx
+++ b/src/pages/CivicProfile.jsx
@@ -6,8 +6,8 @@ import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { useTheme } from '@mui/system';
+// import useMediaQuery from '@mui/material/useMediaQuery';
+// import { useTheme } from '@mui/system';
 // Component Imports
 import { CIVIC_FORM_LIST } from '@components/CivicProfileForms';
 
@@ -23,8 +23,8 @@ const CivicProfile = () => {
 
   localStorage.setItem('restorePath', location.pathname);
   const currentForm = location.pathname.split('/').pop();
-  const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+  // const theme = useTheme();
+  // const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
   return (
     <Container>
@@ -32,7 +32,7 @@ const CivicProfile = () => {
         <nav>
           <Tabs
             value={currentForm}
-            orientation={isSmallScreen ? 'vertical' : 'horizontal'}
+            // orientation={isSmallScreen ? 'vertical' : 'horizontal'}
             aria-label="civic profile tabs"
           >
             {CIVIC_FORM_LIST.map((form) => (
@@ -48,9 +48,9 @@ const CivicProfile = () => {
           </Tabs>
         </nav>
       </Box>
-      <Container>
+      <Box>
         <Outlet />
-      </Container>
+      </Box>
     </Container>
   );
 };

--- a/src/pages/CivicProfile.jsx
+++ b/src/pages/CivicProfile.jsx
@@ -6,8 +6,8 @@ import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
-// import useMediaQuery from '@mui/material/useMediaQuery';
-// import { useTheme } from '@mui/system';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useTheme } from '@mui/system';
 // Component Imports
 import { CIVIC_FORM_LIST } from '@components/CivicProfileForms';
 
@@ -23,17 +23,19 @@ const CivicProfile = () => {
 
   localStorage.setItem('restorePath', location.pathname);
   const currentForm = location.pathname.split('/').pop();
-  // const theme = useTheme();
-  // const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+  const theme = useTheme();
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
   return (
     <Container>
-      <Box>
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
         <nav>
           <Tabs
             value={currentForm}
             // orientation={isSmallScreen ? 'vertical' : 'horizontal'}
             aria-label="civic profile tabs"
+            // centered
+            variant={isSmallScreen ? 'scrollable' : null}
           >
             {CIVIC_FORM_LIST.map((form) => (
               <Tab
@@ -42,6 +44,7 @@ const CivicProfile = () => {
                 to={form.path}
                 label={form.label}
                 value={form.path}
+                // Disabled for incomplete Financial Information form
                 disabled={form.label === 'Financial Information'}
               />
             ))}

--- a/src/pages/CivicProfile.jsx
+++ b/src/pages/CivicProfile.jsx
@@ -37,10 +37,9 @@ const CivicProfile = () => {
       >
         <nav>
           <Tabs
+            orientation={isSmallScreen ? 'vertical' : 'horizontal'}
             value={currentForm}
             aria-label="civic profile tabs"
-            centered={isSmallScreen ? null : true}
-            variant={isSmallScreen ? 'scrollable' : null}
           >
             {CIVIC_FORM_LIST.map((form) => (
               <Tab

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -146,14 +146,15 @@ const Profile = () => {
         }}
       >
         <Typography sx={{ fontWeight: 'bold', fontSize: '18px' }}>My Profile</Typography>
-        <Box
+        {/* TODO: Determine whether this Box is needed */}
+        {/* <Box
           sx={{
             display: 'flex',
             gap: '5px',
             alignItems: 'center',
             flexDirection: isSmallScreen ? 'column' : 'row'
           }}
-        />
+        /> */}
 
         <Box
           sx={{

--- a/test/components/CivicProfileForms/FinancialInfo.test.jsx
+++ b/test/components/CivicProfileForms/FinancialInfo.test.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import { expect, it, describe } from 'vitest';
-import { FinancialInfo } from '@components/CivicProfileForms';
+// import React from 'react';
+// import { render } from '@testing-library/react';
+// import { expect, it, describe } from 'vitest';
+// import { FinancialInfo } from '@components/CivicProfileForms';
 
-describe('Financial Info Form', () => {
-  it('renders', () => {
-    const { getByText } = render(<FinancialInfo />);
-    expect(getByText('Financial Information')).not.toBeNull();
-  });
-});
+// describe('Financial Info Form', () => {
+//   it('renders', () => {
+//     const { getByText } = render(<FinancialInfo />);
+//     expect(getByText('Financial Information')).not.toBeNull();
+//   });
+// });

--- a/test/components/CivicProfileForms/FinancialInfo.test.jsx
+++ b/test/components/CivicProfileForms/FinancialInfo.test.jsx
@@ -6,6 +6,6 @@ import { FinancialInfo } from '@components/CivicProfileForms';
 describe('Financial Info Form', () => {
   it('renders', () => {
     const { getByText } = render(<FinancialInfo />);
-    expect(getByText('Financial Info')).not.toBeNull();
+    expect(getByText('Financial Information')).not.toBeNull();
   });
 });

--- a/test/components/CivicProfileForms/HousingInfo.test.jsx
+++ b/test/components/CivicProfileForms/HousingInfo.test.jsx
@@ -171,3 +171,5 @@ describe('Housing info form', () => {
     expect(timeToHousingLossField.firstChild.textContent).toBe('Data not collected');
   });
 });
+
+

--- a/test/components/CivicProfileForms/HousingInfo.test.jsx
+++ b/test/components/CivicProfileForms/HousingInfo.test.jsx
@@ -171,5 +171,3 @@ describe('Housing info form', () => {
     expect(timeToHousingLossField.firstChild.textContent).toBe('Data not collected');
   });
 });
-
-

--- a/test/pages/CivicProfile.test.jsx
+++ b/test/pages/CivicProfile.test.jsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
-import { render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
-import { CivicProfile } from '@pages';
-import createMatchMedia from '../helpers/createMatchMedia';
+// import React from 'react';
+// import { BrowserRouter } from 'react-router-dom';
+// import { render } from '@testing-library/react';
+// import { describe, expect, it } from 'vitest';
+// import { CivicProfile } from '@pages';
+// import createMatchMedia from '../helpers/createMatchMedia';
 
 // TODO: Rewrite tests to align with changes in CivicProfile component
 // e.g. "successfully navigates to Basic Information"
-describe('CivicProfile Page', () => {
+// describe('CivicProfile Page', () => {
   // it('renders page container flex direction as row and nav container width as 25% by default', () => {
   //   const component = render(
   //     <BrowserRouter>
@@ -35,4 +35,4 @@ describe('CivicProfile Page', () => {
   //   expect(componentContainerStyles.flexDirection).toBe('column');
   //   expect(navContainerStyles.width).toBe('100%');
   // });
-});
+// });

--- a/test/pages/CivicProfile.test.jsx
+++ b/test/pages/CivicProfile.test.jsx
@@ -8,31 +8,31 @@
 // TODO: Rewrite tests to align with changes in CivicProfile component
 // e.g. "successfully navigates to Basic Information"
 // describe('CivicProfile Page', () => {
-  // it('renders page container flex direction as row and nav container width as 25% by default', () => {
-  //   const component = render(
-  //     <BrowserRouter>
-  //       <CivicProfile />
-  //     </BrowserRouter>
-  //   );
-  //   const componentContainer = component.container.firstChild;
-  //   const navContainer = componentContainer.firstChild;
-  //   const componentContainerStyles = getComputedStyle(componentContainer);
-  //   const navContainerStyles = getComputedStyle(navContainer);
-  //   expect(componentContainerStyles.flexDirection).toBe('row');
-  //   expect(navContainerStyles.width).toBe('25%');
-  // });
-  // it('renders page container flex direction as column and nav container width as 100% below 600px', () => {
-  //   window.matchMedia = createMatchMedia(599);
-  //   const component = render(
-  //     <BrowserRouter>
-  //       <CivicProfile />
-  //     </BrowserRouter>
-  //   );
-  //   const componentContainer = component.container.firstChild;
-  //   const navContainer = componentContainer.firstChild;
-  //   const componentContainerStyles = getComputedStyle(componentContainer);
-  //   const navContainerStyles = getComputedStyle(navContainer);
-  //   expect(componentContainerStyles.flexDirection).toBe('column');
-  //   expect(navContainerStyles.width).toBe('100%');
-  // });
+// it('renders page container flex direction as row and nav container width as 25% by default', () => {
+//   const component = render(
+//     <BrowserRouter>
+//       <CivicProfile />
+//     </BrowserRouter>
+//   );
+//   const componentContainer = component.container.firstChild;
+//   const navContainer = componentContainer.firstChild;
+//   const componentContainerStyles = getComputedStyle(componentContainer);
+//   const navContainerStyles = getComputedStyle(navContainer);
+//   expect(componentContainerStyles.flexDirection).toBe('row');
+//   expect(navContainerStyles.width).toBe('25%');
+// });
+// it('renders page container flex direction as column and nav container width as 100% below 600px', () => {
+//   window.matchMedia = createMatchMedia(599);
+//   const component = render(
+//     <BrowserRouter>
+//       <CivicProfile />
+//     </BrowserRouter>
+//   );
+//   const componentContainer = component.container.firstChild;
+//   const navContainer = componentContainer.firstChild;
+//   const componentContainerStyles = getComputedStyle(componentContainer);
+//   const navContainerStyles = getComputedStyle(navContainer);
+//   expect(componentContainerStyles.flexDirection).toBe('column');
+//   expect(navContainerStyles.width).toBe('100%');
+// });
 // });

--- a/test/pages/CivicProfile.test.jsx
+++ b/test/pages/CivicProfile.test.jsx
@@ -1,41 +1,38 @@
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';
-import { expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { CivicProfile } from '@pages';
 import createMatchMedia from '../helpers/createMatchMedia';
 
-it('renders page container flex direction as row and nav container width as 25% by default', () => {
-  const component = render(
-    <BrowserRouter>
-      <CivicProfile />
-    </BrowserRouter>
-  );
-
-  const componentContainer = component.container.firstChild;
-  const navContainer = componentContainer.firstChild;
-
-  const componentContainerStyles = getComputedStyle(componentContainer);
-  const navContainerStyles = getComputedStyle(navContainer);
-
-  expect(componentContainerStyles.flexDirection).toBe('row');
-  expect(navContainerStyles.width).toBe('25%');
-});
-
-it('renders page container flex direction as column and nav container width as 100% below 600px', () => {
-  window.matchMedia = createMatchMedia(599);
-  const component = render(
-    <BrowserRouter>
-      <CivicProfile />
-    </BrowserRouter>
-  );
-
-  const componentContainer = component.container.firstChild;
-  const navContainer = componentContainer.firstChild;
-
-  const componentContainerStyles = getComputedStyle(componentContainer);
-  const navContainerStyles = getComputedStyle(navContainer);
-
-  expect(componentContainerStyles.flexDirection).toBe('column');
-  expect(navContainerStyles.width).toBe('100%');
+// TODO: Rewrite tests to align with changes in CivicProfile component
+// e.g. "successfully navigates to Basic Information"
+describe('CivicProfile Page', () => {
+  // it('renders page container flex direction as row and nav container width as 25% by default', () => {
+  //   const component = render(
+  //     <BrowserRouter>
+  //       <CivicProfile />
+  //     </BrowserRouter>
+  //   );
+  //   const componentContainer = component.container.firstChild;
+  //   const navContainer = componentContainer.firstChild;
+  //   const componentContainerStyles = getComputedStyle(componentContainer);
+  //   const navContainerStyles = getComputedStyle(navContainer);
+  //   expect(componentContainerStyles.flexDirection).toBe('row');
+  //   expect(navContainerStyles.width).toBe('25%');
+  // });
+  // it('renders page container flex direction as column and nav container width as 100% below 600px', () => {
+  //   window.matchMedia = createMatchMedia(599);
+  //   const component = render(
+  //     <BrowserRouter>
+  //       <CivicProfile />
+  //     </BrowserRouter>
+  //   );
+  //   const componentContainer = component.container.firstChild;
+  //   const navContainer = componentContainer.firstChild;
+  //   const componentContainerStyles = getComputedStyle(componentContainer);
+  //   const navContainerStyles = getComputedStyle(navContainer);
+  //   expect(componentContainerStyles.flexDirection).toBe('column');
+  //   expect(navContainerStyles.width).toBe('100%');
+  // });
 });

--- a/test/pages/PersonalProfile.test.jsx
+++ b/test/pages/PersonalProfile.test.jsx
@@ -5,6 +5,8 @@ import { expect, it, describe } from 'vitest';
 import { CivicProfile } from '@pages';
 import { CIVIC_FORM_LIST } from '@components/CivicProfileForms';
 
+// TODO: Shouldn't this be testing Profile.jsx rather than CivicProfile.jsx?
+// There is already a CivicProfile.test.jsx
 describe('Civic Profile', () => {
   const numLinks = CIVIC_FORM_LIST.length;
 
@@ -14,7 +16,7 @@ describe('Civic Profile', () => {
         <CivicProfile />
       </BrowserRouter>
     );
-    expect(getByRole('navigation')).not.toBeNull();
+    expect(getByRole('nav')).not.toBeNull();
     expect(getAllByRole('link').length).toEqual(numLinks);
   });
 });


### PR DESCRIPTION
## This PR:
Resolves #651 and #634

Setting this as a draft for now. 
 
**1.** Disables linking to incomplete Financial Info form
**2.** Reroutes clicking "Civic Profile" in NavBar from main Civic Profile page to the Basic Info form
**3.** Refactors Civic Profile navigation from simple menu to Material UI Tabs

## Screenshots (if applicable):

<img width="475" alt="2024-06-20" src="https://github.com/codeforpdx/PASS/assets/83156697/188dcd0a-91be-4427-8b5a-a5267ce0d399">
<img width="208" alt="2024-06-20 (3)" src="https://github.com/codeforpdx/PASS/assets/83156697/e28ebe63-0e03-491c-bb2e-e57f2d618fb6">
<img width="778" alt="2024-06-20 (2)" src="https://github.com/codeforpdx/PASS/assets/83156697/ce365ac5-0ced-461a-8bb5-e72b51a2ce1b">
<img width="776" alt="2024-06-20 (1)" src="https://github.com/codeforpdx/PASS/assets/83156697/683d9ff4-b7c2-4597-864e-6a62978b5723">

## Additional Context (optional):

These are pretty janky, imperfect solutions. I'm sure I can optimize it but in the interest of time, I'm at least starting out with this.

## Future Steps/PRs Needed to Finish This Work (optional):

Look into code optimization and/or abstraction.

Ensure it's responsive on all screens, browsers, and other user conditions.
