### PR TITLE
619/refactor image upload button

### DIFF
--- a/src/components/Profile/ProfileImageField.jsx
+++ b/src/components/Profile/ProfileImageField.jsx
@@ -8,7 +8,6 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import HideImageIcon from '@mui/icons-material/HideImage';
 import ImageIcon from '@mui/icons-material/Image';
-import { useTheme } from '@mui/material/styles';
 // Contexts Imports
 import { SignedInUserContext } from '@contexts';
 // Component Imports
@@ -36,7 +35,6 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
   const [processing, setProcessing] = useState(false);
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
   const [hover, setHover] = useState(false);
-  const theme = useTheme();
 
   const handleProfileImage = async (event) => {
     if (event.target.files[0].size > 1 * 1000 * 1024) {
@@ -84,9 +82,9 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
     cursor: 'pointer',
     border: 'none',
     color: '#FFFFFF',
-    backgroundColor: theme.palette.content,
+    backgroundColor: '#545454',
     '&:hover': {
-      backgroundColor: theme.palette.content
+      backgroundColor: '#545454'
     }
   };
 
@@ -131,7 +129,6 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
               <Button
                 data-testid="deleteProfilePictureIcon"
                 aria-label="delete-profile-picture"
-                // color={theme.palette.secondary.main}
                 component="label"
                 variant="contained"
                 startIcon={<HideImageIcon />}
@@ -144,7 +141,6 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
               <Button
                 data-testid="uploadProfilePictureIcon"
                 aria-label="upload-profile-picture"
-                // color="content"
                 component="label"
                 variant="contained"
                 startIcon={<ImageIcon />}

--- a/src/components/Profile/ProfileImageField.jsx
+++ b/src/components/Profile/ProfileImageField.jsx
@@ -5,8 +5,8 @@ import { useNotification, useSession } from '@hooks';
 // Material UI Imports
 import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import HideImageIcon from '@mui/icons-material/HideImage';
+import IconButton from '@mui/material/IconButton';
 import ImageIcon from '@mui/icons-material/Image';
 // Contexts Imports
 import { SignedInUserContext } from '@contexts';
@@ -34,6 +34,7 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
   const [profileImg, setProfileImg] = useState(localStorage.getItem('profileImage'));
   const [processing, setProcessing] = useState(false);
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
+  const [hover, setHover] = useState(false);
 
   const handleProfileImage = async (event) => {
     if (event.target.files[0].size > 1 * 1000 * 1024) {
@@ -69,6 +70,15 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
     setShowConfirmationModal(true);
   };
 
+  const iconButtonStyling = {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    color: '#fff'
+  };
+
   return (
     <Box
       sx={{
@@ -80,35 +90,53 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
         gap: '10px'
       }}
     >
-      <Avatar
-        src={contactProfile ? contactProfile.profileImage : profileImg}
-        alt="PASS profile"
-        sx={{ height: '100px', width: '100px', objectFit: 'contain' }}
-      />
-      {!contactProfile &&
-        (profileImg ? (
-          <Button
-            variant="outlined"
-            color="error"
-            sx={{ width: '150px' }}
-            onClick={handleSelectRemoveProfileImg}
-            endIcon={<HideImageIcon />}
-          >
-            Remove Img
-          </Button>
-        ) : (
-          <Button
-            variant="outlined"
-            component="label"
-            color="primary"
-            onChange={handleProfileImage}
-            endIcon={<ImageIcon />}
-            sx={{ width: '150px' }}
-          >
-            Choose Img
-            <input type="file" hidden accept=".gif, .png, .jpeg, .jpg, .webp" />
-          </Button>
-        ))}
+      <Box
+        position="relative"
+        display="inline-block"
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
+      >
+        <Avatar
+          src={contactProfile ? contactProfile.profileImage : profileImg}
+          alt="PASS profile"
+          sx={{ height: '100px', width: '100px', objectFit: 'contain' }}
+        />
+        {hover && (
+          <>
+            <Box
+              sx={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%',
+                backgroundColor: 'rgba(0, 0, 0, 0.5)',
+                borderRadius: '50%'
+              }}
+            />
+            {contactProfile || profileImg ? (
+              <IconButton
+                sx={iconButtonStyling}
+                disableRipple
+                onClick={handleSelectRemoveProfileImg}
+              >
+                <HideImageIcon />
+              </IconButton>
+            ) : (
+              <IconButton sx={iconButtonStyling} component="label" disableRipple>
+                <ImageIcon />
+                <input
+                  type="file"
+                  hidden
+                  accept=".gif, .png, .jpeg, .jpg, .webp"
+                  onChange={handleProfileImage}
+                />
+              </IconButton>
+            )}
+          </>
+        )}
+      </Box>
+
       <ConfirmationModal
         showModal={showConfirmationModal}
         setShowModal={setShowConfirmationModal}

--- a/src/components/Profile/ProfileImageField.jsx
+++ b/src/components/Profile/ProfileImageField.jsx
@@ -103,7 +103,7 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
         onMouseLeave={() => setHover(false)}
       >
         <Avatar
-          src={contactProfile ? contactProfile.profileImage : profileImg}
+          src={contactProfile?.profileImage || profileImg || ''}
           alt="PASS profile"
           sx={{
             height: '100px',

--- a/src/components/Profile/ProfileImageField.jsx
+++ b/src/components/Profile/ProfileImageField.jsx
@@ -5,8 +5,8 @@ import { useNotification, useSession } from '@hooks';
 // Material UI Imports
 import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import HideImageIcon from '@mui/icons-material/HideImage';
-import IconButton from '@mui/material/IconButton';
 import ImageIcon from '@mui/icons-material/Image';
 // Contexts Imports
 import { SignedInUserContext } from '@contexts';
@@ -19,12 +19,12 @@ import ConfirmationModal from '../Modals/ConfirmationModal';
  *
  * @memberof Profile
  * @name ProfileImageField
- * @param {object} Props - Props used for NewMessage
+ * @param {object} Props - Props used for ProfileImageField
  * @param {() => void} Props.loadProfileData - Handler function for setting local
  * state for profile card in PASS
  * @param {object} [Props.contactProfile] - Contact object with data from profile
  * or null if user profile is selected
- * @returns {React.JSX.Element} React component for NewMessage
+ * @returns {React.JSX.Element} React component for ProfileImageField
  */
 const ProfileImageField = ({ loadProfileData, contactProfile }) => {
   const { addNotification } = useNotification();
@@ -72,9 +72,16 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
 
   const iconButtonStyling = {
     position: 'absolute',
+    width: '100%',
+    height: '100%',
     top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
+    borderRadius: '50%',
+    opacity: 0.8,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
     color: '#fff'
   };
@@ -86,8 +93,7 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
         flexDirection: 'column',
         justifyContent: 'center',
         alignItems: 'center',
-        padding: '20px',
-        gap: '10px'
+        padding: '20px'
       }}
     >
       <Box
@@ -99,7 +105,10 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
         <Avatar
           src={contactProfile ? contactProfile.profileImage : profileImg}
           alt="PASS profile"
-          sx={{ height: '100px', width: '100px', objectFit: 'contain' }}
+          sx={{
+            height: '100px',
+            width: '100px'
+          }}
         />
         {hover && (
           <>
@@ -115,23 +124,36 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
               }}
             />
             {contactProfile || profileImg ? (
-              <IconButton
-                sx={iconButtonStyling}
-                disableRipple
+              <Button
+                data-testid="deleteProfilePictureIcon"
+                aria-label="delete-profile-picture"
+                color="content"
+                component="label"
+                variant="contained"
+                startIcon={<HideImageIcon />}
                 onClick={handleSelectRemoveProfileImg}
+                sx={iconButtonStyling}
               >
-                <HideImageIcon />
-              </IconButton>
+                Delete
+              </Button>
             ) : (
-              <IconButton sx={iconButtonStyling} component="label" disableRipple>
-                <ImageIcon />
+              <Button
+                data-testid="uploadProfilePictureIcon"
+                aria-label="upload-profile-picture"
+                color="content"
+                component="label"
+                variant="contained"
+                startIcon={<ImageIcon />}
+                sx={iconButtonStyling}
+              >
+                Upload
                 <input
                   type="file"
                   hidden
                   accept=".gif, .png, .jpeg, .jpg, .webp"
                   onChange={handleProfileImage}
                 />
-              </IconButton>
+              </Button>
             )}
           </>
         )}

--- a/src/components/Profile/ProfileImageField.jsx
+++ b/src/components/Profile/ProfileImageField.jsx
@@ -8,6 +8,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import HideImageIcon from '@mui/icons-material/HideImage';
 import ImageIcon from '@mui/icons-material/Image';
+import { useTheme } from '@mui/material/styles';
 // Contexts Imports
 import { SignedInUserContext } from '@contexts';
 // Component Imports
@@ -35,6 +36,7 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
   const [processing, setProcessing] = useState(false);
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
   const [hover, setHover] = useState(false);
+  const theme = useTheme();
 
   const handleProfileImage = async (event) => {
     if (event.target.files[0].size > 1 * 1000 * 1024) {
@@ -76,14 +78,16 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
     height: '100%',
     top: '50%',
     left: '50%',
+    opacity: 0.8,
     transform: 'translate(-50%, -50%)',
     borderRadius: '50%',
-    opacity: 0.8,
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    color: '#fff'
+    cursor: 'pointer',
+    border: 'none',
+    color: '#FFFFFF',
+    backgroundColor: theme.palette.content,
+    '&:hover': {
+      backgroundColor: theme.palette.content
+    }
   };
 
   return (
@@ -127,7 +131,7 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
               <Button
                 data-testid="deleteProfilePictureIcon"
                 aria-label="delete-profile-picture"
-                color="content"
+                // color={theme.palette.secondary.main}
                 component="label"
                 variant="contained"
                 startIcon={<HideImageIcon />}
@@ -140,7 +144,7 @@ const ProfileImageField = ({ loadProfileData, contactProfile }) => {
               <Button
                 data-testid="uploadProfilePictureIcon"
                 aria-label="upload-profile-picture"
-                color="content"
+                // color="content"
                 component="label"
                 variant="contained"
                 startIcon={<ImageIcon />}

--- a/test/components/Profile/ProfileImageField.test.jsx
+++ b/test/components/Profile/ProfileImageField.test.jsx
@@ -57,5 +57,3 @@ describe('ProfileImageField', () => {
     expect(screen.getByTestId('deleteProfilePictureIcon')).not.toBeNull();
   });
 });
-
-

--- a/test/components/Profile/ProfileImageField.test.jsx
+++ b/test/components/Profile/ProfileImageField.test.jsx
@@ -23,7 +23,6 @@ describe('ProfileImageField', () => {
 
   it('renders image if contactProfile is null but user has profile image', () => {
     const { queryByRole, queryByTestId } = render(
-      // <ThemeProvider theme={theme}>
       <MockProfileComponent mockContactProfile={null} />
     );
 

--- a/test/components/Profile/ProfileImageField.test.jsx
+++ b/test/components/Profile/ProfileImageField.test.jsx
@@ -5,7 +5,9 @@ import { ProfileImageField } from '../../../src/components/Profile';
 import '@testing-library/jest-dom/extend-expect';
 
 const MockProfileComponent = ({ noUserImage, mockContactProfile }) => {
-  if (!noUserImage) {
+  if (noUserImage) {
+    localStorage.removeItem('profileImage');
+  } else {
     localStorage.setItem('profileImage', 'https://example.com/user.png');
   }
   return <ProfileImageField contactProfile={mockContactProfile} />;
@@ -34,9 +36,10 @@ describe('ProfileImageField', () => {
   });
 
   it('renders upload profile picture icon when user hovers over avatar with no profile image', async () => {
-    render(<MockProfileComponent noUserImage mockContactProfile={{}} />);
+    render(<MockProfileComponent noUserImage mockContactProfile={null} />);
 
-    const avatar = screen.getByAltText('PASS profile');
+    const avatar = screen.queryByTestId('PersonIcon');
+    expect(avatar).not.toBeNull();
     expect(screen.queryByTestId('uploadProfilePictureIcon')).toBeNull();
 
     fireEvent.mouseEnter(avatar);

--- a/test/components/Profile/ProfileImageField.test.jsx
+++ b/test/components/Profile/ProfileImageField.test.jsx
@@ -57,3 +57,5 @@ describe('ProfileImageField', () => {
     expect(screen.getByTestId('deleteProfilePictureIcon')).not.toBeNull();
   });
 });
+
+

--- a/test/components/Profile/ProfileImageField.test.jsx
+++ b/test/components/Profile/ProfileImageField.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 import { ProfileImageField } from '../../../src/components/Profile';
 import '@testing-library/jest-dom/extend-expect';
@@ -33,79 +34,29 @@ describe('ProfileImageField', () => {
     expect(svgElement).toBeNull();
   });
 
-  it('renders uploadProfilePictureIcon when user hovers over avatar with no profile image uploaded', () => {
-    const mockContactProfile = { profileImage: 'https://example.com/client.png' };
+  it('renders upload profile picture icon when user hovers over avatar with no profile image', async () => {
+    const mockContactProfile = { profileImage: '' };
     render(<MockProfileComponent noUserImage mockContactProfile={mockContactProfile} />);
 
     const avatar = screen.getByAltText('PASS profile');
+    expect(screen.queryByTestId('uploadProfilePictureIcon')).toBeNull();
 
-    expect(screen.queryByTestId('uploadProfilePictureIcon')).not.toBeInTheDocument();
+    userEvent.hover(avatar);
 
-    fireEvent.mouseEnter(avatar);
-
-    expect(screen.getByTestId('uploadProfilePictureIcon')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByTestId('uploadProfilePictureIcon')).not.toBeNull();
+    });
   });
 
-  // it('renders deleteProfilePictureIcon when user hovers over avatar with profile image uploaded', () => {
-  //   render(<MockProfileComponent mockContactProfile={{}} />);
+  it('renders deleteProfilePictureIcon when user hovers over avatar with profile image uploaded', () => {
+    const mockContactProfile = { profileImage: 'https://example.com/client.png' };
+    render(<MockProfileComponent mockContactProfile={mockContactProfile} />);
 
-  //   const avatar = screen.getByAltText('PASS profile');
+    const avatar = screen.getByAltText('PASS profile');
+    expect(screen.queryByTestId('deleteProfilePictureIcon')).toBeNull();
 
-  //   expect(screen.queryByTestId('deleteProfilePictureIcon')).not.toBeInTheDocument();
-
-  //   fireEvent.mouseEnter(avatar);
-
-  //   expect(screen.getByTestId('deleteProfilePictureIcon')).toBeInTheDocument();
-  // });
-
-  //
-
-  // it('renders Choose Img button and PersonIcon if contactProfile is null and user has no profile img', () => {
-  //   const { queryByRole, queryByTestId } = render(
-  //     <MockProfileComponent noUserImage mockContactProfile={null} />
-  //   );
-  //   const buttonElement = queryByRole('button');
-  //   expect(buttonElement.textContent).toBe('Choose Img');
-
-  //   const svgElement = queryByTestId('PersonIcon');
-  //   expect(svgElement).not.toBeNull();
-  // });
-
-  // it('renders Remove Img button and image if contactProfile is null, but user has profile image', () => {
-  //   const { queryByRole, queryByTestId } = render(
-  //     <MockProfileComponent mockContactProfile={null} />
-  //   );
-  //   const buttonElement = queryByRole('button');
-  //   expect(buttonElement.textContent).toBe('Remove Img');
-
-  //   const muiAvatar = queryByRole('img');
-  //   expect(muiAvatar).toHaveAttribute('src', 'https://example.com/user.png');
-
-  //   const svgElement = queryByTestId('PersonIcon');
-  //   expect(svgElement).toBeNull();
-  // });
-
-  // it('renders no button with PersonIcon if contactProfile is not null and has no profile image', () => {
-  //   const { queryByRole, queryByTestId } = render(<MockProfileComponent mockContactProfile={{}} />);
-  //   const buttonElement = queryByRole('button');
-  //   expect(buttonElement).toBeNull();
-
-  //   const svgElement = queryByTestId('PersonIcon');
-  //   expect(svgElement).not.toBeNull();
-  // });
-
-  // it('renders no button with image if contactProfile is not null and has profile image', () => {
-  //   const mockContactProfile = { profileImage: 'https://example.com/client.png' };
-  //   const { queryByRole, queryByTestId } = render(
-  //     <MockProfileComponent mockContactProfile={mockContactProfile} />
-  //   );
-  //   const buttonElement = queryByRole('button');
-  //   expect(buttonElement).toBeNull();
-
-  //   const muiAvatar = queryByRole('img');
-  //   expect(muiAvatar).toHaveAttribute('src', 'https://example.com/client.png');
-
-  //   const svgElement = queryByTestId('PersonIcon');
-  //   expect(svgElement).toBeNull();
-  // });
+    fireEvent.mouseEnter(avatar);
+    expect(screen.getByTestId('deleteProfilePictureIcon')).not.toBeNull();
+  });
 });
+

--- a/test/components/Profile/ProfileImageField.test.jsx
+++ b/test/components/Profile/ProfileImageField.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { ProfileImageField } from '../../../src/components/Profile';
 import '@testing-library/jest-dom/extend-expect';
@@ -12,23 +12,19 @@ const MockProfileComponent = ({ noUserImage, mockContactProfile }) => {
 };
 
 describe('ProfileImageField', () => {
-  it('renders Choose Img button and PersonIcon if contactProfile is null and user has no profile img', () => {
-    const { queryByRole, queryByTestId } = render(
+  it('renders PersonIcon if contactProfile is null and user has no profile image', () => {
+    const { queryByTestId } = render(
       <MockProfileComponent noUserImage mockContactProfile={null} />
     );
-    const buttonElement = queryByRole('button');
-    expect(buttonElement.textContent).toBe('Choose Img');
 
     const svgElement = queryByTestId('PersonIcon');
     expect(svgElement).not.toBeNull();
   });
 
-  it('renders Remove Img button and image if contactProfile is null, but user has profile image', () => {
+  it('renders image if contactProfile is null but user has profile image', () => {
     const { queryByRole, queryByTestId } = render(
       <MockProfileComponent mockContactProfile={null} />
     );
-    const buttonElement = queryByRole('button');
-    expect(buttonElement.textContent).toBe('Remove Img');
 
     const muiAvatar = queryByRole('img');
     expect(muiAvatar).toHaveAttribute('src', 'https://example.com/user.png');
@@ -37,27 +33,79 @@ describe('ProfileImageField', () => {
     expect(svgElement).toBeNull();
   });
 
-  it('renders no button with PersonIcon if contactProfile is not null and has no profile image', () => {
-    const { queryByRole, queryByTestId } = render(<MockProfileComponent mockContactProfile={{}} />);
-    const buttonElement = queryByRole('button');
-    expect(buttonElement).toBeNull();
-
-    const svgElement = queryByTestId('PersonIcon');
-    expect(svgElement).not.toBeNull();
-  });
-
-  it('renders no button with image if contactProfile is not null and has profile image', () => {
+  it('renders uploadProfilePictureIcon when user hovers over avatar with no profile image uploaded', () => {
     const mockContactProfile = { profileImage: 'https://example.com/client.png' };
-    const { queryByRole, queryByTestId } = render(
-      <MockProfileComponent mockContactProfile={mockContactProfile} />
-    );
-    const buttonElement = queryByRole('button');
-    expect(buttonElement).toBeNull();
+    render(<MockProfileComponent noUserImage mockContactProfile={mockContactProfile} />);
 
-    const muiAvatar = queryByRole('img');
-    expect(muiAvatar).toHaveAttribute('src', 'https://example.com/client.png');
+    const avatar = screen.getByAltText('PASS profile');
 
-    const svgElement = queryByTestId('PersonIcon');
-    expect(svgElement).toBeNull();
+    expect(screen.queryByTestId('uploadProfilePictureIcon')).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(avatar);
+
+    expect(screen.getByTestId('uploadProfilePictureIcon')).toBeInTheDocument();
   });
+
+  // it('renders deleteProfilePictureIcon when user hovers over avatar with profile image uploaded', () => {
+  //   render(<MockProfileComponent mockContactProfile={{}} />);
+
+  //   const avatar = screen.getByAltText('PASS profile');
+
+  //   expect(screen.queryByTestId('deleteProfilePictureIcon')).not.toBeInTheDocument();
+
+  //   fireEvent.mouseEnter(avatar);
+
+  //   expect(screen.getByTestId('deleteProfilePictureIcon')).toBeInTheDocument();
+  // });
+
+  //
+
+  // it('renders Choose Img button and PersonIcon if contactProfile is null and user has no profile img', () => {
+  //   const { queryByRole, queryByTestId } = render(
+  //     <MockProfileComponent noUserImage mockContactProfile={null} />
+  //   );
+  //   const buttonElement = queryByRole('button');
+  //   expect(buttonElement.textContent).toBe('Choose Img');
+
+  //   const svgElement = queryByTestId('PersonIcon');
+  //   expect(svgElement).not.toBeNull();
+  // });
+
+  // it('renders Remove Img button and image if contactProfile is null, but user has profile image', () => {
+  //   const { queryByRole, queryByTestId } = render(
+  //     <MockProfileComponent mockContactProfile={null} />
+  //   );
+  //   const buttonElement = queryByRole('button');
+  //   expect(buttonElement.textContent).toBe('Remove Img');
+
+  //   const muiAvatar = queryByRole('img');
+  //   expect(muiAvatar).toHaveAttribute('src', 'https://example.com/user.png');
+
+  //   const svgElement = queryByTestId('PersonIcon');
+  //   expect(svgElement).toBeNull();
+  // });
+
+  // it('renders no button with PersonIcon if contactProfile is not null and has no profile image', () => {
+  //   const { queryByRole, queryByTestId } = render(<MockProfileComponent mockContactProfile={{}} />);
+  //   const buttonElement = queryByRole('button');
+  //   expect(buttonElement).toBeNull();
+
+  //   const svgElement = queryByTestId('PersonIcon');
+  //   expect(svgElement).not.toBeNull();
+  // });
+
+  // it('renders no button with image if contactProfile is not null and has profile image', () => {
+  //   const mockContactProfile = { profileImage: 'https://example.com/client.png' };
+  //   const { queryByRole, queryByTestId } = render(
+  //     <MockProfileComponent mockContactProfile={mockContactProfile} />
+  //   );
+  //   const buttonElement = queryByRole('button');
+  //   expect(buttonElement).toBeNull();
+
+  //   const muiAvatar = queryByRole('img');
+  //   expect(muiAvatar).toHaveAttribute('src', 'https://example.com/client.png');
+
+  //   const svgElement = queryByTestId('PersonIcon');
+  //   expect(svgElement).toBeNull();
+  // });
 });

--- a/test/components/Profile/ProfileImageField.test.jsx
+++ b/test/components/Profile/ProfileImageField.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { ProfileImageField } from '../../../src/components/Profile';
 import '@testing-library/jest-dom/extend-expect';
@@ -24,6 +23,7 @@ describe('ProfileImageField', () => {
 
   it('renders image if contactProfile is null but user has profile image', () => {
     const { queryByRole, queryByTestId } = render(
+      // <ThemeProvider theme={theme}>
       <MockProfileComponent mockContactProfile={null} />
     );
 
@@ -35,17 +35,13 @@ describe('ProfileImageField', () => {
   });
 
   it('renders upload profile picture icon when user hovers over avatar with no profile image', async () => {
-    const mockContactProfile = { profileImage: '' };
-    render(<MockProfileComponent noUserImage mockContactProfile={mockContactProfile} />);
+    render(<MockProfileComponent noUserImage mockContactProfile={{}} />);
 
     const avatar = screen.getByAltText('PASS profile');
     expect(screen.queryByTestId('uploadProfilePictureIcon')).toBeNull();
 
-    userEvent.hover(avatar);
-
-    await waitFor(() => {
-      expect(screen.queryByTestId('uploadProfilePictureIcon')).not.toBeNull();
-    });
+    fireEvent.mouseEnter(avatar);
+    expect(screen.getByTestId('uploadProfilePictureIcon')).not.toBeNull();
   });
 
   it('renders deleteProfilePictureIcon when user hovers over avatar with profile image uploaded', () => {
@@ -59,4 +55,3 @@ describe('ProfileImageField', () => {
     expect(screen.getByTestId('deleteProfilePictureIcon')).not.toBeNull();
   });
 });
-


### PR DESCRIPTION
## This PR:
Resolves #619
 
**1.** Removes "Choose/Remove Img" button on the Profile page and refactors it as a hover effect directly over the avatar
**2.** This approach more closely matches the way many services program the same functionality, so it ought to be intuitive enough for users

## Screenshots (if applicable):

No photo uploaded:
![2024-09-19 (14)](https://github.com/user-attachments/assets/56673e5f-d1d7-4b80-bcc9-694dd6a13d4e)
No photo uploaded (plus hover):
![2024-09-23 (1)](https://github.com/user-attachments/assets/b1898747-a8f7-40e5-af85-de33fe5edeaa)
With photo uploaded:
![2024-09-19 (12)](https://github.com/user-attachments/assets/27fbcd4a-16c4-4f4f-89ff-f366eb4986d7)
With photo uploaded (plus hover):
![2024-09-23](https://github.com/user-attachments/assets/30c972a0-dc0f-4030-8cb0-8d01925a6d94)

## Additional Context (optional):

The goal is to make the Profile card less crowded-looking without sacrificing ease of use.

## Future Steps/PRs Needed to Finish This Work (optional):

- Ensure this is accessible and intuitive.
- Can tweak it by adding text back over, if we decide that's necessary (rather than use the images alone).
