### PR TITLE
[Bug Fix] - Adjust state logic for Edit and Delete action buttons in table row

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pass",
   "homepage": ".",
-  "version": "1.1.0-alpha",
+  "version": "1.1.1-alpha",
   "description": "",
   "scripts": {
     "start": "concurrently --kill-others \"npm run podserver\" \"npm run dev\"",

--- a/src/components/Documents/DocumentsDesktop.jsx
+++ b/src/components/Documents/DocumentsDesktop.jsx
@@ -14,8 +14,6 @@ import {
 } from '@mui/x-data-grid';
 // Util Imports
 import { getTypeText } from '@utils';
-// Hooks Imports
-import { useSession } from '@hooks';
 // Theme Imports
 import theme from '../../theme';
 
@@ -68,9 +66,7 @@ const CustomToolbar = () => (
  * @returns {React.JSX.Element} The DocumentsDesktop component
  */
 const DocumentsDesktop = ({ documents, handlers }) => {
-  const { session } = useSession();
   const location = useLocation();
-  const profileWebId = decodeURIComponent(location.pathname.split('/')[2]);
 
   const columnTitlesArray = [
     { field: 'Name', minWidth: 120, flex: 1, headerAlign: 'center', align: 'center' },
@@ -116,7 +112,7 @@ const DocumentsDesktop = ({ documents, handlers }) => {
             onClick={() => handlers.onShare('document', name, type)}
             label="Share"
             data-testid={`share-button-${id}`}
-            disabled={session.info.webId !== profileWebId}
+            disabled={location.pathname !== '/documents'}
           />
         );
       }
@@ -138,7 +134,7 @@ const DocumentsDesktop = ({ documents, handlers }) => {
             onClick={() => handlers.onDelete(document)}
             label="Delete"
             data-testid={`delete-button-${document.id}`}
-            disabled={session.info.webId !== profileWebId}
+            disabled={location.pathname !== '/documents'}
           />
         );
       }


### PR DESCRIPTION
## This PR:

Resolves #686 and updates the state logic for the component DocumentsDesktop so that the Shared and Delete buttons would be accessible. (see clip below)

## Screenshots (if applicable):

https://github.com/user-attachments/assets/e702fdb6-251c-43ca-9791-0f88332f4c7f
