### PR TITLE
Issue 690/add copywebid desktop contacts

### DIFF
--- a/src/components/Contacts/ContactListTableDesktop.jsx
+++ b/src/components/Contacts/ContactListTableDesktop.jsx
@@ -74,11 +74,6 @@ const ContactListTableDesktop = ({
     },
     {
       field: 'webId',
-      headerName: 'Web ID',
-      minWidth: 150,
-      flex: 1,
-      headerAlign: 'center',
-      align: 'center',
       renderCell: (contact) => (
         <Typography
           noWrap
@@ -87,7 +82,12 @@ const ContactListTableDesktop = ({
         >
           {contact.id}
         </Typography>
-      )
+      ),
+      headerName: 'Web ID',
+      minWidth: 150,
+      flex: 1,
+      headerAlign: 'center',
+      align: 'center'
     },
     {
       field: 'Profile',

--- a/src/components/Contacts/ContactListTableDesktop.jsx
+++ b/src/components/Contacts/ContactListTableDesktop.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
 import EditOutlined from '@mui/icons-material/EditOutlined';
 import SendIcon from '@mui/icons-material/Send';
+import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
 import {
   DataGrid,
@@ -12,6 +13,10 @@ import {
   GridToolbarFilterButton,
   GridToolbarDensitySelector
 } from '@mui/x-data-grid';
+// Custom Hooks Imports
+import useNotification from '@hooks/useNotification';
+// Util Imports
+import { saveToClipboard } from '@utils';
 // Component Imports
 import ContactProfileIcon from './ContactProfileIcon';
 
@@ -49,6 +54,7 @@ const ContactListTableDesktop = ({
   handleSendMessage,
   'data-testid': dataTestId
 }) => {
+  const { addNotification } = useNotification();
   const theme = useTheme();
 
   const columnTitlesArray = [
@@ -72,7 +78,16 @@ const ContactListTableDesktop = ({
       minWidth: 150,
       flex: 1,
       headerAlign: 'center',
-      align: 'center'
+      align: 'center',
+      renderCell: (contact) => (
+        <Typography
+          noWrap
+          sx={{ cursor: 'pointer', fontSize: '0.875rem' }}
+          onClick={() => saveToClipboard(contact.id, 'webId copied to clipboard', addNotification)}
+        >
+          {contact.id}
+        </Typography>
+      )
     },
     {
       field: 'Profile',
@@ -101,7 +116,7 @@ const ContactListTableDesktop = ({
       field: 'Edit',
       renderCell: (contact) => (
         <EditOutlined
-          sx={{ color: 'gray', cursor: 'pointer' }}
+          sx={{ color: '#808080', cursor: 'pointer' }}
           onClick={() => editContact(contact.row.Profile)}
         />
       ),

--- a/src/components/Contacts/ContactListTableMobile.jsx
+++ b/src/components/Contacts/ContactListTableMobile.jsx
@@ -187,6 +187,18 @@ const ContactListTableMobile = ({
               >
                 <MenuItem
                   component={Button}
+                  onClick={handleMenuItemClick(
+                    () =>
+                      saveToClipboard(contact.webId, 'webId copied to clipboard', addNotification),
+                    contact
+                  )}
+                  startIcon={<ContentCopyIcon sx={iconSize} />}
+                  sx={iconStyling}
+                >
+                  Copy WebId
+                </MenuItem>
+                <MenuItem
+                  component={Button}
                   onClick={handleMenuItemClick(handleProfileClick, contact)}
                   startIcon={<ContactProfileIcon contact={contact} sx={iconSize} />}
                   sx={iconStyling}
@@ -208,21 +220,6 @@ const ContactListTableMobile = ({
                   sx={iconStyling}
                 >
                   Message
-                </MenuItem>
-                {/* TODO: Keep copy function? */}
-                {/* If so, also add to Desktop table? */}
-                {/* Maybe without any icon. Simply click on the web ID and it will copy? */}
-                <MenuItem
-                  component={Button}
-                  onClick={handleMenuItemClick(
-                    () =>
-                      saveToClipboard(contact.webId, 'webId copied to clipboard', addNotification),
-                    contact
-                  )}
-                  startIcon={<ContentCopyIcon sx={iconSize} />}
-                  sx={iconStyling}
-                >
-                  Copy WebId
                 </MenuItem>
                 <MenuItem
                   component={Button}

--- a/src/pages/Contacts.jsx
+++ b/src/pages/Contacts.jsx
@@ -158,7 +158,6 @@ const Contacts = () => {
                 }}
                 IconComponent={KeyboardArrowDownIcon}
               >
-                {' '}
                 <MenuItem value="Sort by:" disabled>
                   Sort by:
                 </MenuItem>


### PR DESCRIPTION
## This PR:
Resolves #690 
 
**1.** Adds ability to copy WebId to clipboard when clicked when using desktop version   
**2.** Converts one color naming to hex code    
**3.** Rearranges mobile action menu to match the order the desktop version has

## Screenshots (if applicable):
![2024-11-14 (9)](https://github.com/user-attachments/assets/2d26a88e-691d-4902-bc29-f6cae9f6ea5c)

![2024-11-14 (10)](https://github.com/user-attachments/assets/dad5eb81-bbc1-47ff-aecc-69a3e9a10967)
