### PR TITLE
resize document columns for preview, share, and delete

### DIFF
--- a/src/components/Documents/DocumentsDesktop.jsx
+++ b/src/components/Documents/DocumentsDesktop.jsx
@@ -121,7 +121,6 @@ const DocumentsDesktop = ({ documents, handlers }) => {
       field: 'Delete',
       minWidth: 100,
       flex: 1,
-      flexShrink: 3,
       headerAlign: 'center',
       align: 'center',
       sortable: false,

--- a/src/components/Documents/DocumentsDesktop.jsx
+++ b/src/components/Documents/DocumentsDesktop.jsx
@@ -69,11 +69,11 @@ const DocumentsDesktop = ({ documents, handlers }) => {
   const location = useLocation();
 
   const columnTitlesArray = [
-    { field: 'Name', minWidth: 120, flex: 1, headerAlign: 'center', align: 'center' },
-    { field: 'Type', minWidth: 120, flex: 1, headerAlign: 'center', align: 'center' },
-    { field: 'Description', minWidth: 120, flex: 1, headerAlign: 'center', align: 'center' },
-    { field: 'Upload Date', minWidth: 120, flex: 1, headerAlign: 'center', align: 'center' },
-    { field: 'Expiration Date', minWidth: 120, flex: 1, headerAlign: 'center', align: 'center' },
+    { field: 'Name', minWidth: 120, flex: 3, headerAlign: 'center', align: 'center' },
+    { field: 'Type', minWidth: 120, flex: 2, headerAlign: 'center', align: 'center' },
+    { field: 'Description', minWidth: 120, flex: 3, headerAlign: 'center', align: 'center' },
+    { field: 'Upload Date', minWidth: 120, flex: 2, headerAlign: 'center', align: 'center' },
+    { field: 'Expiration Date', minWidth: 120, flex: 2, headerAlign: 'center', align: 'center' },
     {
       field: 'Preview',
       minWidth: 100,
@@ -121,6 +121,7 @@ const DocumentsDesktop = ({ documents, handlers }) => {
       field: 'Delete',
       minWidth: 100,
       flex: 1,
+      flexShrink: 3,
       headerAlign: 'center',
       align: 'center',
       sortable: false,


### PR DESCRIPTION
## This PR:
Resolves #689 
 
I updated the flex values to give preference to name and description. Preview, share, and delete have the smallest value

## Screenshots (if applicable):
<img width="1406" alt="Screen Shot 2024-11-18 at 3 35 43 PM" src="https://github.com/user-attachments/assets/9b8f5257-165d-408e-9d7e-ce8b3bbee100">