### PR TITLE
Make error messages user-friendly when adding contacts.

### DIFF
--- a/src/components/Modals/AddContactModal.jsx
+++ b/src/components/Modals/AddContactModal.jsx
@@ -159,13 +159,18 @@ const AddContactModal = ({
   };
 
   const getUserFriendlyError = (e) => {
-    if (e.status === 404 || (typeof e.message === 'string' && e.message.includes('404'))) {
+    const status = e?.status || e?.response?.status;
+    const message = typeof e?.message === 'string' ? e.message : '';
+
+    console.error('Add contact error:', status, message, e);
+
+    if (status === 404 || message.includes('404')) {
       return 'The contact could not be found in the pod. Please ensure the username is correct and registered with this pod.';
     }
-    if (e.status === 401 || (typeof e.message === 'string' && e.message.includes('401'))) {
+    if (status === 401 || status === 403 || message.includes('401') || message.includes('403')) {
       return 'You are not authorized to add this contact. Please check your permissions.';
     }
-    if (typeof e.message === 'string' && e.message.toLowerCase().includes('network')) {
+    if (message.toLowerCase().includes('network')) {
       return 'Network error: Unable to reach the pod. Please check your connection and try again.';
     }
 

--- a/src/components/Modals/AddContactModal.jsx
+++ b/src/components/Modals/AddContactModal.jsx
@@ -158,6 +158,20 @@ const AddContactModal = ({
     setOIDC(e.target.value);
   };
 
+  const getUserFriendlyError = (e) => {
+    if (e.status === 404 || (typeof e.message === 'string' && e.message.includes('404'))) {
+      return 'The contact could not be found in the pod. Please ensure the username is correct and registered with this pod.';
+    }
+    if (e.status === 401 || (typeof e.message === 'string' && e.message.includes('401'))) {
+      return 'You are not authorized to add this contact. Please check your permissions.';
+    }
+    if (typeof e.message === 'string' && e.message.toLowerCase().includes('network')) {
+      return 'Network error: Unable to reach the pod. Please check your connection and try again.';
+    }
+
+    return 'An unexpected error occurred while adding the contact. Please try again or contact support.';
+  };
+
   const handleAddContact = async (event) => {
     event.preventDefault();
     setProcessing(true);
@@ -207,8 +221,8 @@ const AddContactModal = ({
       setShowAddContactModal(false);
       clearInputFields();
     } catch (e) {
-      const errorMessage = e ? e.message : 'Unknown error occurred';
-      addNotification('error', `Add contact failed. Reason: ${errorMessage}`);
+      const errorMessage = getUserFriendlyError(e);
+      addNotification('error', `${errorMessage}`);
       setInvalidWebId(true);
     } finally {
       setProcessing(false);


### PR DESCRIPTION
## This PR:
Resolves #697

This PR updates the error handling in the Add Contact flow to ensure that users see clear, user-friendly error messages instead of raw exception output.
 
**1. Replaced raw exception messages with a getUserFriendlyError helper that maps common errors (401, 403, 404, network) into readable notifications for end users.**   

## Screenshots (if applicable):
![issue-697-snip2](https://github.com/user-attachments/assets/be0af831-cb85-498e-a913-69c8c6c3397a)
![issue-697-snip](https://github.com/user-attachments/assets/3da316a1-7b67-446f-919f-27a9a3d15765)
