### PR TITLE
Let's a user share their WebID via a QR code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,22 +32,16 @@ jobs:
           npm run build
 
       - name: Upload frontend assets
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v1
         with:
           path: './dist'
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-artifacts
-          path: ./dist
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    steps:
+    steps: 
       - name: Code Checkout
         uses: actions/checkout@v3
       - name: Setup Node.js
@@ -67,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    steps:
+    steps: 
       - name: Code Checkout
         uses: actions/checkout@v3
       - name: Setup Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,18 @@ jobs:
         with:
           path: './dist'
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: ./dist
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    steps: 
+    steps:
       - name: Code Checkout
         uses: actions/checkout@v3
       - name: Setup Node.js
@@ -61,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    steps: 
+    steps:
       - name: Code Checkout
         uses: actions/checkout@v3
       - name: Setup Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           npm run build
 
       - name: Upload frontend assets
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: './dist'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-paginate": "^8.2.0",
+        "react-qr-code": "^2.0.18",
         "react-router-dom": "^6.10.0",
         "react-router-hash-link": "^2.4.3",
         "react-webcam": "^7.2.0",
@@ -11631,6 +11632,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "dev": true,
@@ -12029,6 +12035,18 @@
       },
       "peerDependencies": {
         "react": "^16 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-qr-code": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.18.tgz",
+      "integrity": "sha512-v1Jqz7urLMhkO6jkgJuBYhnqvXagzceg3qJUWayuCK/c6LTIonpWbwxR1f1APGd4xrW/QcQEovNrAojbUz65Tg==",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {
@@ -22587,6 +22605,11 @@
       "version": "2.3.1",
       "dev": true
     },
+    "qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
+    },
     "querystringify": {
       "version": "2.2.0",
       "dev": true
@@ -22903,6 +22926,15 @@
       "version": "8.2.0",
       "requires": {
         "prop-types": "^15"
+      }
+    },
+    "react-qr-code": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.18.tgz",
+      "integrity": "sha512-v1Jqz7urLMhkO6jkgJuBYhnqvXagzceg3qJUWayuCK/c6LTIonpWbwxR1f1APGd4xrW/QcQEovNrAojbUz65Tg==",
+      "requires": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
       }
     },
     "react-refresh": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-paginate": "^8.2.0",
+    "react-qr-code": "^2.0.18",
     "react-router-dom": "^6.10.0",
     "react-router-hash-link": "^2.4.3",
     "react-webcam": "^7.2.0",

--- a/src/components/Profile/CreateQRCode.jsx
+++ b/src/components/Profile/CreateQRCode.jsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import QRCode from 'react-qr-code';
+import QrCode2Icon from '@mui/icons-material/QrCode2';
+// import Box from '@mui/material/Box';
+// import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import IconButton from '@mui/material/IconButton';
+// import Typography from '@mui/material/Typography';
+// import useMediaQuery from '@mui/material/useMediaQuery';
+// import { useTheme } from '@mui/material/styles';
+
+/**
+ *
+ * @param root0
+ * @param root0.webId
+ */
+const CreateQRCode = ({ webId }) => {
+  console.log('WebId: ', webId);
+  const [qrIconClicked, setQrIconClicked] = useState(false);
+
+  const createQrCode = () => {
+    setQrIconClicked(!qrIconClicked);
+  };
+
+  return (
+    <IconButton
+      aria-label="Create QR Code"
+      edge="end"
+      onClick={() => {
+        createQrCode();
+      }}
+    >
+      <QrCode2Icon />
+      {qrIconClicked ? (
+        <div style={{ height: 'auto', margin: '0 auto', maxWidth: 64, width: '100%' }}>
+          <QRCode
+            size={256}
+            style={{ height: 'auto', maxWidth: '100%', width: '100%' }}
+            value={webId}
+            viewBox="0 0 256 256"
+          />
+        </div>
+      ) : (
+        ''
+      )}
+    </IconButton>
+  );
+};
+
+export default CreateQRCode;

--- a/src/components/Profile/CreateQRCode.jsx
+++ b/src/components/Profile/CreateQRCode.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import QRCode from 'react-qr-code';
 import QrCode2Icon from '@mui/icons-material/QrCode2';
-import IconButton from '@mui/material/IconButton';
 import {
   Dialog,
   DialogTitle,
@@ -33,14 +32,16 @@ const CreateQRCode = ({ webId }) => {
   };
 
   return (
-    <IconButton
-      aria-label="Create QR Code"
-      edge="end"
-      onClick={() => {
-        createQrCode();
-      }}
-    >
-      <QrCode2Icon />
+    <>
+      <Button
+        variant="outlined"
+        startIcon={<QrCode2Icon />}
+        onClick={() => {
+          createQrCode();
+        }}
+      >
+        Show QR Code
+      </Button>
       {qrIconClicked ? (
         <Dialog
           open={qrIconClicked}
@@ -85,7 +86,7 @@ const CreateQRCode = ({ webId }) => {
       ) : (
         ''
       )}
-    </IconButton>
+    </>
   );
 };
 

--- a/src/components/Profile/CreateQRCode.jsx
+++ b/src/components/Profile/CreateQRCode.jsx
@@ -71,7 +71,13 @@ const CreateQRCode = ({ webId }) => {
             </Stack>
           </DialogContent>
           <DialogActions sx={{ justifyContent: 'center' }}>
-            <Button onClick={closeModal} variant="contained">
+            <Button
+              onClick={closeModal}
+              variant="contained"
+              sx={{
+                width: { xs: '90%', sm: '75%' }
+              }}
+            >
               Close
             </Button>
           </DialogActions>

--- a/src/components/Profile/CreateQRCode.jsx
+++ b/src/components/Profile/CreateQRCode.jsx
@@ -13,8 +13,11 @@ import {
 
 /**
  *
- * @param root0
- * @param root0.webId
+ * @memberof Profile
+ * @name CreateQRCode
+ * @param {object} Props - React props
+ * @param {string} [Props.webId] - The webId of the user's profile
+ * @returns {React.JSX.Element} The CreateQRCode Modal
  */
 
 const CreateQRCode = ({ webId }) => {

--- a/src/components/Profile/CreateQRCode.jsx
+++ b/src/components/Profile/CreateQRCode.jsx
@@ -1,24 +1,35 @@
 import React, { useState } from 'react';
 import QRCode from 'react-qr-code';
 import QrCode2Icon from '@mui/icons-material/QrCode2';
-// import Box from '@mui/material/Box';
-// import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import IconButton from '@mui/material/IconButton';
-// import Typography from '@mui/material/Typography';
-// import useMediaQuery from '@mui/material/useMediaQuery';
-// import { useTheme } from '@mui/material/styles';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Stack,
+  Typography
+} from '@mui/material';
 
 /**
  *
  * @param root0
  * @param root0.webId
  */
+
 const CreateQRCode = ({ webId }) => {
-  console.log('WebId: ', webId);
   const [qrIconClicked, setQrIconClicked] = useState(false);
+  const [docUrl, setDocUrl] = useState(null);
 
   const createQrCode = () => {
     setQrIconClicked(!qrIconClicked);
+    const trimmedWebId = webId && webId.includes('#') ? webId.split('#')[0] : webId;
+    setDocUrl(trimmedWebId);
+  };
+
+  const closeModal = () => {
+    setQrIconClicked(false);
   };
 
   return (
@@ -31,14 +42,40 @@ const CreateQRCode = ({ webId }) => {
     >
       <QrCode2Icon />
       {qrIconClicked ? (
-        <div style={{ height: 'auto', margin: '0 auto', maxWidth: 64, width: '100%' }}>
-          <QRCode
-            size={256}
-            style={{ height: 'auto', maxWidth: '100%', width: '100%' }}
-            value={webId}
-            viewBox="0 0 256 256"
-          />
-        </div>
+        <Dialog
+          open={qrIconClicked}
+          onClose={closeModal}
+          aria-labelledby="qr-modal-title"
+          maxWidth="xs"
+          fullWidth
+        >
+          <DialogTitle id="qr-modal-title" sx={{ textAlign: 'center' }}>
+            Share your WebID
+          </DialogTitle>
+          <DialogContent>
+            <Stack spacing={2} alignItems="center" sx={{ py: 1 }}>
+              <div style={{ background: '#fff' }}>
+                <div style={{ width: 256 }}>
+                  <QRCode
+                    value={docUrl || ''}
+                    size={256}
+                    style={{ width: '100%', height: 'auto' }}
+                    viewBox="0 0 256 256"
+                    level="M"
+                  />
+                </div>
+              </div>
+              <Typography variant="body2" sx={{ wordBreak: 'break-all', textAlign: 'center' }}>
+                {docUrl}
+              </Typography>
+            </Stack>
+          </DialogContent>
+          <DialogActions sx={{ justifyContent: 'center' }}>
+            <Button onClick={closeModal} variant="contained">
+              Close
+            </Button>
+          </DialogActions>
+        </Dialog>
       ) : (
         ''
       )}

--- a/src/components/Profile/ProfileComponent.jsx
+++ b/src/components/Profile/ProfileComponent.jsx
@@ -18,6 +18,7 @@ import { saveToClipboard } from '@utils';
 import ProfileInputField from './ProfileInputField';
 import ProfileEditButtonGroup from './ProfileEditButtonGroup';
 import ProfileImageField from './ProfileImageField';
+import CreateQRCode from './CreateQRCode';
 
 /**
  * UserProfile - Component is a component that renders the user's profile on
@@ -135,15 +136,18 @@ const ProfileComponent = ({ contactProfile, webId }) => {
             inputName="WebId"
             inputValue={webId}
             endAdornment={
-              <IconButton
-                aria-label="Copy WebId"
-                edge="end"
-                onClick={() => {
-                  saveToClipboard(webId, 'webId copied to clipboard', addNotification);
-                }}
-              >
-                <ContentCopyIcon />
-              </IconButton>
+              <>
+                <IconButton
+                  aria-label="Copy WebId"
+                  edge="end"
+                  onClick={() => {
+                    saveToClipboard(webId, 'webId copied to clipboard', addNotification);
+                  }}
+                >
+                  <ContentCopyIcon />
+                </IconButton>
+                <CreateQRCode webId={webId} />
+              </>
             }
           />
         </Box>

--- a/src/components/Profile/ProfileComponent.jsx
+++ b/src/components/Profile/ProfileComponent.jsx
@@ -136,42 +136,44 @@ const ProfileComponent = ({ contactProfile, webId }) => {
             inputName="WebId"
             inputValue={webId}
             endAdornment={
-              <>
-                <IconButton
-                  aria-label="Copy WebId"
-                  edge="end"
-                  onClick={() => {
-                    saveToClipboard(webId, 'webId copied to clipboard', addNotification);
-                  }}
-                >
-                  <ContentCopyIcon />
-                </IconButton>
-                <CreateQRCode webId={webId} />
-              </>
-            }
-          />
-        </Box>
-        {!contactProfile && (
-          <Box sx={{ display: 'flex', flexDirection: 'row', gap: '10px', alignSelf: 'end' }}>
-            <Typography sx={{ marginTop: '8px' }}>
-              <Link to={`${signupLink}?webId=${encodeURIComponent(session.info.webId)}`}>
-                Your Invite Link
-              </Link>
               <IconButton
-                aria-label="Copy Invite Link"
+                aria-label="Copy WebId"
                 edge="end"
                 onClick={() => {
-                  saveToClipboard(
-                    `${signupLink}?webId=${encodeURIComponent(session.info.webId)}`,
-                    'Invite link copied to clipboard',
-                    addNotification
-                  );
+                  saveToClipboard(webId, 'webId copied to clipboard', addNotification);
                 }}
               >
                 <ContentCopyIcon />
               </IconButton>
-            </Typography>
-          </Box>
+            }
+          />
+        </Box>
+        {!contactProfile && (
+          <>
+            <Box sx={{ display: 'flex', flexDirection: 'row', gap: '10px', alignSelf: 'end' }}>
+              <Typography sx={{ marginTop: '8px' }}>
+                <Link to={`${signupLink}?webId=${encodeURIComponent(session.info.webId)}`}>
+                  Your Invite Link
+                </Link>
+                <IconButton
+                  aria-label="Copy Invite Link"
+                  edge="end"
+                  onClick={() => {
+                    saveToClipboard(
+                      `${signupLink}?webId=${encodeURIComponent(session.info.webId)}`,
+                      'Invite link copied to clipboard',
+                      addNotification
+                    );
+                  }}
+                >
+                  <ContentCopyIcon />
+                </IconButton>
+              </Typography>
+            </Box>
+            <Box sx={{ alignSelf: 'end' }}>
+              <CreateQRCode webId={webId} />
+            </Box>
+          </>
         )}
       </form>
     </Box>


### PR DESCRIPTION
## This PR:
Resolves #691 
 
**1. Added a new button labeled "Show QR Code" on the user's Profile page, which opens a modal containing a scannable QR code of the user's webID using a library called _react-qr-code_. Their WebID is also displayed underneath the code for easy verification.**    

## Screenshots (if applicable):
![qr-code-btn](https://github.com/user-attachments/assets/96ccda58-69fb-4a03-b9c5-5f395de4e51e)
![qr-code-modal](https://github.com/user-attachments/assets/62275872-7f04-4509-8fd3-3a7c2f804803)

## Additional Context (optional):
This has currently only been tested on a _localhost_ WebID but should work with other pods.

## Future Steps/PRs Needed to Finish This Work (optional):
- Could add a _Download_ button so the QR code can be saved as a PNG for easy sharing (although they could just screenshot it as well - might not be necessary).
- Consider adding QR code support for other areas (ex: contact sharing).
